### PR TITLE
Fill the keys the translations were missing

### DIFF
--- a/custom_components/gtfs2/translations/de.json
+++ b/custom_components/gtfs2/translations/de.json
@@ -96,7 +96,6 @@
       "stop_incorrect": "Start- und/oder Endziel falsch, möglicherweise kein Transport ‚heute‘ oder nicht in die gleiche Richtung, Protokolle prüfen",
       "generic_failure": "Gesamtfehler, Protokolle prüfen",
       "no_data_file": "Problem bei der Datenerfassung: URL falsch oder Dateiname nicht im richtigen Ordner",
-	  "stop_limit_reached": "Es wurde eine hohe Anzahl von Stopps für diesen Umkreis festgestellt. \n Es besteht die Gefahr einer Beeinträchtigung der Systemleistung. \n Sie können die Limite auf eigenes Risiko ändern, bevor Sie den Umkreis ändern",
       "no_zip_file": "Problem bei der Datenerfassung: ZIP-Datei nicht im richtigen Ordner"
     },
     "abort": {
@@ -121,7 +120,9 @@
           "real_time": "Echtzeitintegration einrichten? \n (benötigt Daten aus derselben Quelle)",
           "local_stop_refresh_interval": "Datenaktualisierungsintervall (in Minuten)",
           "timerange": "Prüfung auf zukünftige Abfahrten ab ‚jetzt‘ (in Minuten: zwischen 15 und 120)",
-          "radius": "Radius für die Suche nach Haltestellen (in Metern zwischen 50 und 500)"
+          "radius": "Radius für die Suche nach Haltestellen (in Metern zwischen 50 und 500)",
+          "source_timezone_correction": "Zeitzone der GTFS-Quelle korrigieren (in Stunden)",
+          "check_source_dates": "experimentell: vermeiden, ein neues ZIP bzw. eine Quelle ohne aktuelle Informationen zu verwenden"
         }
       },
       "real_time": {
@@ -159,6 +160,13 @@
         "2": "Züge, zwischen manuell eingegebene Städte (nächsten Bildschirm)",
         "99": "Alle, außer Züge, zwischen ausgewählte Haltestellen (nächsten Bildschirm)"
       }
+    },
+    "api_key_location": {
+      "options": {
+        "not_applicable": "kein Schlüssel verwendet (Standard)",
+        "header": "header: den Aufruf mit Header/Schlüssel aufbauen",
+        "query_string": "query-string: den Aufruf mit Query/Schlüssel aufbauen"
+      }
     }
   },
   "services": {
@@ -195,6 +203,34 @@
         "url": {
           "name": "URL",
           "description": "Geben Sie den vollständigen Pfad zu den Echtzeitdaten an."
+        },
+        "api_key": {
+          "name": "api_schlüssel",
+          "description": "API-Schlüssel angeben, falls erforderlich"
+        },
+        "api_key_name": {
+          "name": "api_schlüssel_name",
+          "description": "Name des API-Schlüssels, Standard ist api_key"
+        },
+        "api_key_location": {
+          "name": "api_schlüssel_ort",
+          "description": "Ort des Schlüssels auswählen"
+        },
+        "accept": {
+          "name": "Accept",
+          "description": "application/protobuf zum Header hinzufügen"
+        },
+        "rt_type": {
+          "name": "Art der Echtzeitdaten angeben",
+          "description": "Art der Echtzeitdaten der Quelle auswählen"
+        },
+        "entity_for_siri": {
+          "name": "SIRI-RT-Linie",
+          "description": "Experimentell: nur Echtzeit im SIRI-Format (!) wählen Sie Ihre Konfiguration. siehe Dokumentation > Dienst"
+        },
+        "debug_output": {
+          "name": "debug_ausgabe",
+          "description": "In eine lesbare lokale Datei speichern"
         }
       }
     },

--- a/custom_components/gtfs2/translations/es.json
+++ b/custom_components/gtfs2/translations/es.json
@@ -120,7 +120,9 @@
 		  "real_time": "¿Integración en tiempo real? \n (necesita datos de la misma fuente)",
 		  "local_stop_refresh_interval": "Intervalo de actualización de datos (en minutos)",
           "timerange": "Comprobación de salidas en el futuro a partir de 'ahora' (en minutos: entre 15 y 120)",
