### PR TITLE
Fix Python 3.14 process pickling crash and SQLAlchemy fd leak

### DIFF
--- a/custom_components/gtfs2/config_flow.py
+++ b/custom_components/gtfs2/config_flow.py
@@ -433,7 +433,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if self._pygtfs in ['no_data_file', 'no_zip_file', 'extracting'] :
             return self._pygtfs
         check_index = await self.hass.async_add_executor_job(
-                    check_datasource_index, self.hass, self._pygtfs, DEFAULT_PATH, data["file"]
+                    check_datasource_index, self._pygtfs, self.hass.config.path(DEFAULT_PATH), data["file"]
                 )            
         return None
         
@@ -457,7 +457,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         }
         # check and/or add indexes
         check_index = await self.hass.async_add_executor_job(
-                    check_datasource_index, self.hass, self._pygtfs, DEFAULT_PATH, data["file"]
+                    check_datasource_index, self._pygtfs, self.hass.config.path(DEFAULT_PATH), data["file"]
                 )
         try:
             self._data["next_departure"] = await self.hass.async_add_executor_job(

--- a/custom_components/gtfs2/coordinator.py
+++ b/custom_components/gtfs2/coordinator.py
@@ -81,7 +81,7 @@ class GTFSUpdateCoordinator(DataUpdateCoordinator):
             "alert": {}
         }           
         
-        if check_extracting(self.hass, self._data['gtfs_dir'],self._data['file']):    
+        if check_extracting(self.hass.config.path(self._data['gtfs_dir']), self._data['file']):    
             _LOGGER.debug("Cannot update this sensor as still unpacking: %s", self._data["file"])
             previous_data["extracting"] = True
             return previous_data
@@ -102,7 +102,7 @@ class GTFSUpdateCoordinator(DataUpdateCoordinator):
             self._data = previous_data
         else:
             check_index = await self.hass.async_add_executor_job(
-                    check_datasource_index, self.hass, self._pygtfs, DEFAULT_PATH, data["file"]
+                    check_datasource_index, self._pygtfs, self.hass.config.path(DEFAULT_PATH), data["file"]
                 )
 
             try:
@@ -227,7 +227,7 @@ class GTFSLocalStopUpdateCoordinator(DataUpdateCoordinator):
         }           
         self._data["gtfs_updated_at"] = dt_util.utcnow().isoformat() 
         
-        if check_extracting(self.hass, self._data['gtfs_dir'],self._data['file']):    
+        if check_extracting(self.hass.config.path(self._data['gtfs_dir']), self._data['file']):    
             _LOGGER.debug("Cannot update this sensor as still unpacking: %s", self._data["file"])
             previous_data["extracting"] = True
             return previous_data

--- a/custom_components/gtfs2/coordinator.py
+++ b/custom_components/gtfs2/coordinator.py
@@ -60,6 +60,11 @@ class GTFSUpdateCoordinator(DataUpdateCoordinator):
         previous_data = None if self.data is None else self.data.copy()
         _LOGGER.debug("Previous data: %s", previous_data)  
 
+        if self._pygtfs and hasattr(self._pygtfs, 'engine'):
+            try:
+                self._pygtfs.engine.dispose()
+            except Exception:
+                pass
         self._pygtfs = get_gtfs(
             self.hass, DEFAULT_PATH, data, False
         )        
@@ -210,6 +215,11 @@ class GTFSLocalStopUpdateCoordinator(DataUpdateCoordinator):
                     self._headers[CONF_API_KEY] = options.get(CONF_API_KEY, None)
                     self._headers[CONF_ACCEPT_HEADER_PB] = options.get(CONF_ACCEPT_HEADER_PB, False)
                 _LOGGER.debug("RT header: %s", self._headers)
+        if self._pygtfs and hasattr(self._pygtfs, 'engine'):
+            try:
+                self._pygtfs.engine.dispose()
+            except Exception:
+                pass
         self._pygtfs = get_gtfs(
             self.hass, DEFAULT_PATH, data, False
         )        

--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -10,7 +10,6 @@ import json
 import requests
 import pygtfs
 from sqlalchemy.sql import text
-import multiprocessing
 from multiprocessing import Process
 from . import zip_file as zipfile
 from pathlib import Path
@@ -44,7 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_next_departure(hass, _data):
     _LOGGER.debug("Get next departure with data: %s", _data)
