### PR TITLE
Add support for an API Key on the static data source

### DIFF
--- a/custom_components/gtfs2/config_flow.py
+++ b/custom_components/gtfs2/config_flow.py
@@ -147,13 +147,38 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="source",
                 data_schema=vol.Schema(
                     {
-                        vol.Required(CONF_EXTRACT_FROM): selector.SelectSelector(selector.SelectSelectorConfig(options=["url", "zip"], translation_key="extract_from")),
+                        vol.Required(CONF_EXTRACT_FROM): selector.SelectSelector(
+                            selector.SelectSelectorConfig(
+                                options=["url", "zip"], translation_key="extract_from"
+                            )
+                        ),
                         vol.Required(CONF_FILE): str,
                         vol.Required(CONF_URL, default="na"): str,
+                        vol.Optional(
+                            CONF_API_KEY,
+                            default=self.config_entry.options.get(CONF_API_KEY),
+                        ): str,
+                        vol.Optional(
+                            CONF_API_KEY_NAME,
+                            default=self.config_entry.options.get(
+                                CONF_API_KEY_NAME, DEFAULT_API_KEY_NAME
+                            ),
+                        ): str,
+                        vol.Required(
+                            CONF_API_KEY_LOCATION,
+                            default=self.config_entry.options.get(
+                                CONF_API_KEY_LOCATION, DEFAULT_API_KEY_LOCATION
+                            ),
+                        ): selector.SelectSelector(
+                            selector.SelectSelectorConfig(
+                                options=ATTR_API_KEY_LOCATIONS,
+                                translation_key="api_key_location",
+                            )
+                        ),
                     },
                 ),
                 errors=errors,
-            )    
+            )
         check_data = await self._check_data(user_input)
         if check_data :
             errors["base"] = check_data

--- a/custom_components/gtfs2/config_flow.py
+++ b/custom_components/gtfs2/config_flow.py
@@ -154,21 +154,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         ),
                         vol.Required(CONF_FILE): str,
                         vol.Required(CONF_URL, default="na"): str,
