### PR TITLE
Fix issue with rt data when sensors going unavailable after the last departure of the day

### DIFF
--- a/custom_components/gtfs2/coordinator.py
+++ b/custom_components/gtfs2/coordinator.py
@@ -127,11 +127,7 @@ class GTFSUpdateCoordinator(DataUpdateCoordinator):
         if "real_time" in options:
             if options["real_time"]:
                 if not self._data.get("next_departure"):
-                    # after the last departure of the day (without include_tomorrow)
-                    # get_next_departure returns {}: skip the realtime block instead
-                    # of crashing on its fields (KeyError: origin_stop_sequence),
-                    # which marked the update failed and took every entity of this
-                    # config entry to unavailable until the next morning
+                    # when there are no more departures, skip the realtime block
                     _LOGGER.debug("GTFS RT: no next departure for this entry, skipping realtime update")
                     return self._data
                 self._get_next_service = {}

--- a/custom_components/gtfs2/coordinator.py
+++ b/custom_components/gtfs2/coordinator.py
@@ -126,6 +126,14 @@ class GTFSUpdateCoordinator(DataUpdateCoordinator):
         # STILL REQUIRES A SOLUTION IF CONNECTION TIMING OUT
         if "real_time" in options:
             if options["real_time"]:
+                if not self._data.get("next_departure"):
+                    # after the last departure of the day (without include_tomorrow)
+                    # get_next_departure returns {}: skip the realtime block instead
+                    # of crashing on its fields (KeyError: origin_stop_sequence),
+                    # which marked the update failed and took every entity of this
+                    # config entry to unavailable until the next morning
+                    _LOGGER.debug("GTFS RT: no next departure for this entry, skipping realtime update")
+                    return self._data
                 self._get_next_service = {}
                 """Initialize the info object."""
                 self._route_delimiter = None


### PR DESCRIPTION
## Symptom

Observed live (TAO Orléans, line 40, realtime enabled, `include_tomorrow` off): the day's last bus departs at 21:17, and at the next coordinator refresh the whole config entry dies —

```
KeyError: 'origin_stop_sequence'
```

The update is marked failed by the `DataUpdateCoordinator`, and **every entity of the entry turns `unavailable` until the next morning** (4 static attributes left, versus ~99 on a healthy sensor). Side effect: the vehicle-positions geojson stops being rewritten, so map consumers keep displaying the last buses of the evening as frozen ghosts all night.

## Cause

- `get_next_departure()` builds yesterday+today's timetable (tomorrow only with `include_tomorrow`) and, after the last departure, finds nothing → returns `{}` (gtfs_helper.py:343).
- With realtime enabled, the coordinator then reads `self._data["next_departure"]["origin_stop_sequence"]` with a **direct access** (coordinator.py:152), while the neighbouring lines use `.get(...)`. `{}` → `KeyError`.
- The exception fires **before** the realtime feed is ever queried, so this is not "no realtime because no bus" — the sensor dies on the way there.

## Fix

Guard the realtime block: when `next_departure` is empty, skip it with a debug log and return the data as-is. The sensors stay **available** with an empty departure list — same behaviour as a realtime-disabled entry after end of service — and recover by themselves at the first departure of the next day.

Status: the failure chain was verified live (logs and entity states above); the one-line guard is compile-checked; deploying it on the same install for an overnight validation is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
