### PR TITLE
Fix the NameError at the end of get_trip_stops

### DIFF
--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -1553,5 +1553,5 @@ async def get_trip_stops(hass, data):
     }
     
     _LOGGER.debug("Tripstops returned: %s", _tripstops)
-    _pygtfs.engine.dispose()
+    schedule.engine.dispose()
     return _tripstops       


### PR DESCRIPTION
get_trip_stops opens its db handle under the name schedule, but the line before the return disposes _pygtfs, a name that only exists in get_route_departures, so every extract_trip_stops service call raises NameError just before returning its result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)