### PR TITLE
Dispose the previous schedule before opening the new one

### DIFF
--- a/custom_components/gtfs2/coordinator.py
+++ b/custom_components/gtfs2/coordinator.py
@@ -215,11 +215,21 @@ class GTFSLocalStopUpdateCoordinator(DataUpdateCoordinator):
         data = self.config_entry.data
         options = self.config_entry.options
         previous_data = {} if self.data is None else self.data.copy()
-        _LOGGER.debug("Previous data: %s", previous_data)  
+        _LOGGER.debug("Previous data: %s", previous_data)
+
+        # close the previous cycle's schedule before opening the new one, so
+        # the old db file handles are released here and not whenever the
+        # garbage collector gets to the abandoned engine
+        if self._pygtfs and hasattr(self._pygtfs, 'session'):
+            try:
+                self._pygtfs.session.close()
+                self._pygtfs.engine.dispose()
+            except Exception:
+                pass
 
         self._pygtfs = get_gtfs(
             self.hass, DEFAULT_PATH, data, False
-        )        
+        )
 
         self._data = {
             "schedule": self._pygtfs,
@@ -263,15 +273,8 @@ class GTFSLocalStopUpdateCoordinator(DataUpdateCoordinator):
                     self._headers[CONF_API_KEY] = options.get(CONF_API_KEY, None)
                     self._headers[CONF_ACCEPT_HEADER_PB] = options.get(CONF_ACCEPT_HEADER_PB, False)
                 #_LOGGER.debug("RT header: %s", self._headers)
-                
-        if self._pygtfs and hasattr(self._pygtfs, 'session'):
-            try:
-                self._pygtfs.session.close()
-                self._pygtfs.engine.dispose()
-            except Exception:
-                pass
 
-        try:    
+        try:
             self._data["local_stops_next_departures"] = await self.hass.async_add_executor_job(
                     get_local_stops_next_departures, self
                 )

--- a/custom_components/gtfs2/coordinator.py
+++ b/custom_components/gtfs2/coordinator.py
@@ -217,9 +217,6 @@ class GTFSLocalStopUpdateCoordinator(DataUpdateCoordinator):
         previous_data = {} if self.data is None else self.data.copy()
         _LOGGER.debug("Previous data: %s", previous_data)
 
-        # close the previous cycle's schedule before opening the new one, so
-        # the old db file handles are released here and not whenever the
-        # garbage collector gets to the abandoned engine
         if self._pygtfs and hasattr(self._pygtfs, 'session'):
             try:
                 self._pygtfs.session.close()


### PR DESCRIPTION
Small follow-up to this morning's 4883da5. Moving get_gtfs to the top of the local stop coordinator refresh left the dispose block halfway down the method, where it now closes the engine that was just created, while the previous cycle's engine is only released whenever the garbage collector gets to it. Since get_gtfs builds a new Schedule on every call, moving the dispose above get_gtfs gives it back its original target, the previous cycle's schedule, and the db file handles are released at a known point again.

No behaviour change otherwise: disposing the fresh engine was harmless (connections reopen on use), this just restores the explicit release order the code had before.
