### PR TITLE
Use the local date, not UTC, for the date filters in get_next_departure

### DIFF
--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -87,16 +87,16 @@ def get_next_departure(hass, _data):
     # days.
     limit = 24 * 60 * 60 * 2
     tomorrow_select = tomorrow_select2 = tomorrow_where = tomorrow_order = ""
-    tomorrow_calendar_date_where = f"AND (calendar_date_today.date = date('now'))"
+    tomorrow_calendar_date_where = f"AND (calendar_date_today.date = date(:now_offset))"
     if include_tomorrow:
         _LOGGER.debug("Includes Tomorrow")
         limit = int(limit / 2 * 3)
         tomorrow_name = tomorrow.strftime("%A").lower()
-        tomorrow_select = f"( select calendar.{tomorrow_name} - ( select case when (select '1' from calendar_dates where service_id=trip.service_id and date = {tomorrow_date} and exception_type = 2 ) == '1' then '1' else '0' end) ) as tomorrow,"
+        tomorrow_select = f"( select calendar.{tomorrow_name} - ( select case when (select '1' from calendar_dates where service_id=trip.service_id and date = date(:now_offset,'+1 day') and exception_type = 2 ) == '1' then '1' else '0' end) ) as tomorrow,"
         tomorrow_where = f"OR calendar.{tomorrow_name} = 1"
         tomorrow_order = f"calendar.{tomorrow_name} DESC,"
-        tomorrow_calendar_date_where = f"AND (calendar_date_today.date = date('now') or calendar_date_today.date = date('now','+1 day') )"
-        tomorrow_select2 = f"CASE WHEN date('now') < calendar_date_today.date THEN 1 else 0 END as tomorrow,"
+        tomorrow_calendar_date_where = f"AND (calendar_date_today.date = date(:now_offset) or calendar_date_today.date = date(:now_offset,'+1 day') )"
+        tomorrow_select2 = f"CASE WHEN date(:now_offset) < calendar_date_today.date THEN 1 else 0 END as tomorrow,"
     sql_query = f"""
         SELECT trip.trip_id, trip.route_id,trip.trip_headsign, trip.direction_id,trip.trip_short_name,
                route.route_long_name,route.route_short_name,
@@ -125,7 +125,7 @@ def get_next_departure(hass, _data):
                destination_stop_time.stop_sequence AS dest_stop_sequence,
                destination_stop_time.timepoint AS dest_stop_timepoint,
                calendar.{yesterday.strftime("%A").lower()} AS yesterday,
-               ( select calendar.{now.strftime("%A").lower()} - (  select case when (select '1' from calendar_dates where service_id=trip.service_id and date = date('now') and exception_type = 2 ) == '1' then '1' else '0' end  ) ) as today,
+               ( select calendar.{now.strftime("%A").lower()} - (  select case when (select '1' from calendar_dates where service_id=trip.service_id and date = date(:now_offset) and exception_type = 2 ) == '1' then '1' else '0' end  ) ) as today,
                {tomorrow_select}
                calendar.start_date AS start_date,
                calendar.end_date AS end_date,
@@ -150,8 +150,8 @@ def get_next_departure(hass, _data):
         {start_station_where}
         {end_station_where}
         AND origin_stop_sequence < dest_stop_sequence
-        AND calendar.start_date <= date('now')
-        AND calendar.end_date >= date('now')
+        AND calendar.start_date <= date(:now_offset)
+        AND calendar.end_date >= date(:now_offset)
 		UNION ALL
 	    SELECT trip.trip_id, trip.route_id,trip.trip_headsign, trip.direction_id,trip.trip_short_name,
                route.route_long_name,route.route_short_name,
@@ -182,8 +182,8 @@ def get_next_departure(hass, _data):
                '0' AS yesterday,
                '0' AS today,
                {tomorrow_select2}
-               date('now') AS start_date,
-               date('now') AS end_date,
+               date(:now_offset) AS start_date,
+               date(:now_offset) AS end_date,
                calendar_date_today.date as calendar_date,
                calendar_date_today.exception_type as today_cd
         FROM trips trip
@@ -223,6 +223,10 @@ def get_next_departure(hass, _data):
                 "end_station_id": end_station_id,
                 "limit": limit,
                 "route_type": route_type,
+                # Bound as a date string rather than a datetime: every use is
+                # wrapped in date(), and passing a datetime through to sqlite3
+                # relies on its default adapter, deprecated since Python 3.12.
+                "now_offset": now_date,
             },
         )
         rows = result.fetchall()


### PR DESCRIPTION
Fixes #166

Independent of #165. That one changes how rows are attributed to a day in the timetable loop, this one changes which days the query asks for. They touch different lines and can be merged in either order.

### Problem

`get_next_departure()` mixes two notions of "today" in a single query.

The SQL side used bare `date('now')`, which SQLite always evaluates in UTC. The Python side derives `now_date`, `tomorrow_date` and the timetable keys from local time via `dt_util.now()` at lines 73-83. For any timezone behind UTC the two disagree for part of every evening: the queried window has already advanced a day while the labels have not, and the user's actual local day is never queried at all.

In `America/Toronto` at 21:00 local on Tue 2026-07-28, `date('now')` is `2026-07-29`.

### Fix

Bind the offset-adjusted local `now` and use `date(:now_offset)`, which is exactly what `get_local_stops_next_departures()` already does (`"now_offset": now` at line 976). Nine occurrences across eight lines, all inside `get_next_departure`.

`date('now','localtime')` was deliberately not used: it follows the container's `TZ` rather than the timezone configured in Home Assistant, so it would be right only by coincidence.

### Second change in the same lines

The `exception_type = 2` lookup for tomorrow interpolated `tomorrow_date` unquoted:

```python
... where service_id=trip.service_id and date = {tomorrow_date} and exception_type = 2
```

That renders as `date = 2026-07-29`, which SQLite parses as arithmetic and reduces to the integer `1990`, so the comparison can never match. A service removed for tomorrow via `exception_type = 2` was therefore still reported as running. The equivalent lookup for today, on the line below, was already quoted; this brings the two into line. Happy to split it into its own PR if you would rather keep them separate.

### Verification

Against the Metrolinx UP Express feed, which has service on both dates so a missing date can only be the filter's doing. `date('now')` cannot be simulated as it reads the real clock, so the current behaviour is modelled by pinning the literal date UTC would report at that moment.

Simulated local time 21:00 on 2026-07-28, expected window `2026-07-28` plus `2026-07-29`:

| | dates fetched | local today present | today flagged correctly |
|---|---|---|---|
| before | `2026-07-29`, `2026-07-30` | no | no, `2026-07-29` flagged as today |
| after | `2026-07-28`, `2026-07-29` | yes | yes |

During the day, when the local and UTC dates agree, `date(:now_offset)` and `date('now')` evaluate identically, so there is no change outside the offset window.

For the quoting fix, with an `exception_type = 2` row present for tomorrow: the old expression matched 0 rows, the new one matches 1.

The `datetime` bind was exercised through pygtfs's own SQLAlchemy engine rather than raw sqlite3, so it goes through the same path as the running integration.
