### PR TITLE
Fix realtime departures announced too early at terminus/layover stops

### DIFF
--- a/custom_components/gtfs2/gtfs_rt_helper.py
+++ b/custom_components/gtfs2/gtfs_rt_helper.py
@@ -281,12 +281,15 @@ def get_rt_route_trip_statuses(self):
                             departure_times[self._route_id][direction_id][stop_id]["departures"] = []
                             departure_times[self._route_id][direction_id][stop_id]["delays"] = []
                         
-                        # Use stop arrival time;
-                        # fall back on departure time if not available                            
-                        if stop["arrival"]["time"] == 0:
-                            stop_time = stop["departure"]["time"]
-                        else:
+                        # Use stop departure time;
+                        # fall back on arrival time if not available
+                        # both callers report departures from this stop, so the departure time is
+                        # the correct one: at a terminus or layover the vehicle can stand several
+                        # minutes, and the arrival time would announce a bus that has not left yet
+                        if stop["departure"]["time"] == 0:
                             stop_time = stop["arrival"]["time"]
+                        else:
+                            stop_time = stop["departure"]["time"]
                             
                         if stop["departure"].get("delay",0) >= stop["arrival"].get("delay",0):
                             delay = stop["departure"].get("delay",0)

--- a/custom_components/gtfs2/gtfs_rt_helper.py
+++ b/custom_components/gtfs2/gtfs_rt_helper.py
@@ -281,15 +281,15 @@ def get_rt_route_trip_statuses(self):
                             departure_times[self._route_id][direction_id][stop_id]["departures"] = []
                             departure_times[self._route_id][direction_id][stop_id]["delays"] = []
                         
-                        # Use stop departure time;
-                        # fall back on arrival time if not available
-                        # both callers report departures from this stop, so the departure time is
-                        # the correct one: at a terminus or layover the vehicle can stand several
-                        # minutes, and the arrival time would announce a bus that has not left yet
-                        if stop["departure"]["time"] == 0:
-                            stop_time = stop["arrival"]["time"]
-                        else:
-                            stop_time = stop["departure"]["time"]
+                        # Both callers report departures from this stop, so the
+                        # later of the two times is the one to announce: at a
+                        # terminus or a layover the vehicle stands several
+                        # minutes at its bay, and the arrival would announce a
+                        # bus that has not left yet. A time the feed does not
+                        # publish arrives as 0, so it can never be the later
+                        # one, which is the fallback for the poorer feeds.
+                        stop_time = max(stop["arrival"]["time"],
+                                        stop["departure"]["time"])
                             
                         if stop["departure"].get("delay",0) >= stop["arrival"].get("delay",0):
                             delay = stop["departure"].get("delay",0)

--- a/custom_components/gtfs2/gtfs_rt_helper.py
+++ b/custom_components/gtfs2/gtfs_rt_helper.py
@@ -281,13 +281,9 @@ def get_rt_route_trip_statuses(self):
                             departure_times[self._route_id][direction_id][stop_id]["departures"] = []
                             departure_times[self._route_id][direction_id][stop_id]["delays"] = []
                         
-                        # Both callers report departures from this stop, so the
-                        # later of the two times is the one to announce: at a
-                        # terminus or a layover the vehicle stands several
-                        # minutes at its bay, and the arrival would announce a
-                        # bus that has not left yet. A time the feed does not
-                        # publish arrives as 0, so it can never be the later
-                        # one, which is the fallback for the poorer feeds.
+                        # the later of the two 'time' attributes is the one to announce
+                        # e.g. at a terminus/layover where the vehicle stands several
+                        # minutes at its bay
                         stop_time = max(stop["arrival"]["time"],
                                         stop["departure"]["time"])
                             


### PR DESCRIPTION
## Symptom

On a start/end sensor whose origin stop is a **terminus with a layover**, the realtime departures (`next_departures_realtime` / `next_departure_realtime`) are announced **too early** — 7 to 11 minutes on the feed below. The static schedule (`next_departures`) is correct, and the opposite direction of the same line is unaffected.

