### PR TITLE
Update config_flow.py

### DIFF
--- a/custom_components/gtfs2/config_flow.py
+++ b/custom_components/gtfs2/config_flow.py
@@ -412,7 +412,7 @@ class GTFSOptionsFlowHandler(config_entries.OptionsFlow):
         if self.config_entry.data.get(CONF_DEVICE_TRACKER_ID, None):
             opt1_schema = {
                     vol.Optional(CONF_LOCAL_STOP_REFRESH_INTERVAL, default=self.config_entry.options.get(CONF_LOCAL_STOP_REFRESH_INTERVAL, DEFAULT_LOCAL_STOP_REFRESH_INTERVAL)): int,
-                    vol.Optional(CONF_RADIUS, default=self.config_entry.options.get(CONF_RADIUS, DEFAULT_LOCAL_STOP_RADIUS)): vol.All(vol.Coerce(int), vol.Range(min=50, max=500)),
+                    vol.Optional(CONF_RADIUS, default=self.config_entry.options.get(CONF_RADIUS, DEFAULT_LOCAL_STOP_RADIUS)): vol.All(vol.Coerce(int), vol.Range(min=50, max=1500)),
                     vol.Optional(CONF_TIMERANGE, default=self.config_entry.options.get(CONF_TIMERANGE, DEFAULT_LOCAL_STOP_TIMERANGE)): vol.All(vol.Coerce(int), vol.Range(min=15, max=120)),
                     vol.Optional(CONF_REAL_TIME, default=self.config_entry.options.get(CONF_REAL_TIME)): selector.BooleanSelector()
                 }


### PR DESCRIPTION
Currently the variable "CONF_RADIUS" is set with min=50, max=500, I think that for cities it is correct but for small towns or remote houses I think it should be possible to increase the range to 1500M or even more.

Increase maximum range in "CONF_RADIUS" to 1500M