### PR TITLE
Stable identity and readable labels for realtime vehicle position markers

### DIFF
--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -505,6 +505,7 @@ def get_next_departure(hass, _data):
     data_returned = {
         "trip_id": item["trip_id"],
         "route_id": item["route_id"],
+        "route_short_name": item["route_short_name"],
         "trip_direction_id": item["direction_id"],
         "trip_short_name": item["trip_short_name"],
         "day": item["day"],

--- a/custom_components/gtfs2/gtfs_rt_helper.py
+++ b/custom_components/gtfs2/gtfs_rt_helper.py
@@ -344,8 +344,32 @@ def get_rt_vehicle_positions(self):
             geojson_element["geometry"]["coordinates"] = []
             geojson_element["geometry"]["coordinates"].append(vehicle["position"]["longitude"])
             geojson_element["geometry"]["coordinates"].append(vehicle["position"]["latitude"])
-            geojson_element["properties"]["id"] = str(self._route_id) + "(" + str(vehicle["trip"]["direction_id"]) + ")" + str(binascii.crc32((vehicle["trip"]["trip_id"]).encode('utf8')))[-3:]
-            geojson_element["properties"]["title"] = str(self._route_id) + "(" + str(vehicle["trip"]["direction_id"]) + ")" + str(binascii.crc32((vehicle["trip"]["trip_id"]).encode('utf8')))[-3:] + "_" + self._icon.split(':')[1]
+            # Stable, human-readable marker identity.
+            # geo_json_events registers each marker with unique_id
+            # <config_entry_id>_<properties.id>; the crc32 of the trip_id changes
+            # every trip, so each vehicle came back as a brand-new entity on every
+            # run and the entity registry grew without bound. The vehicle id is
+            # stable across trips and days, so the entity (and its name) is reused.
+            # The id joins the raw route_id, the direction and the vehicle id
+            # with underscores, so it cannot be mistaken for the old
+            # route_id(direction)crc form. The map card uses the title as
+            # entity name: line short name, destination, vehicle. Fall back on
+            # the original crc-based label when the feed publishes no vehicle
+            # id or the sensor carries no usable line name or destination.
+            _crc = str(binascii.crc32((vehicle["trip"]["trip_id"]).encode('utf8')))[-3:]
+            _veh = str(vehicle.get("vehicle", {}).get("id", "") or vehicle.get("vehicle", {}).get("label", "")).strip()
+            _dir = str(vehicle["trip"]["direction_id"])
+            try:
+                _line = str(self._data.get("next_departure", {}).get("route_short_name") or "").strip()
+                _dest = self.config_entry.data.get("destination", "").split(": ")[-1].split(" (")[0].split(" - ")[0].strip()
+            except Exception:  # the label is cosmetic, it must never break the update
+                _line, _dest = "", ""
+            if _line and _dest:
+                _label = _line + " → " + _dest + " " + (_veh or _crc)
+            else:
+                _label = str(self._route_id) + "(" + _dir + ")" + _crc + "_" + self._icon.split(':')[1]
+            geojson_element["properties"]["id"] = str(self._route_id) + "_" + _dir + "_" + (_veh or _crc)
+            geojson_element["properties"]["title"] = _label
             geojson_element["properties"]["trip_id"] = vehicle["trip"]["trip_id"]
             geojson_element["properties"]["route_id"] = str(self._route_id)
             geojson_element["properties"]["direction_id"] = vehicle["trip"]["direction_id"]

--- a/custom_components/gtfs2/gtfs_rt_helper.py
+++ b/custom_components/gtfs2/gtfs_rt_helper.py
@@ -344,25 +344,15 @@ def get_rt_vehicle_positions(self):
             geojson_element["geometry"]["coordinates"] = []
             geojson_element["geometry"]["coordinates"].append(vehicle["position"]["longitude"])
             geojson_element["geometry"]["coordinates"].append(vehicle["position"]["latitude"])
-            # Stable, human-readable marker identity.
-            # geo_json_events registers each marker with unique_id
-            # <config_entry_id>_<properties.id>; the crc32 of the trip_id changes
-            # every trip, so each vehicle came back as a brand-new entity on every
-            # run and the entity registry grew without bound. The vehicle id is
-            # stable across trips and days, so the entity (and its name) is reused.
-            # The id joins the raw route_id, the direction and the vehicle id
-            # with underscores, so it cannot be mistaken for the old
-            # route_id(direction)crc form. The map card uses the title as
-            # entity name: line short name, destination, vehicle. Fall back on
-            # the original crc-based label when the feed publishes no vehicle
-            # id or the sensor carries no usable line name or destination.
+            # Altered to use vehicle_id (if existing) to create the unique indicator instead of trip_id
+            # to reduce number of entities created by geojson. 
             _crc = str(binascii.crc32((vehicle["trip"]["trip_id"]).encode('utf8')))[-3:]
             _veh = str(vehicle.get("vehicle", {}).get("id", "") or vehicle.get("vehicle", {}).get("label", "")).strip()
             _dir = str(vehicle["trip"]["direction_id"])
             try:
                 _line = str(self._data.get("next_departure", {}).get("route_short_name") or "").strip()
                 _dest = self.config_entry.data.get("destination", "").split(": ")[-1].split(" (")[0].split(" - ")[0].strip()
-            except Exception:  # the label is cosmetic, it must never break the update
+            except Exception: 
                 _line, _dest = "", ""
             if _line and _dest:
                 _label = _line + " → " + _dest + " " + (_veh or _crc)


### PR DESCRIPTION
## Two problems with the realtime vehicle position markers

`get_rt_vehicle_positions` builds `properties.id` and `properties.title` of the GeoJSON features from the raw `route_id`, the `direction_id` and the last 3 digits of the crc32 of the `trip_id`.

### 1. Unstable identity → unbounded entity-registry growth

The `geo_json_events` integration registers each marker with `unique_id = <config_entry_id>_<properties.id>`:

```
geo_location.orleans_line_40_0_156_bus
  unique_id = 01M0D312WVNW3VYW8CKQDFE0YE_ORLEANS:Line:40(0)156
```

The crc32 of the `trip_id` changes **on every trip**, so every vehicle comes back as a brand-new entity on each run, and the registry grows without bound. Observed on a live install (TAO Orléans feed), registry vs live states after only ~30 minutes:

```
in registry: 5        alive: 4
  ALIVE  geo_location.orleans_line_40_0_156_bus
  stale  geo_location.orleans_line_40_0_547_bus   <- bus left the feed
  ALIVE  geo_location.orleans_line_40_1_189_bus
  ALIVE  geo_location.orleans_line_40_1_720_bus
  ALIVE  geo_location.orleans_line_40_1_934_bus
```

### 2. Unreadable labels on the map

`geo_json_events` uses `properties.title` as the entity name, and the map card displays it as the marker label: `ORLEANS:Line:40(0)156_bus`. Worse, the marker badge only shows the first letter of each word (3 max, see `ha-map.ts`), and this title contains no space — so the badge shows a single letter.

## Fix

Build the identity from what is actually stable, and the label from what a human reads:

- `properties.id` = `<route_id>_<direction>_<vehicle id>` (e.g. `ORLEANS:Line:40_1_7015`). The feed's `vehicle.id` is stable across trips and days, so a vehicle keeps the same `unique_id`, hence the same entity and name. The registry stabilizes at the size of the fleet serving the tracked line.
- `properties.title` = `<line short name> → <destination> <vehicle id>` (e.g. `40 → Gaston Galloux 7015`). The short name comes from the schedule (`get_next_departure` now returns it next to `route_id`), the destination from the config entry, cleaned of the stop-id prefix, platform suffix and counter.

Fallbacks keep every previous behavior reachable:

- feed publishes no `vehicle.id` → fall back on the crc32 digits (original behavior for that vehicle);
- config entry has no usable destination (e.g. local-stop sensors) → fall back on the original full label;
- the destination parsing is wrapped in `try` and the vehicle descriptor is read with `.get()` — a label is cosmetic and must never break the update.

Before/after on the live feed:

```
before:  geo_location.orleans_line_40_1_934_bus   (new entity every trip)
after:   geo_location.40_gaston_galloux_7015      (stable across trips/days)
         friendly name: 40 → Gaston Galloux 7015
```

The registry entries left by the old ids are cleaned up in a separate PR (#179).

## Known limitation

If a feed stops publishing `vehicle.id`, the crc fallback brings back the original per-trip churn for that vehicle. On the observed feed all 94 vehicles carry one.

Verified live on TAO Orléans (`https://ara-api.enroute.mobi/tao/gtfs/vehicle-positions`): stable entity set (~a dozen for two lines), readable names on the map card, local-stop sensors untouched (fallback label).
