### PR TITLE
Import ConfigEntryNotReady in __init__.py

### DIFF
--- a/custom_components/gtfs2/__init__.py
+++ b/custom_components/gtfs2/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from datetime import timedelta
 


### PR DESCRIPTION
`async_setup_entry` raises `ConfigEntryNotReady` when the coordinator reports a failed update, but the name is never imported. Nothing shows today because `last_update_success` starts at True, so the branch never runs. The day a first refresh happens before the platforms are forwarded, which is what #184 asks for, the raise would come out as a NameError and the entry would fail instead of retrying. One import line, found by a script that lists the names a module uses without defining or importing them.
