### PR TITLE
Export route shape and ordered stops for map cards

### DIFF
--- a/custom_components/gtfs2/const.py
+++ b/custom_components/gtfs2/const.py
@@ -1,27 +1,5 @@
 """Constants for the GTFS integration."""
-import re
-
 from homeassistant.const import CONF_OFFSET, STATE_UNKNOWN, Platform
-
-
-_UNSAFE_FILE_PART = re.compile(r"[^a-z0-9._-]+")
-
-
-def safe_file_part(value) -> str:
-    """A route or direction id, made safe to put in a file name.
-
-    Both geojson files are named after ids that come out of the datasource,
-    that is to say out of a url the user pasted: an id like ZOP:653 makes a
-    file no Windows share can read, a percent sign has to be escaped in the
-    /local/ url that serves the file, and an id carrying a slash writes into
-    a directory that does not exist and loses the file to an OSError.
-
-    Rather than list the separators a feed may bring, keep letters, digits,
-    dot, dash and underscore, replace every run of the rest with a single
-    underscore and lowercase, so one route always lands on one file.
-    """
-    return re.sub(r"\.\.+", "_", _UNSAFE_FILE_PART.sub("_", str(value).lower()))
-
 
 DOMAIN = "gtfs2"
 

--- a/custom_components/gtfs2/const.py
+++ b/custom_components/gtfs2/const.py
@@ -1,5 +1,27 @@
 """Constants for the GTFS integration."""
+import re
+
 from homeassistant.const import CONF_OFFSET, STATE_UNKNOWN, Platform
+
+
+_UNSAFE_FILE_PART = re.compile(r"[^a-z0-9._-]+")
+
+
+def safe_file_part(value) -> str:
+    """A route or direction id, made safe to put in a file name.
+
+    Both geojson files are named after ids that come out of the datasource,
+    that is to say out of a url the user pasted: an id like ZOP:653 makes a
+    file no Windows share can read, a percent sign has to be escaped in the
+    /local/ url that serves the file, and an id carrying a slash writes into
+    a directory that does not exist and loses the file to an OSError.
+
+    Rather than list the separators a feed may bring, keep letters, digits,
+    dot, dash and underscore, replace every run of the rest with a single
+    underscore and lowercase, so one route always lands on one file.
+    """
+    return re.sub(r"\.\.+", "_", _UNSAFE_FILE_PART.sub("_", str(value).lower()))
+
 
 DOMAIN = "gtfs2"
 

--- a/custom_components/gtfs2/coordinator.py
+++ b/custom_components/gtfs2/coordinator.py
@@ -28,7 +28,7 @@ from .const import (
     ICON,
     ICONS
 )    
-from .gtfs_helper import get_gtfs, get_next_departure, check_datasource_index, create_trip_geojson, check_extracting, get_local_stops_next_departures
+from .gtfs_helper import get_gtfs, get_next_departure, check_datasource_index, create_trip_geojson, check_extracting, get_local_stops_next_departures, update_route_geojson
 from .gtfs_rt_helper import get_next_services, get_rt_alerts
 
 _LOGGER = logging.getLogger(__name__)
@@ -119,7 +119,18 @@ class GTFSUpdateCoordinator(DataUpdateCoordinator):
                 self._data["gtfs_updated_at"] = dt_util.utcnow().isoformat()
             except Exception as ex:  # pylint: disable=broad-except
                 raise UpdateFailed(f"Error in getting gtfs data: {ex}") from ex
