### PR TITLE
Give a local stop sensor only its own stop's departures

### DIFF
--- a/custom_components/gtfs2/sensor.py
+++ b/custom_components/gtfs2/sensor.py
@@ -556,7 +556,10 @@ class GTFSLocalStopSensor(CoordinatorEntity, SensorEntity):
         self._attributes["next_departures_lines"] = {}
         if self._departure:
             for stop in self._departure:
-                if self._name.startswith(stop["stop_id"]):
+                # matched on the id itself, not on the sensor name: the name
+                # starts with the stop_id, so a prefix test also claimed the
+                # departures of any stop whose id is a prefix of this one
+                if stop["stop_id"] == self._stop["stop_id"]:
                     self._attributes["next_departures_lines"] = stop["departure"]
                     self._attributes["latitude"] = stop["latitude"]  
                     self._attributes["longitude"] = stop["longitude"]  

--- a/custom_components/gtfs2/sensor.py
+++ b/custom_components/gtfs2/sensor.py
@@ -556,9 +556,6 @@ class GTFSLocalStopSensor(CoordinatorEntity, SensorEntity):
         self._attributes["next_departures_lines"] = {}
         if self._departure:
             for stop in self._departure:
-                # matched on the id itself, not on the sensor name: the name
-                # starts with the stop_id, so a prefix test also claimed the
-                # departures of any stop whose id is a prefix of this one
                 if stop["stop_id"] == self._stop["stop_id"]:
                     self._attributes["next_departures_lines"] = stop["departure"]
                     self._attributes["latitude"] = stop["latitude"]  


### PR DESCRIPTION
A local stop sensor picks its rows out of the coordinator data with a startswith on the sensor name. The name begins with the stop_id, so a sensor whose stop_id has another stop's id as a prefix also claimed that stop's departures (a sensor for stop 10001 matched stop 1000 too, and the last match won). It now compares the stop_id itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)