### PR TITLE
Give SQLite more time to wait when the database is busy

### DIFF
--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -564,7 +564,7 @@ def get_gtfs(hass, path, data, update=False):
             return
     
     (gtfs_root, _) = os.path.splitext(file)    
-    sqlite_file = f"{gtfs_root}.sqlite?check_same_thread=False"
+    sqlite_file = f"{gtfs_root}.sqlite?check_same_thread=False&timeout=60"
     joined_path = os.path.join(gtfs_dir, sqlite_file)  
 
     gtfs = pygtfs.Schedule(joined_path)


### PR DESCRIPTION
## The problem

When several GTFS entries start up at the same time, they all open the same
database at once. SQLite allows only one writer at a time, so the others have
to wait their turn.

The connection is opened without a `timeout` value, so SQLite uses its default
of 5 seconds. On a large database that is not enough. The entries give up with
`database is locked`, and because that happens during setup their sensors are
never created at all.

Seen on a 1.1 GB feed with 8 entries: 7 of the 8 failed to set up after a
restart, with errors arriving at almost exactly 5.0 second intervals.

```
06:50:26  Error writing route geojson: database is locked
06:50:51  Error while setting up gtfs2 platform for sensor: database is locked
```

## The change

One line: pass `timeout=60` in the connection string, next to the
`check_same_thread=False` that is already there.

```python
sqlite_file = f"{gtfs_root}.sqlite?check_same_thread=False&timeout=60"
```

Entries now wait their turn instead of giving up. When the database is not
busy, nothing changes: the timeout only applies while waiting for a lock.

## Verification

The SQLite dialect does forward `timeout` from the connection string, the same
way it already does for `check_same_thread` (SQLAlchemy 2.0.52):

```python
>>> d.create_connect_args(make_url("sqlite:///t.sqlite?check_same_thread=False&timeout=60"))
(['t.sqlite'], {'timeout': 60.0, 'check_same_thread': False})

>>> d.create_connect_args(make_url("sqlite:///t.sqlite?check_same_thread=False"))
(['t.sqlite'], {'check_same_thread': False})
```

It is picked up by the dialect's numeric-argument coercion, so it arrives at
the driver as a float, which is what `sqlite3.connect()` expects.

The behaviour was also confirmed end to end: holding an `EXCLUSIVE` lock on a
database for 8 seconds while a second connection tries to write.

```
without timeout (5s default)  -> fails after 7.0s: OperationalError: database is locked
with timeout=60               -> waits, then succeeds
```

That is the same failure the integration hit at startup.