-            _LOGGER.debug("GTFS coordinator data from helper: %s", self._data["next_departure"]) 
+            _LOGGER.debug("GTFS coordinator data from helper: %s", self._data["next_departure"])
+            # The planned side of the map: the journey's ordered stops, written
+            # next to the vehicle positions. It follows the static data, needs
+            # no realtime at all, and only changes with the drawn trip, so it
+            # is keyed on the trip rather than rewritten every refresh.
+            trip_for_export = self._data.get("next_departure", {}).get("trip_id", None)
+            if trip_for_export and trip_for_export != getattr(self, "_route_export_trip", None):
+                try:
+                    await self.hass.async_add_executor_job(update_route_geojson, self)
+                    self._route_export_trip = trip_for_export
+                except Exception as ex:  # pylint: disable=broad-except
+                    _LOGGER.error("Error writing route geojson: %s", ex)
         
         # collect and return rt attributes
         # STILL REQUIRES A SOLUTION IF CONNECTION TIMING OUT

--- a/custom_components/gtfs2/coordinator.py
+++ b/custom_components/gtfs2/coordinator.py
@@ -52,6 +52,9 @@ class GTFSUpdateCoordinator(DataUpdateCoordinator):
         
         self._pygtfs = ""
         self._data: dict[str, str] = {}
+        # the trip whose stops are already exported, so the geojson is
+        # rewritten when the journey changes and not on every refresh
+        self._route_export_trip = None
 
     async def _async_update_data(self) -> dict[str, str]:
         """Get the latest data from GTFS and GTFS relatime, depending refresh interval"""
@@ -125,7 +128,7 @@ class GTFSUpdateCoordinator(DataUpdateCoordinator):
             # no realtime at all, and only changes with the drawn trip, so it
             # is keyed on the trip rather than rewritten every refresh.
             trip_for_export = self._data.get("next_departure", {}).get("trip_id", None)
-            if trip_for_export and trip_for_export != getattr(self, "_route_export_trip", None):
+            if trip_for_export and trip_for_export != self._route_export_trip:
                 try:
                     await self.hass.async_add_executor_job(update_route_geojson, self)
                     self._route_export_trip = trip_for_export

--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -24,6 +24,7 @@ from homeassistant.helpers import entity_registry as er
 
 from .const import (
     DEFAULT_PATH_GEOJSON,
+    safe_file_part,
     CONF_API_KEY,
     CONF_API_KEY_LOCATION,
     CONF_API_KEY_NAME,
@@ -991,7 +992,9 @@ def update_route_geojson(self):
         })
     geojson_dir = self.hass.config.path(DEFAULT_PATH_GEOJSON)
     os.makedirs(geojson_dir, exist_ok=True)