-    if check_extracting(hass, _data['gtfs_dir'],_data['file']):
+    if check_extracting(hass.config.path(_data['gtfs_dir']), _data['file']):
         _LOGGER.debug("Cannot get next depurtures on this datasource as still unpacking: %s", self._data["file"])
         return {}
 
@@ -467,7 +466,7 @@ def get_gtfs(hass, path, data, update=False):
     sqlite = data["file"] + ".sqlite"
     check_source_dates = data.get("check_source_dates", False)
     journal = os.path.join(gtfs_dir, filename + ".sqlite-journal")
-    if check_extracting(hass, gtfs_dir,filename) and not update :
+    if check_extracting(gtfs_dir, filename) and not update :
         _LOGGER.debug("Cannot use this datasource as still unpacking: %s", filename)
         return "extracting"
     if update and data["extract_from"] == "url" and os.path.exists(os.path.join(gtfs_dir, file)):
@@ -501,25 +500,24 @@ def get_gtfs(hass, path, data, update=False):
    
     if not gtfs.feeds: 
         if data.get("clean_feed_info", False):
-            _fork_ctx = multiprocessing.get_context("fork")
-            extract = _fork_ctx.Process(target=extract_from_zip, args = (hass, gtfs,gtfs_dir,file,['shapes.txt','transfers.txt','fare_attributes.txt','levels.txt','pathways.txt','translations.txt','feed_info.txt']))
+            extract = Process(target=extract_from_zip, args=(joined_path, gtfs_dir, file, ['shapes.txt','transfers.txt','fare_attributes.txt','levels.txt','pathways.txt','translations.txt','feed_info.txt']))
         else: 
-            _fork_ctx = multiprocessing.get_context("fork")
-            extract = _fork_ctx.Process(target=extract_from_zip, args = (hass, gtfs,gtfs_dir,file,['shapes.txt','transfers.txt','fare_attributes.txt','levels.txt','pathways.txt','translations.txt']))
+            extract = Process(target=extract_from_zip, args=(joined_path, gtfs_dir, file, ['shapes.txt','transfers.txt','fare_attributes.txt','levels.txt','pathways.txt','translations.txt']))
         extract.start()
         extract.join()
         _LOGGER.info("Exiting main after start subprocess for unpacking: %s", file)
         return "extracting"
     return gtfs
 
-def extract_from_zip(hass, gtfs, gtfs_dir, file, remove_file):
+def extract_from_zip(joined_path, gtfs_dir, file, remove_file):
     _LOGGER.debug("Extracting gtfs file: %s", file)
     # first remove shapes from zip to avoid possibly very large db 
-    clean = remove_from_zip(remove_file,gtfs_dir, file[:-4])
+    clean = remove_from_zip(remove_file, gtfs_dir, file[:-4])
     if os.fork() != 0:
         return
+    gtfs = pygtfs.Schedule(joined_path)
     pygtfs.append_feed(gtfs, os.path.join(gtfs_dir, file))
-    check_datasource_index(hass, gtfs, gtfs_dir, file[:-4])
+    check_datasource_index(gtfs, gtfs_dir, file[:-4])
     
 def check_calendar_dates_from_zip(gtfs_dir,file):
     _LOGGER.debug("Checking if file contains only future data: %s ", file)
@@ -697,9 +695,8 @@ def remove_datasource(hass, path, filename, include_sqlite):
         os.remove(os.path.join(gtfs_dir, filename + ".zip"))        
     return "removed"
     
-def check_extracting(hass, gtfs_dir,file):
+def check_extracting(gtfs_dir, file):
     _LOGGER.debug(f"Checking if extracting: %s", file)
-    gtfs_dir = hass.config.path(gtfs_dir)
     filename = file
     journal = os.path.join(gtfs_dir, filename + ".sqlite-journal")
     tempzip = os.path.join(gtfs_dir, filename + "_temp.zip")
@@ -709,9 +706,9 @@ def check_extracting(hass, gtfs_dir,file):
     return False    
 
 
-def check_datasource_index(hass, schedule, gtfs_dir, file):
+def check_datasource_index(schedule, gtfs_dir, file):
     _LOGGER.debug("Check datasource index for file: %s", file)
