### PR TITLE
Stage datasource downloads and keep existing data when a refresh fails

### DIFF
--- a/custom_components/gtfs2/const.py
+++ b/custom_components/gtfs2/const.py
@@ -13,6 +13,10 @@ DEFAULT_LOCAL_STOP_RADIUS = 200
 DEFAULT_MAX_LOCAL_STOPS = 15
 
 DEFAULT_NAME = "GTFS Sensor2"
+# (connect, read) timeout for fetching a static datasource. The read timeout
+# applies between chunks rather than to the whole transfer, so a slow but
+# progressing download is not cut off.
+DEFAULT_DOWNLOAD_TIMEOUT = (10, 60)
 DEFAULT_PATH = "gtfs2"
 DEFAULT_PATH_GEOJSON = "www/gtfs2"
 DEFAULT_PATH_RT = "www/gtfs2"

--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -27,7 +27,8 @@ from .const import (
     CONF_API_KEY_LOCATION,
     CONF_API_KEY_NAME,
     CONF_ACCEPT_HEADER_PB,
-    DEFAULT_LOCAL_STOP_TIMERANGE, 
+    DEFAULT_DOWNLOAD_TIMEOUT,
+    DEFAULT_LOCAL_STOP_TIMERANGE,
     DEFAULT_LOCAL_STOP_TIMERANGE_HISTORY,
     DEFAULT_LOCAL_STOP_RADIUS,
     DEFAULT_PATH_RT,
@@ -473,23 +474,53 @@ def get_gtfs(hass, path, data, update=False):
     if check_extracting(hass, gtfs_dir,filename) and not update :
         _LOGGER.debug("Cannot use this datasource as still unpacking: %s", filename)
         return "extracting"
-    if update and data["extract_from"] == "url" and os.path.exists(os.path.join(gtfs_dir, file)):
-        remove_datasource(hass, path, filename, True)
     if update and data["extract_from"] == "zip" and os.path.exists(os.path.join(gtfs_dir, file)) and os.path.exists(os.path.join(gtfs_dir, sqlite)):
-        os.remove(os.path.join(gtfs_dir, sqlite))      
+        os.remove(os.path.join(gtfs_dir, sqlite))
     if data["extract_from"] == "zip":
         if not os.path.exists(os.path.join(gtfs_dir, file)):
             _LOGGER.error("The given GTFS zipfile was not found")
             return "no_zip_file"
     if data["extract_from"] == "url":
-        if not os.path.exists(os.path.join(gtfs_dir, file)):
+        target = os.path.join(gtfs_dir, file)
+        # Fetch when there is nothing yet, or when a service call asks for a
+        # refresh. Download to a staging file and only replace the datasource once
+        # the new archive has arrived complete and is really a zip. Removing the
+        # old zip and sqlite up front, as this used to, means a failed, truncated
+        # or non-zip response leaves the datasource with nothing at all until the
+        # next successful run.
+        if update or not os.path.exists(target):
+            staged = os.path.join(gtfs_dir, filename + "_download.zip")
             try:
-                r = requests.get(url,headers=_headers, allow_redirects=True)
-                open(os.path.join(gtfs_dir, file), "wb").write(r.content)
+                with requests.get(
+                    url,
+                    headers=_headers,
+                    allow_redirects=True,
+                    timeout=DEFAULT_DOWNLOAD_TIMEOUT,
+                    stream=True,
+                ) as r:
+                    r.raise_for_status()
+                    with open(staged, "wb") as staged_file:
+                        for chunk in r.iter_content(chunk_size=65536):
+                            staged_file.write(chunk)
             except Exception as ex:  # pylint: disable=broad-except
-                _LOGGER.error("The given URL or GTFS data file/folder was not found")
-                return "no_data_file"                
-    
+                _LOGGER.error(
+                    "Could not download GTFS data from: %s, keeping the current data, error: %s",
+                    url,
+                    ex,
+                )
+                if os.path.exists(staged):
+                    os.remove(staged)
+                return "no_data_file"
+            if not zipfile.is_zipfile(staged):
+                _LOGGER.error(
+                    "Data downloaded from: %s is not a zip archive, keeping the current data",
+                    url,
+                )
+                os.remove(staged)
+                return "no_data_file"
+            remove_datasource(hass, path, filename, True)
+            os.replace(staged, target)
+
     # if update (servicecall) then check if new file does not only have future dates
     if check_source_dates:
         if update and not check_calendar_dates_from_zip(gtfs_dir, file):


### PR DESCRIPTION
Fixes #168

Independent of #165 and #167. Those are both in `get_next_departure()`, this is in `get_gtfs()`. All three merge cleanly in any order.

### Problem

`get_gtfs()` removed the zip and the sqlite before fetching a replacement, then wrote whatever came back straight to the datasource without checking the response.

- **A failed refresh left nothing behind.** `remove_datasource()` ran first, so a network error meant the datasource had neither its archive nor its database until the next successful run.
- **Any response body became the archive.** No `raise_for_status()`, so an error page was saved as `<file>.zip` and the function returned normally, as though the refresh had worked. The caller could not distinguish an HTTP error from success.
- **No timeout**, so a connection that opened and then stalled could block indefinitely.

### Fix

Fetch to `<file>_download.zip`, require a 2xx, confirm the result really is a zip, and only then remove the old files and move the new one into place.

- the staging name avoids `<file>_temp.zip`, which `check_extracting()` uses as its marker, and is opened with `"wb"` so a leftover from an interrupted run is truncated rather than reused
- the timeout is a `(connect, read)` pair; with `stream=True` the read half applies between chunks, so a slow but progressing download is not cut off
- `zipfile.is_zipfile` comes from the vendored `zip_file` module already imported here

Behaviour is otherwise unchanged: a missing archive is still fetched, an existing one is still left alone unless a service call asks for a refresh, and a successful refresh still clears the sqlite so the feed is re-extracted.

### Verification

Each mode run against live endpoints, starting from a working datasource every time (a valid zip plus a sqlite):

| case | before | after |
|---|---|---|
| success, real feed | `ok`, new data | `ok`, new data |
| HTTP 404, empty body | **`ok`**, 0-byte file saved as the zip, sqlite deleted | `no_data_file`, zip and sqlite intact |
| HTTP 200 with HTML | **`ok`**, 278445 bytes of HTML saved as the zip, sqlite deleted | `no_data_file`, zip and sqlite intact |
| unroutable host | `no_data_file`, zip and sqlite both gone | `no_data_file`, zip and sqlite intact |

The two bold rows are the ones worth noting: the function reported success while having destroyed the datasource.

URLs used: `GO-GTFS-Static.zip` on the assets host for the 404, `metrolinx.com/en/about-us/open-data` for HTML with a 200, and `192.0.2.1` (TEST-NET-1) for the stall.

### Not included

No conditional request support. `update_gtfs` still re-downloads and re-extracts unconditionally, which for the GO Transit feed is a 14.7MB download and a 227MB sqlite rebuild of roughly 12 minutes on a Yellow, even when the feed has not changed. Both Metrolinx endpoints emit strong ETags and `Last-Modified` and honour `If-None-Match` and `If-Modified-Since` with a 304, so this is avoidable. The staging structure here makes it a natural follow-on, but it needs somewhere to persist the validator between runs, which felt like your call rather than something to slip into a bug fix. Happy to open it separately.