-    file = os.path.join(geojson_dir, str(route_id) + "_" + direction + "_route.json")
+    # the ids come out of the datasource, so they are not file names until
+    # they are made ones: see safe_file_part
+    file = os.path.join(geojson_dir, f"{safe_file_part(route_id)}_{safe_file_part(direction)}_route.json")
     _LOGGER.debug("Creating route geojson file: %s", file)
     with open(file, "w") as outfile:
         json.dump({

--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -23,6 +23,7 @@ from homeassistant.const import CONF_NAME
 from homeassistant.helpers import entity_registry as er
 
 from .const import (
+    DEFAULT_PATH_GEOJSON,
     CONF_API_KEY,
     CONF_API_KEY_LOCATION,
     CONF_API_KEY_NAME,
@@ -932,6 +933,76 @@ def create_trip_geojson(self):
     self.geojson = {"features": [{"geometry": {"coordinates": coordinates, "type": "LineString"}, "properties": {"id": self._trip_id, "title": self._trip_id}, "type": "Feature"}], "type": "FeatureCollection"}    
     _LOGGER.debug("Geojson output: %s", json.dumps(self.geojson))
     return None
+
+
+def _fmt_gtfs_time(value):
+    """Render a pygtfs departure_time (seconds since midnight, may exceed 24h) as HH:MM:SS."""
+    try:
+        s = int(value)
+        return f"{s // 3600:02d}:{(s % 3600) // 60:02d}:{s % 60:02d}"
+    except (TypeError, ValueError):
+        return str(value) if value is not None else None
+
+
+def update_route_geojson(self):
+    """Write the journey's ordered stops to www/gtfs2/<route>_<direction>_route.json.
+
+    Companion file to the vehicle-positions geojson. Points only: the geojson
+    integration reads nothing else, and since the import strips shapes.txt a
+    LineString could only duplicate the stops; a map card rebuilds the path by
+    joining the points in stop_sequence order. Each point carries an id and a
+    title the way the geojson integration expects, plus the trip_id; what
+    describes the whole journey sits on the FeatureCollection.
+    Rewritten only when the drawn trip changes (see coordinator).
+    """
+    schedule = self._data["schedule"]
+    departure = self._data.get("next_departure") or {}
+    trip_id = departure.get("trip_id", None)
+    route_id = departure.get("route_id", None)
+    direction = str(departure.get("trip_direction_id", ""))
+    if not trip_id or not route_id:
+        return
+    sql_stops = """
+    SELECT st.stop_id, s.stop_name, s.stop_lat, s.stop_lon, st.stop_sequence, st.departure_time
+    FROM stop_times st
+    JOIN stops s ON s.stop_id = st.stop_id
+    WHERE st.trip_id = :trip_id
+    ORDER BY st.stop_sequence
+    """
+    with schedule.engine.connect() as conn:
+        stop_rows = conn.execute(text(sql_stops), {"trip_id": trip_id}).fetchall()
+    if not stop_rows:
+        _LOGGER.debug("No stops found for trip: %s", trip_id)
+        return
+    features = []
+    for row in stop_rows:
+        features.append({
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [row[3], row[2]]},
+            "properties": {
+                "id": str(route_id) + "_" + direction + "_" + str(row[4]),
+                "title": row[1],
+                "trip_id": trip_id,
+                "stop_id": row[0],
+                "stop_name": row[1],
+                "stop_sequence": row[4],
+                "departure_time": _fmt_gtfs_time(row[5]),
+            },
+        })
+    geojson_dir = self.hass.config.path(DEFAULT_PATH_GEOJSON)
+    os.makedirs(geojson_dir, exist_ok=True)
+    file = os.path.join(geojson_dir, str(route_id) + "_" + direction + "_route.json")
+    _LOGGER.debug("Creating route geojson file: %s", file)
+    with open(file, "w") as outfile:
+        json.dump({
+            "type": "FeatureCollection",
+            "properties": {
+                "trip_id": trip_id,
+                "route_id": str(route_id),
+                "direction_id": direction,
+            },
+            "features": features,
+        }, outfile)
     
 def get_local_stop_list(hass, schedule, data):
     _LOGGER.debug("Getting local stops list with data: %s", data)

--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -24,7 +24,6 @@ from homeassistant.helpers import entity_registry as er
 
 from .const import (
     DEFAULT_PATH_GEOJSON,
-    safe_file_part,
     CONF_API_KEY,
     CONF_API_KEY_LOCATION,
     CONF_API_KEY_NAME,
@@ -39,7 +38,7 @@ from .const import (
     DOMAIN,
     TIME_STR_FORMAT
     )
-from .gtfs_rt_helper import get_rt_route_trip_statuses, get_gtfs_rt
+from .gtfs_rt_helper import get_rt_route_trip_statuses, get_gtfs_rt, safe_file_part
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/gtfs2/gtfs_rt_helper.py
+++ b/custom_components/gtfs2/gtfs_rt_helper.py
@@ -55,7 +55,8 @@ from .const import (
     DEFAULT_PATH,
     DEFAULT_PATH_GEOJSON,
 
-    TIME_STR_FORMAT
+    TIME_STR_FORMAT,
+    safe_file_part,
 )
 
 def due_in_minutes(timestamp):
@@ -357,7 +358,8 @@ def get_rt_vehicle_positions(self):
     self.geojson = {"features": geojson_body, "type": "FeatureCollection"}
         
     _LOGGER.debug("Vehicle geojson: %s", json.dumps(self.geojson))
-    self._route_dir = str(self._route_id) + "_" + str(self._direction)
+    # named the same way as the route file next to it, see safe_file_part
+    self._route_dir = safe_file_part(self._route_id) + "_" + safe_file_part(self._direction)
     update_geojson(self)
     return geojson_body
     

--- a/custom_components/gtfs2/gtfs_rt_helper.py
+++ b/custom_components/gtfs2/gtfs_rt_helper.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import datetime, timedelta
 import json
 import os
@@ -55,9 +56,27 @@ from .const import (
     DEFAULT_PATH,
     DEFAULT_PATH_GEOJSON,
 
-    TIME_STR_FORMAT,
-    safe_file_part,
+    TIME_STR_FORMAT
 )
+
+_UNSAFE_FILE_PART = re.compile(r"[^a-z0-9._-]+")
+
+
+def safe_file_part(value) -> str:
+    """A route or direction id, made safe to put in a file name.
+
+    Both geojson files are named after ids that come out of the datasource,
+    that is to say out of a url the user pasted: an id like ZOP:653 makes a
+    file no Windows share can read, a percent sign has to be escaped in the
+    /local/ url that serves the file, and an id carrying a slash writes into
+    a directory that does not exist and loses the file to an OSError.
+
+    Rather than list the separators a feed may bring, keep letters, digits,
+    dot, dash and underscore, replace every run of the rest with a single
+    underscore and lowercase, so one route always lands on one file.
+    """
+    return re.sub(r"\.\.+", "_", _UNSAFE_FILE_PART.sub("_", str(value).lower()))
+
 
 def due_in_minutes(timestamp):
     """Get the remaining minutes from now until a given (aware, UTC) datetime object."""


### PR DESCRIPTION
## What

`get_rt_vehicle_positions` already writes the line's realtime vehicle positions to `www/gtfs2/<route>_<direction>.json`, which map cards can consume. But nothing exposes the **planned journey**, so a card can show where the vehicles are, never where they are going.

This PR writes a companion file, `www/gtfs2/<route>_<direction>_route.json`: one `Point` per stop of the journey the sensor follows, ordered by `stop_sequence`. Each point carries:

- `id` (`<route>_<direction>_<stop_sequence>`) and `title` (the stop name), so the geojson integration can consume the file as is;
- `stop_id`, `stop_name`, `stop_sequence`, the scheduled `departure_time` (rendered `HH:MM:SS`, times past 24:00 supported) and the `trip_id`.

The `FeatureCollection` itself carries `trip_id`, `route_id` and `direction_id`.

Points only, no `LineString`: the geojson integration cannot read one, and since the import strips `shapes.txt` a `LineString` could only duplicate the stop coordinates. A map card rebuilds the path by joining the points in `stop_sequence` order.

## File name

Both files share a base name, `<route>_<direction>`, built from ids that come out of the datasource: everything outside letters, digits, dot, dash and underscore becomes a single underscore and the name is lowercased, so `ZOP:653` direction 0 writes `zop_653_0_route.json` next to `zop_653_0.json`. That also covers an id carrying a slash, which used to write into a directory that does not exist and lose the file to an `OSError`. Files written under the previous names stay on disk and have to be removed once by hand.

The point `id` keeps the raw `route_id`: it is an entity id rather than a file name, and changing it would replace every marker in the registry.

## How

- Written from the **static refresh**, so it needs no realtime configuration at all: an entry without any RT url still gets its journey exported.
- Keyed on the drawn trip: the file is only rewritten when the trip changes, not on every refresh.
- Any failure is logged and never breaks the refresh.

## Consumer

The file is read directly (a simple fetch of `/local/gtfs2/<route>_<direction>_route.json`) by a map card I am building; I sent you an invite to its repository. Through the geojson integration the points also work as `geo_location` entities, each named after its stop.

## Verification

This standalone version is compile-checked; its equivalent has been running on a live TAO Orléans install since 2026-08-19 (bus and tram lines, both directions), and the points-only format is rendered by the card on real data.