-		  "radius": "Radio de búsqueda de paradas (en metros entre 50 y 500)"
+		  "radius": "Radio de búsqueda de paradas (en metros entre 50 y 500)",
+          "source_timezone_correction": "Corregir la zona horaria de la fuente gtfs (en horas)",
+          "check_source_dates": "experimental: evitar usar un nuevo zip/fuente que no contenga información actual"
         }
       },
 	  "real_time": {
@@ -158,6 +160,13 @@
 		"99": "Todos menos los trenes, entre las paradas seleccionadas (pantalla siguiente)",
 		"2": "Sólo trenes, entre ciudades introducidas manualmente (pantalla siguiente)"
       }
+    },
+    "api_key_location": {
+      "options": {
+        "not_applicable": "no se usa clave (por defecto)",
+        "header": "header: construir la llamada con cabecera/clave",
+        "query_string": "query-string: construir la llamada con consulta/clave"
+      }
     }
   },
   "services": {
@@ -194,7 +203,35 @@
 		"url": {
           "name": "URL",
 		  "description": "Proporcione la ruta completa a los datos en tiempo real"
-		}
+		},
+        "api_key": {
+          "name": "clave_api",
+          "description": "proporcione la clave API si es necesario"
+        },
+        "api_key_name": {
+          "name": "nombre_clave_api",
+          "description": "Nombre de la clave API, por defecto api_key"
+        },
+        "api_key_location": {
+          "name": "ubicación_clave_api",
+          "description": "Seleccione la ubicación de la clave"
+        },
+        "accept": {
+          "name": "Aceptar",
+          "description": "Añadir application/protobuf a la cabecera"
+        },
+        "rt_type": {
+          "name": "Indique el tipo de datos en tiempo real",
+          "description": "Seleccione el tipo de datos en tiempo real de la fuente"
+        },
+        "entity_for_siri": {
+          "name": "Ruta RT SIRI",
+          "description": "Experimental: solo tiempo real en formato SIRI (!) seleccione su configuración. ver documentación > servicio"
+        },
+        "debug_output": {
+          "name": "salida_depuración",
+          "description": "Guardar en un archivo local, en formato legible"
+        }
 	  }
 	},
 	"update_gtfs_local_stops": {

--- a/custom_components/gtfs2/translations/fr.json
+++ b/custom_components/gtfs2/translations/fr.json
@@ -77,7 +77,8 @@
           "origin": "Ville de départ",
           "destination": "Ville d'arrivée",
           "name": "Nom de la ligne",
-          "include_tomorrow": "Inclure le lendemain?"
+          "include_tomorrow": "Inclure le lendemain?",
+          "refresh_interval": "Intervalle de rafraîchissement en minutes"
         },
 		"description": "Sélectionnez parmi les options [(docu)]({docu_setup_train})"
       },	  
@@ -119,7 +120,9 @@
 		  "real_time": "Ajoute intégration temps réel? \n (nécessite données de la même source)",
 		  "local_stop_refresh_interval": "Intervalle d'actualisation en minutes",
           "timerange": "Période dans la future pour départs depuis 'maintenant' (en minutes entre 15 et 120)",
-		  "radius": "Radius pour la recherche des stops (en metres entre 50 et 500)"
+		  "radius": "Radius pour la recherche des stops (en metres entre 50 et 500)",
+          "source_timezone_correction": "Corriger le fuseau horaire de la source gtfs (en heures)",
+          "check_source_dates": "expérimental : éviter d'utiliser un nouveau zip/source ne contenant aucune information actuelle"
         }
       },
 	  "real_time": {
@@ -130,7 +133,8 @@
 		  "api_key": "API_KEY, si nécessaire",
 		  "api_key_name": "Nom de API_KEY, si nécessaire",  
 		  "api_key_location": "L'endroit ou (X_)API_KEY doit être appliqué",
-		  "accept": "Ajoutez Accept:application/x-protobuf à l'en-tête"
+		  "accept": "Ajoutez Accept:application/x-protobuf à l'en-tête",
+          "alerts_url": "URL vers les alertes"
         }
       }
     },
@@ -155,6 +159,13 @@
       "options": {
 		"2": "Voyages ferroviaires, entre villes manuellement définiés (prochain écran)",
 		"99": "Tout à part des ferroviaires, entre stops sélectionnés (prochain écran)"
+      }
+    },
+    "api_key_location": {
+      "options": {
+        "not_applicable": "aucune clé utilisée (par défaut)",
+        "header": "header : construire l'appel avec en-tête/clé",
+        "query_string": "query-string : construire l'appel avec requête/clé"
       }
     }
   },
