### PR TITLE
Report an error instead of returning no data when a refresh fails

### DIFF
--- a/custom_components/gtfs2/coordinator.py
+++ b/custom_components/gtfs2/coordinator.py
@@ -119,7 +119,7 @@ class GTFSUpdateCoordinator(DataUpdateCoordinator):
                 self._data["gtfs_updated_at"] = dt_util.utcnow().isoformat()
             except Exception as ex:  # pylint: disable=broad-except
                 _LOGGER.error("Error getting gtfs data from generic helper: %s", ex)
-                return None
+                raise UpdateFailed(f"Error in getting gtfs data: {ex}") from ex
             _LOGGER.debug("GTFS coordinator data from helper: %s", self._data["next_departure"]) 
         
         # collect and return rt attributes


### PR DESCRIPTION
## The problem

When fetching departures fails, `GTFSUpdateCoordinator._async_update_data`
logs the error and returns `None`:

```python
except Exception as ex:  # pylint: disable=broad-except
    _LOGGER.error("Error getting gtfs data from generic helper: %s", ex)
    return None
```

Home Assistant reads a returned value as a **successful** refresh. So a
failure is recorded as a refresh that simply contains nothing:

- the sensors are not marked unavailable, they just go blank
- the coordinator does not retry, because as far as it knows nothing failed
- during setup, `async_config_entry_first_refresh()` sees success, so Home
  Assistant does not schedule a retry either

The result is that a temporary problem becomes permanent. In my case the
database was briefly locked at startup; the entry stayed blank for over two
hours until I restarted, and nothing in the UI suggested anything was wrong.

## The change

Raise `UpdateFailed` instead of returning `None`:

```python
raise UpdateFailed(f"Error in getting gtfs data: {ex}") from ex
```

Home Assistant then knows the refresh failed: it marks the sensors
unavailable, retries on the normal schedule, and during setup it waits and
retries instead of giving up.

`UpdateFailed` is already imported in this file, and
`GTFSLocalStopUpdateCoordinator` already does exactly this a little further
down. This makes the two coordinators behave the same way.

## Note for review

The `except` clause is broad and I deliberately left it that way to keep the
change to a single line. It does mean genuine bugs now surface as failed
refreshes rather than silent blanks, which I think is the more useful
behaviour, but it is a visible change for anyone who had an entry quietly
failing until now.

Running on my own install since the startup failure described above; the
entry now recovers on its own instead of staying blank.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

