### PR TITLE
Only convert direction_id when the realtime feed actually sets it

### DIFF
--- a/custom_components/gtfs2/gtfs_rt_helper.py
+++ b/custom_components/gtfs2/gtfs_rt_helper.py
@@ -577,11 +577,15 @@ def convert_gtfs_realtime_to_json(gtfs_realtime_data):
                     "start_time": entity.trip_update.trip.start_time,
                     "start_date": entity.trip_update.trip.start_date,
                     "route_id": entity.trip_update.trip.route_id,
-                    "direction_id": str(entity.trip_update.trip.direction_id)
                 },
                 "stop_time_update": []
             }
         }
+        # direction_id is optional and protobuf returns 0 when a feed omits
+        # it, which reads as a genuine direction and mislabels every untagged
+        # trip; leave the key out instead so the reader falls back to "nn"
+        if entity.trip_update.trip.HasField("direction_id"):
+            entity_dict["trip_update"]["trip"]["direction_id"] = str(entity.trip_update.trip.direction_id)
         for stop_time_update in entity.trip_update.stop_time_update:
             stop_time_update_dict = {
                 "stop_sequence": stop_time_update.stop_sequence,


### PR DESCRIPTION
direction_id is optional in the GTFS-RT spec and protobuf hands back the default value 0 when a feed leaves it out (the SNCF and TTC feeds do). convert_gtfs_realtime_to_json wrote that 0 into every converted trip, so every untagged trip came out labeled direction 0 and the reader's fallback for an absent direction ("nn") was unreachable. The key is now written only when the field is explicitly set; the reader already handles its absence. The SIRI path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)