-    if check_extracting(hass, gtfs_dir,file):
+    if check_extracting(gtfs_dir, file):
         _LOGGER.warning("Cannot check indexes on this datasource as still unpacking: %s", file)
         return
     sql_index_1 = f"""
@@ -907,7 +904,7 @@ def get_local_stop_list(hass, schedule, data):
 
 def get_local_stops_next_departures(self):
     _LOGGER.debug("Get local stop departure with data: %s", self._data)
-    if check_extracting(self.hass, self._data['gtfs_dir'],self._data['file']):
+    if check_extracting(self.hass.config.path(self._data['gtfs_dir']), self._data['file']):
         _LOGGER.warning("Cannot get next depurtures on this datasource as still unpacking: %s", self._data["file"])
         return {}
     """Get next departures from data."""

--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -208,15 +208,16 @@ def get_next_departure(hass, _data):
 		{tomorrow_calendar_date_where}
         ORDER BY calendar_date,origin_depart_date, today_cd, origin_depart_time
         """  # noqa: S608
-    result = schedule.engine.connect().execute(
-        text(sql_query),
-        {
-            "origin_station_id": start_station_id,
-            "end_station_id": end_station_id,
-            "limit": limit,
-            "route_type": route_type,
-        },
-    )
+    with schedule.engine.connect() as conn:
+        result = conn.execute(
+            text(sql_query),
+            {
+                "origin_station_id": start_station_id,
+                "end_station_id": end_station_id,
+                "limit": limit,
+                "route_type": route_type,
+            },
+        ).fetchall()
     # Create lookup timetable for today and possibly tomorrow, taking into
     # account any departures from yesterday scheduled after midnight,
     # as long as all departures are within the calendar date range.
@@ -604,10 +605,8 @@ def get_route_list(schedule, data):
     {agency_where}
     order by agency_name, cast(route_id as decimal)
     """  # noqa: S608
-    result = schedule.engine.connect().execute(
-        text(sql_routes),
-        {"q": "q"},
-    )
+    with schedule.engine.connect() as conn:
+        result = conn.execute(text(sql_routes), {"q": "q"}).fetchall()
     routes_list = []
     routes = []
     for row_cursor in result:
@@ -630,10 +629,8 @@ def get_stop_list(schedule, route_id, direction):
     and (t.direction_id = {direction} or t.direction_id is null)
     order by st.stop_sequence
     """  # noqa: S608
-    result = schedule.engine.connect().execute(
-        text(sql_stops),
-        {"q": "q"},
-    )
+    with schedule.engine.connect() as conn:
+        result = conn.execute(text(sql_stops), {"q": "q"}).fetchall()
     stops_list = []
     stops = []
     for row_cursor in result:
@@ -652,10 +649,8 @@ def get_agency_list(schedule, data):
     from agency a
     order by a.agency_name
     """
-    result = schedule.engine.connect().execute(
-        text(sql_agencies),
-        {"q": "q"},
-    )
+    with schedule.engine.connect() as conn:
+        result = conn.execute(text(sql_agencies), {"q": "q"}).fetchall()
     agencies_list = []
     agencies = []
     for row_cursor in result:
@@ -765,83 +760,56 @@ def check_datasource_index(schedule, gtfs_dir, file):
         where agency_id='None'
     """
     