Observed on TAO Orléans (trip updates: `https://ara-api.enroute.mobi/tao/gtfs/trip-updates`), line 40, direction Gare d'Orléans → Gaston Galloux, origin stop `ORLEANS:StopArea:01001712` (Gare d'Orléans - Quai E):

| shown by gtfs2 | actual departure |
|---|---|
| 14:32 | 14:43 |
| 15:03 | 15:13 |
| 15:35 | 15:42 |

## Cause

`get_rt_route_trip_statuses` keeps the **arrival** time of the `stop_time_update`, with the departure time only as fallback:

```python
# Use stop arrival time;
# fall back on departure time if not available
if stop["arrival"]["time"] == 0:
    stop_time = stop["departure"]["time"]
else:
    stop_time = stop["arrival"]["time"]
```

Mid-route, `arrival == departure`, so the choice makes no visible difference and the bug stays invisible. At a terminus or a timing/regulation point the vehicle stands still for a while and the two values diverge. Raw trace of the feed:

```
Line 40, dir=1, Quai E (01001712) — terminus of the return leg
  seq=1  arrival=14:32:41  departure=14:43:00   layover=10 min
  seq=1  arrival=15:03:13  departure=15:13:00   layover=9 min
  seq=1  arrival=15:35:00  departure=15:42:00   layover=7 min

Line 40, dir=0, Gaston Galloux (00026500) — mid-route stop
  seq=19 arrival=14:24:11  departure=14:24:11   identical
```

Both callers of this function consume the result as **departure** times:

- `gtfs_rt_helper.get_next_services` → key `"departures"`, exposed as `next_departures_realtime` / `next_departure_realtime`;
- the local-stops path in `gtfs_helper.get_local_stops_next_departures` → `departures` / `departure_rt`, compared against the planned **departure** time.

So the departure time is the correct value in both cases: the arrival time announces a bus that is standing at the platform but has not left yet.

(For context: line 40 is a loop, so the same stop_id appears in both directions at this stop. That was the first suspect, but replaying the entity-matching condition with the sensor's real values showed all retained entities were the correct `dir=1, seq=1` — the direction filter works. The gap came solely from the arrival/departure choice inside the right `stop_time_update`.)

## Fix

Invert the preference — departure first, arrival as fallback:

```python
# Use stop departure time;
# fall back on arrival time if not available
if stop["departure"]["time"] == 0:
    stop_time = stop["arrival"]["time"]
else:
    stop_time = stop["departure"]["time"]
```

The fallback remains necessary: some feeds only publish one of the two times.

## Verification

Old and new logic simulated on the live TAO feed, compared to the static schedule:

| sensor | before (arrival) | after (departure) | schedule |
|---|---|---|---|
| 40 Galloux→Gare | 14:24, 14:54, 15:24 | 14:24, 14:54, 15:24 | 14:24, 14:54, 15:25 |
| **40 Gare→Galloux** | 14:32, 15:03, 15:35 | **14:43, 15:13, 15:42** ✅ | 14:43, 15:13, 15:42 |
| 41 Galloux→Gare | 16:22, 16:43, 17:00 | 16:22, 16:43, 17:00 | 16:21, 16:43, 16:59 |
| **41 Gare→Galloux** | 16:15, 16:34, 16:56 | **16:15, 16:41, 17:06** ✅ | 16:15, 16:41, 17:06 |

The unaffected directions are byte-identical before/after (arrival == departure mid-route); their one-minute deviations from the schedule are legitimate realtime, not a regression.

## Deliberately not touched

The delay selection just below the changed block keeps `max(departure_delay, arrival_delay)`. For consistency it could prefer the departure delay, but the `max()` is a defensible fallback for feeds that only fill the arrival delay, and the observed feed publishes no `delay` field at all. Can be revisited separately if a feed with asymmetric delays shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