-                        vol.Optional(
-                            CONF_API_KEY,
-                            default=self.config_entry.options.get(CONF_API_KEY),
-                        ): str,
+                        vol.Optional(CONF_API_KEY): str,
                         vol.Optional(
                             CONF_API_KEY_NAME,
-                            default=self.config_entry.options.get(
-                                CONF_API_KEY_NAME, DEFAULT_API_KEY_NAME
-                            ),
+                            default=DEFAULT_API_KEY_NAME,
                         ): str,
                         vol.Required(
                             CONF_API_KEY_LOCATION,
-                            default=self.config_entry.options.get(
-                                CONF_API_KEY_LOCATION, DEFAULT_API_KEY_LOCATION
-                            ),
+                            default=DEFAULT_API_KEY_LOCATION,
                         ): selector.SelectSelector(
                             selector.SelectSelectorConfig(
                                 options=ATTR_API_KEY_LOCATIONS,

--- a/custom_components/gtfs2/services.yaml
+++ b/custom_components/gtfs2/services.yaml
@@ -30,6 +30,33 @@ update_gtfs:
       example: "https://path-to-my-zip-file-location/filename.zip"
       selector:
         text:            
+    api_key:
+      name: api_key
+      description: provide API key, if required
+      required: false
+      selector:
+        text:        
+    api_key_name:
+      name: api_key_name
+      description: API key_name when using api_key
+      required: true
+      default: "api_key"
+      example: "api_key"
+      selector:
+        text:         
+    api_key_location:
+      name: Indicate location of the key
+      description: Select location of the key
+      required: true      
+      default: "not_applicable"
+      example: "not_applicable"
+      selector:
+        select:
+          translation_key: "api_key_location"
+          options:
+            - "not_applicable"
+            - "header"
+            - "query_string"     
     clean_feed_info:
       name: Remove feed-info
       description: Removes feed_info.txt from zip (use in case file content incorrect)

--- a/custom_components/gtfs2/translations/de.json
+++ b/custom_components/gtfs2/translations/de.json
@@ -28,6 +28,9 @@
         "data": {
           "file": "Neuer Name der Datenquellen",
           "url": "Externe URL zur GTFS-Datendatei (zip)",
+          "api_key": "API-Schlüssel, falls erforderlich",
+          "api_key_name": "API Schlüssel Name, falls erforderlich",
+          "api_key_location": "der Ort, an dem der Schlüssel angewendet wird",
           "extract_from": "Daten extrahieren von:"
         },
         "description": "HINWEIS: Bei einer neuen URL/ZIP-Datei kann dies je \n nach Dateigröße und Systemleistung einige Zeit in Anspruch nehmen [(docu)](https://github.com/vingerha/gtfs2/wiki/1.-Initial-setup:-the-static-data-source)"

--- a/custom_components/gtfs2/translations/en.json
+++ b/custom_components/gtfs2/translations/en.json
@@ -28,6 +28,9 @@
         "data": {
           "file": "New datasource name",
           "url": "external url to gtfs data (zip) file",
+          "api_key": "API key, if required",
+          "api_key_name": "API key name",
+          "api_key_location": "the location where the key is applied",
 		  "extract_from": "Extract data from:"
         },
         "description": "NOTE: with a new url/zip, this may take quite a bit of time, \n depending on file-size and system performance [(docu)](https://github.com/vingerha/gtfs2/wiki/1.-Initial-setup:-the-static-data-source)"

--- a/custom_components/gtfs2/translations/es.json
+++ b/custom_components/gtfs2/translations/es.json
@@ -28,6 +28,9 @@
         "data": {
           "file": "Nuevo nombre de la fuente de datos",
           "url": "url externa al archivo de datos gtfs (zip)",
+          "api_key": "Clave API, si es necesaria",
+          "api_key_name": "API Clave Nombre",
+          "api_key_location": "el lugar donde se aplica la clave",
 		  "extract_from": "Extraer datos de:"
         },
         "description": "NOTA: con una nueva url/zip, esto puede llevar bastante tiempo, \n dependiendo del tamaño del archivo y el rendimiento del sistema [(docu)](https://github.com/vingerha/gtfs2/wiki/1.-Initial-setup:-the-static-data-source)"

--- a/custom_components/gtfs2/translations/fr.json
+++ b/custom_components/gtfs2/translations/fr.json
@@ -28,6 +28,9 @@
         "data": {
           "file": "Nom de la nouvelle source de données",
           "url": "URL externe vers le fichier (zip) des données GTFS",
+          "api_key": "API_KEY, si nécessaire",
+          "api_key_name": "Nom de API_KEY, si nécessaire",
+          "api_key_location": "L'endroit ou (X_)API_KEY doit être appliqué",
 		  "extract_from": "Collecte données de:"
         },
         "description": "REMARQUE: avec une nouvelle URL/zip, cela peut prendre du temps après la soumission, selon la taille du fichier et performance du serveur [(docu)](https://github.com/vingerha/gtfs2/wiki/1.-Initial-setup:-the-static-data-source)"


### PR DESCRIPTION
Hi there,

This PR adds support for an API Key to be used when accessing the static data source URL, in the same way as it is possible with the real time feeds.

Transport for NSW (Australia) has a seperate set of timetables which correspond with the real time feeds, and these timetables are only accessible with an API Key. With these changes, it is possible to configure the integration using the URL for those timetables, rather than the complete static file that does not correspond with the real time feeds.

I'm not sure if this will be common with any other transport operators, but it is of course still possible to not use an API Key, as the implementation is identical to how it was done for the real time feeds.

Details:
* Introduces API Key configurations to the data schema for the new data source step.
* Adds corresponding translations (using the translation data already available from the real time step)
* Adds support in `get_gtfs` to use the API Key as configured in the GET request

Kind regards,
Mark