-    result_1a = schedule.engine.connect().execute(
-        text(sql_index_1),
-        {"q": "q"},
-    )
-    for row_cursor in result_1a:
-        _LOGGER.debug("IDX result1: %s", row_cursor._asdict())
-        if row_cursor._asdict()['checkidx'] == 0:
-            _LOGGER.warning("Adding index 1 to improve performance")
-            result_1b = schedule.engine.connect().execute(
-            text(sql_add_index_1),
-            {"q": "q"},
-            )        
-        
-    result_2a = schedule.engine.connect().execute(
-        text(sql_index_2),
-        {"q": "q"},
-    )
-    for row_cursor in result_2a:
-        _LOGGER.debug("IDX result2: %s", row_cursor._asdict())
-        if row_cursor._asdict()['checkidx'] == 0:
-            _LOGGER.warning("Adding index 2 to improve performance")
-            result_2b = schedule.engine.connect().execute(
-            text(sql_add_index_2),
-            {"q": "q"},
-            )
-            
-    result_3a = schedule.engine.connect().execute(
-        text(sql_index_3),
-        {"q": "q"},
-    )
-    for row_cursor in result_3a:
-        _LOGGER.debug("IDX result3: %s", row_cursor._asdict())
-        if row_cursor._asdict()['checkidx'] == 0:
-            _LOGGER.warning("Adding index 3 to improve performance")
-            result_3b = schedule.engine.connect().execute(
-            text(sql_add_index_3),
-            {"q": "q"},
-            )    
-    result_4a = schedule.engine.connect().execute(
-        text(sql_index_4),
-        {"q": "q"},
-    )
-    for row_cursor in result_4a:
-        _LOGGER.debug("IDX result4: %s", row_cursor._asdict())
-        if row_cursor._asdict()['checkidx'] == 0:
-            _LOGGER.warning("Adding index 4 to improve performance")
-            result_4b = schedule.engine.connect().execute(
-            text(sql_add_index_4),
-            {"q": "q"},
-            )  
-    result_5a = schedule.engine.connect().execute(
-        text(sql_index_5),
-        {"q": "q"},  
-    )
-    for row_cursor in result_5a:
-        _LOGGER.debug("IDX result5: %s", row_cursor._asdict())
-        if row_cursor._asdict()['checkidx'] == 0:
-            _LOGGER.warning("Adding index 5 to improve performance")
-            result_5b = schedule.engine.connect().execute(
-            text(sql_add_index_5),
-            {"q": "q"},
-            )  
-    
-    result_6a = schedule.engine.connect().execute(
-        text(sql_check_route_agency),
-        {"q": "q"},  
-    )
-    for row_cursor in result_6a:
-        _LOGGER.debug("Agency 'None' in routes: %s", row_cursor._asdict())
-        if row_cursor._asdict()['check_agency'] > 0:
-            _LOGGER.warning("Fix missing agency_id in routes table")
-            conn = schedule.engine.connect()
-            result_6b = conn.execute(
-            text(sql_fix_route_agency),
-            {"q": "q"},
-            )
-            conn.commit()
+    with schedule.engine.connect() as conn:
+        result_1a = conn.execute(text(sql_index_1), {"q": "q"})
+        for row_cursor in result_1a:
+            _LOGGER.debug("IDX result1: %s", row_cursor._asdict())
+            if row_cursor._asdict()['checkidx'] == 0:
+                _LOGGER.warning("Adding index 1 to improve performance")
+                conn.execute(text(sql_add_index_1), {"q": "q"})
+
+    with schedule.engine.connect() as conn:
+        result_2a = conn.execute(text(sql_index_2), {"q": "q"})
+        for row_cursor in result_2a:
+            _LOGGER.debug("IDX result2: %s", row_cursor._asdict())
+            if row_cursor._asdict()['checkidx'] == 0:
+                _LOGGER.warning("Adding index 2 to improve performance")
+                conn.execute(text(sql_add_index_2), {"q": "q"})
+
+    with schedule.engine.connect() as conn:
+        result_3a = conn.execute(text(sql_index_3), {"q": "q"})
+        for row_cursor in result_3a:
+            _LOGGER.debug("IDX result3: %s", row_cursor._asdict())
+            if row_cursor._asdict()['checkidx'] == 0:
+                _LOGGER.warning("Adding index 3 to improve performance")
+                conn.execute(text(sql_add_index_3), {"q": "q"})
+
+    with schedule.engine.connect() as conn:
+        result_4a = conn.execute(text(sql_index_4), {"q": "q"})
+        for row_cursor in result_4a:
+            _LOGGER.debug("IDX result4: %s", row_cursor._asdict())
+            if row_cursor._asdict()['checkidx'] == 0:
+                _LOGGER.warning("Adding index 4 to improve performance")
+                conn.execute(text(sql_add_index_4), {"q": "q"})
+
+    with schedule.engine.connect() as conn:
+        result_5a = conn.execute(text(sql_index_5), {"q": "q"})
+        for row_cursor in result_5a:
+            _LOGGER.debug("IDX result5: %s", row_cursor._asdict())
+            if row_cursor._asdict()['checkidx'] == 0:
+                _LOGGER.warning("Adding index 5 to improve performance")
+                conn.execute(text(sql_add_index_5), {"q": "q"})
+
+    with schedule.engine.connect() as conn:
+        result_6a = conn.execute(text(sql_check_route_agency), {"q": "q"})
+        for row_cursor in result_6a:
+            _LOGGER.debug("Agency 'None' in routes: %s", row_cursor._asdict())
+            if row_cursor._asdict()['check_agency'] > 0:
+                _LOGGER.warning("Fix missing agency_id in routes table")
+                conn.execute(text(sql_fix_route_agency), {"q": "q"})
+                conn.commit()
+
+    schedule.engine.dispose()
 
     
             