@@ -192,7 +203,35 @@
 		"url": {
           "name": "URL",
 		  "description": "URL externe vers les données GTFS temp réels"
-		}
+		},
+        "api_key": {
+          "name": "clé_api",
+          "description": "fournissez la clé API si nécessaire"
+        },
+        "api_key_name": {
+          "name": "nom_clé_api",
+          "description": "Nom de la clé API, api_key par défaut"
+        },
+        "api_key_location": {
+          "name": "emplacement_clé_api",
+          "description": "Sélectionnez l'emplacement de la clé"
+        },
+        "accept": {
+          "name": "Accept",
+          "description": "Ajouter application/protobuf à l'en-tête"
+        },
+        "rt_type": {
+          "name": "Indiquez le type de données temps réel",
+          "description": "Sélectionnez le type de données temps réel de la source"
+        },
+        "entity_for_siri": {
+          "name": "Ligne RT SIRI",
+          "description": "Expérimental : temps réel au format SIRI uniquement (!) sélectionnez votre configuration. voir documentation > service"
+        },
+        "debug_output": {
+          "name": "sortie_debug",
+          "description": "Enregistrer dans un fichier local, en format lisible"
+        }
 	  }
 	},
 	"update_gtfs_local_stops": {

--- a/custom_components/gtfs2/translations/pt.json
+++ b/custom_components/gtfs2/translations/pt.json
@@ -96,7 +96,6 @@
       "stop_incorrect": "Paragem de início e/ou de fim incorreta, possivelmente sem transporte 'hoje' ou não na mesma direção, verifique os logs",
       "generic_failure": "Falha geral, verifique os logs",
       "no_data_file": "Problema de recolha de dados: URL incorreta ou nome do ficheiro não está na pasta correta",
-	  "stop_limit_reached": "Mais de 15 paragens encontradas para este raio. \n Risco de impacto no desempenho do sistema. \n Por favor, selecione um raio menor",
 	  "no_zip_file": "Problema de recolha de dados: Ficheiro ZIP não está na pasta correta"
     },
     "abort": {
@@ -122,7 +121,8 @@
 		  "local_stop_refresh_interval": "Intervalo de atualização de dados (em minutos)",
           "timerange": "Verificação de partidas no futuro a partir de 'agora' (em minutos: entre 15 e 120)",
 		  "check_source_dates": "experimental: evitar usar uma nova zip/fonte contendo informações desatualizadas",
-		  "radius": "Raio para procurar paragens (em metros entre 50 e 500)"
+		  "radius": "Raio para procurar paragens (em metros entre 50 e 500)",
+          "source_timezone_correction": "Corrigir o fuso horário da fonte gtfs (em horas)"
         }
       },
 	  "real_time": {
@@ -223,6 +223,14 @@
         "debug_output": {
           "name": "output_debug",
           "description": "Guardar em ficheiro local num formato legível"
+        },
+        "rt_type": {
+          "name": "Indique o tipo de dados em tempo real",
+          "description": "Selecione o tipo de dados em tempo real da fonte"
+        },
+        "entity_for_siri": {
+          "name": "Rota RT SIRI",
+          "description": "Experimental: apenas tempo real em formato SIRI (!) selecione a sua configuração. ver documentação > serviço"
         }
       }
     },


### PR DESCRIPTION
The four translated languages had drifted from `strings.json`: 21 keys missing in French, 19 in German, 19 in Spanish, 5 in Portuguese. German and Portuguese also still carried `stop_limit_reached`, which strings no longer declares. Home Assistant falls back to English for a missing key, so those fields showed English inside an otherwise translated flow.

Most of the gap is the `update_gtfs_rt_local` service fields and the `api_key_location` selector, which had never been translated outside Portuguese, plus `source_timezone_correction` and `check_source_dates` on the options screen.

I translated your English, and followed the wording each language already uses rather than imposing my own. Portuguese was the model for the service fields, being the only language that had them. No code, no behaviour change, no existing string touched: additions only, plus the two stale keys removed. Nothing is reformatted, so the diff is only the new lines.

If it helps, I am happy to keep the five files in step whenever a screen changes, rather than leaving them to drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)