@@ -858,10 +826,8 @@ def create_trip_geojson(self):
     and t.trip_id = '{self._trip_id}'
     order by s.shape_pt_sequence
     """
-    result = schedule.engine.connect().execute(
-        text(sql_shape),
-        {"q": "q"},
-    )
+    with schedule.engine.connect() as conn:
+        result = conn.execute(text(sql_shape), {"q": "q"}).fetchall()
     shapes_list = []
     coordinates = []
     for row_cursor in result:
@@ -887,14 +853,12 @@ def get_local_stop_list(hass, schedule, data):
         FROM stops stop
         where abs(stop.stop_lat - :latitude) < :radius and abs(stop.stop_lon - :longitude) < :radius
         """  
-    result = schedule.engine.connect().execute(
-        text(sql_query),
-        {
+    with schedule.engine.connect() as conn:
+        result = conn.execute(text(sql_query), {
             "latitude": latitude,
             "longitude": longitude,
-            "radius": radius
-        },
-    )   
+            "radius": radius,
+        }).fetchall()
     rowcount = 0
     for row_cursor in result:
         rowcount += 1
@@ -996,17 +960,15 @@ def get_local_stops_next_departures(self):
         )
         order by stop_id, tomorrow, departure_time
         """  # noqa: S608
-    result = schedule.engine.connect().execute(
-        text(sql_query),
-        {
+    with schedule.engine.connect() as conn:
+        result = conn.execute(text(sql_query), {
             "latitude": latitude,
             "longitude": longitude,
             "timerange": time_range,
             "timerange_history": time_range_history,
             "radius": radius,
-            "now_offset": now
-        },
-    )        
+            "now_offset": now,
+        }).fetchall()
     timetable = []
     local_stops_list = []
     prev_stop_id = ""
@@ -1269,10 +1231,8 @@ async def get_trip_stops(hass, data):
     where  st.trip_id in {trip_list}
     order by st.trip_id, st.departure_time, st.stop_sequence
     """  # noqa: S608
-    result = schedule.engine.connect().execute(
-        text(sql_stops),
-        {"q": "q"},
-    )
+    with schedule.engine.connect() as conn:
+        result = conn.execute(text(sql_stops), {"q": "q"}).fetchall()
     stops_list = []
     stops = []
     for row_cursor in result:


### PR DESCRIPTION
## Summary

This PR fixes two related issues that cause instability under Home Assistant 2026.3 (Python 3.14).

### Issue 1 — Process args pickling crash (TypeError: cannot pickle '_asyncio.Future' object)

**Root cause**: Python 3.14 changed the default multiprocessing start method from `fork` to `forkserver` on POSIX ([docs](https://docs.python.org/3.14/library/multiprocessing.html#contexts-and-start-methods)). `forkserver` requires all `Process` args to be picklable, but `hass` (HomeAssistant) contains `asyncio.Future` objects that cannot be pickled.

The previous fix in commit `8485c91` used `get_context('fork')` to force the old method. This PR takes the proper approach: **remove `hass` and the `pygtfs.Schedule` object from `Process` args entirely**, so no pickling is required regardless of start method.

**Changes**:
- `get_gtfs()`: pass `joined_path` string instead of `hass`/`gtfs` to `Process`
- `extract_from_zip()`: reconstruct `pygtfs.Schedule` inside the child process from the path string; remove `hass` parameter
- `check_datasource_index()`: remove `hass` parameter; accept absolute `gtfs_dir`
- `check_extracting()`: remove `hass` parameter; callers now resolve `hass.config.path()` before calling
- All callers in `coordinator.py` and `config_flow.py` updated accordingly

### Issue 2 — SQLAlchemy connection/engine fd leak (2000+ open fds to TEC.sqlite)

**Root cause**: Two compounding leaks:

1. Each coordinator update cycle (every minute per sensor) called `get_gtfs()` → `pygtfs.Schedule(path)` → new SQLAlchemy engine + connection pool, but **never disposed the previous one**. Added `engine.dispose()` before reassigning `self._pygtfs` in both coordinator classes.

2. All `schedule.engine.connect().execute(...)` calls throughout `gtfs_helper.py` were made **without a context manager**, leaving connections open in the pool indefinitely. Wrapped all call sites with `with schedule.engine.connect() as conn:` and `.fetchall()` to eagerly consume results before the connection closes.

3. Added `schedule.engine.dispose()` at the end of `check_datasource_index` since it runs in a child process and should release resources before exit.

**Why visible now**: Python 3.14 changed GC timing (introduced incremental GC), so SQLAlchemy engine objects are no longer finalized as promptly as before, making the pre-existing leak accumulate rapidly.