### PR TITLE
Provider tree: say what was asked and what answered, write results.txt and results.json

### DIFF
--- a/tests_provider/conftest.py
+++ b/tests_provider/conftest.py
@@ -1,9 +1,23 @@
-"""Bootstrap for the provider tree: the Home Assistant stand-ins of
-tests/ha_stub.py, registered before any test module is imported.
+"""Bootstrap for the provider tree, and the two results files.
 
-tests/ is put on sys.path for that one import, so the two trees share a
-single stub and a single answer to "what does the integration read off
-Home Assistant". Nothing else of tests/ is read from here.
+The Home Assistant stand-ins of tests/ha_stub.py are registered before
+any test module is imported. tests/ is put on sys.path for that one
+import, so the two trees share a single stub and a single answer to "what
+does the integration read off Home Assistant". Nothing else of tests/ is
+read from here.
+
+At the end of a session the records each case handed over through
+record_property are written next to this file, the way tests/ writes its
+own results.txt:
+
+    results.txt   one entry per case with its outcome, and for a case that
+                  did not pass the lines that broke the promise; to read
+    results.json  every check of every case, passed or not, as fields with
+                  the keys sorted; to diff between two checkouts or load
+                  into a tool. Written by a plain full run only, so a -k
+                  or --runxfail run does not overwrite a full one
+
+Both files in the repo are the run on main, as examples of the output.
 """
 from __future__ import annotations
 
@@ -15,3 +29,77 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tests"))
 import ha_stub  # noqa: E402
 
 ha_stub.install()
+
+
+import json  # noqa: E402
+
+HERE = Path(__file__).resolve().parent
+_reports = []
+
+
+def pytest_runtest_logreport(report):
+    if "test_journeys.py::" not in report.nodeid:
+        return
+    if report.when == "call" or (report.when == "setup" and report.failed):
+        _reports.append(report)
+
+
+def _outcome(report):
+    if report.when == "setup":
+        return "error"
+    if hasattr(report, "wasxfail"):
+        return "xfailed" if report.skipped else "xpassed"
+    if report.failed and str(report.longrepr).startswith("[XPASS(strict)]"):
+        return "xpassed"
+    return report.outcome
+
+
+def _reason(report):
+    if hasattr(report, "wasxfail"):
+        return report.wasxfail
+    text = str(report.longrepr)
+    if text.startswith("[XPASS(strict)]"):
+        return text[len("[XPASS(strict)]"):].strip()
+    return None
+
+
+def _cases():
+    cases = []
+    for report in _reports:
+        props = dict(report.user_properties)
+        case = {"id": report.nodeid.split("[", 1)[-1].rstrip("]"),
+                "outcome": _outcome(report), "reason": _reason(report),
+                "checks": props.get("checks", [])}
+        case.update(props.get("case", {}))
+        if not case["checks"] and report.longrepr is not None:
+            case["error"] = [line[2:].strip() for line in
+                             str(report.longrepr).splitlines()
+                             if line.startswith("E ")] or [str(report.longrepr)]
+        cases.append(case)
+    return sorted(cases, key=lambda c: c["id"])
+
+
+def pytest_sessionfinish(session, exitstatus):  # noqa: ARG001
+    if not _reports:
+        return
+    cases = _cases()
+    lines = [f"test_journeys.py case results -- {len(cases)} case(s)", ""]
+    for case in cases:
+        lines += [f"case: {case['id']}", f"  result: {case['outcome'].upper()}"]
+        if case["reason"]:
+            lines.append(f"  reason: {case['reason']}")
+        broke = [c["text"] for c in case["checks"] if not c["ok"]]
+        broke += case.get("error", [])
+        if broke:
+            lines.append("  detail:")
+            lines += [f"    {text}" for text in broke]
+        lines.append("")
+    (HERE / "results.txt").write_text("\n".join(lines), encoding="utf-8")
+
+    option = session.config.option
+    partial = option.keyword or option.markexpr or option.runxfail
+    if partial or exitstatus == 2:  # a -k, -m or --runxfail run, or interrupted
+        return
+    (HERE / "results.json").write_text(
+        json.dumps({"cases": cases}, indent=2, sort_keys=True, ensure_ascii=False)
+        + "\n", encoding="utf-8")

--- a/tests_provider/instructions.txt
+++ b/tests_provider/instructions.txt
@@ -13,4 +13,44 @@ Install and run, from the component root:
 	pip install -r tests_provider/requirements.txt
 	pytest tests_provider/
 
+How a case is built:
+- the routes come from the fixture's manifest (routes_kept); for each one and
+  each direction_id its trips carry, the distinct stop sequences of those trips
+  are read from stop_times. That is the expected side: there is no expected
+  file, the feed itself says what the line rides
+- stop_list asks get_stop_list for the route and direction and checks the list
+  against every sequence: each stop once, in an order every trip agrees with
+- pairs and swapped take three pairs per sequence (the two ends, first stop to
+  middle, middle to last), pin the clock with freezegun at 00:05 in the agency's
+  zone on the first day one of those trips runs, and hand get_next_departure
+  the same data dict a sensor would
+- the answer is checked against the sequence: the asked stops (a platform of the
+  same station counts), origin before destination, arrival not before
+  departure. The swapped pair may answer nothing, or only a ride this direction
+  really makes
+- trains (route_type 2) are asked by stop name and line, the way the train
+  sensor does, and only pairs is checked: a swapped pair is the return journey
+
+Reading a failure:
+- a test id reads fixture-line-direction-promise: palmbus-A-d0-swapped is the
+  Palm Bus fixture, line A, direction 0, the swapped pair promise; a train line
+  carries the last characters of its route_id, P8(A594575:)
+- every run writes tests_provider/results.txt: one entry per
+  case, PASSED, XFAILED, XPASSED or FAILED, its reason when it carries a mark,
+  and for a case that did not pass the lines that broke the promise: what was
+  asked (origin -> destination, line, direction, where the two stops sit in
+  the ride) and what get_next_departure gave back (stops, line, direction and
+  trip it took them from), so the trip can be looked up in the fixture zip
+- a plain full run also writes tests_provider/results.json: the same records,
+  every check of every case whether it passed or not, as fields, keys sorted.
+  A run with -k, -m or --runxfail leaves the file alone
+- both files in the repo are the run on main, as examples of the output. Run
+  the suite on another branch and `git diff tests_provider/results.json` is
+  what that branch changed, pair by pair
+- for a spreadsheet, one line turns it into csv, one row per check:
+  python -c "import json, pandas as pd; pd.json_normalize(json.load(open('tests_provider/results.json'))['cases'], 'checks', ['id', 'outcome']).to_csv('results.csv', index=False)"
+- on screen, pytest -rx lists the marked cases with their reason, and
+  --runxfail prints the failing lines as well
+- pytest tests_provider/ -k "palmbus and A" narrows to one line
+
 Needs pygtfs, sqlalchemy and the protobuf bindings for real, which tests/ does not; that is why the tree, its requirements and its workflow are separate. tests/ha_stub.py is shared, nothing else is.

--- a/tests_provider/instructions.txt
+++ b/tests_provider/instructions.txt
@@ -41,6 +41,11 @@ Reading a failure:
   asked (origin -> destination, line, direction, where the two stops sit in
   the ride) and what get_next_departure gave back (stops, line, direction and
   trip it took them from), so the trip can be looked up in the fixture zip
+- a stop list failure names the stops it judged: a stop the selector
+  offers twice comes with the two sequence numbers it was offered at
+  (THEC0A Théoule Plages at 1 and 13), two records of one station offered
+  one after the other come as the pair, and a stop a trip serves but the
+  list leaves out comes with the ride it was found on
 - a plain full run also writes tests_provider/results.json: the same records,
   every check of every case whether it passed or not, as fields, keys sorted.
   A run with -k, -m or --runxfail leaves the file alone

--- a/tests_provider/results.json
+++ b/tests_provider/results.json
@@ -1,0 +1,14242 @@
+{
+  "cases": [
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3979810",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3979966",
+            "ride_length": 15,
+            "route": "152323",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "3979810",
+            "direction": 0,
+            "origin": "3979966",
+            "route": "152323",
+            "trip": "380877660"
+          },
+          "ok": true,
+          "text": "asked 3979966 -> 3979810 on 152323 d0 (stop 1 to stop 15 of a 15-stop ride): got 3979966 -> 3979810 on 152323 d0, trip 380877660"
+        },
+        {
+          "asked": {
+            "destination": "3979766",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3979966",
+            "ride_length": 15,
+            "route": "152323",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3979766",
+            "direction": 0,
+            "origin": "3979966",
+            "route": "152323",
+            "trip": "380877660"
+          },
+          "ok": true,
+          "text": "asked 3979966 -> 3979766 on 152323 d0 (stop 1 to stop 8 of a 15-stop ride): got 3979966 -> 3979766 on 152323 d0, trip 380877660"
+        },
+        {
+          "asked": {
+            "destination": "3979810",
+            "direction": 0,
+            "from_stop": 8,
+            "origin": "3979766",
+            "ride_length": 15,
+            "route": "152323",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "3979810",
+            "direction": 0,
+            "origin": "3979766",
+            "route": "152323",
+            "trip": "380877660"
+          },
+          "ok": true,
+          "text": "asked 3979766 -> 3979810 on 152323 d0 (stop 8 to stop 15 of a 15-stop ride): got 3979766 -> 3979810 on 152323 d0, trip 380877660"
+        },
+        {
+          "asked": {
+            "destination": "4015830",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980295",
+            "ride_length": 16,
+            "route": "152323",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "4015830",
+            "direction": 0,
+            "origin": "3980295",
+            "route": "152323",
+            "trip": "380816180"
+          },
+          "ok": true,
+          "text": "asked 3980295 -> 4015830 on 152323 d0 (stop 1 to stop 16 of a 16-stop ride): got 3980295 -> 4015830 on 152323 d0, trip 380816180"
+        },
+        {
+          "asked": {
+            "destination": "3980004",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980295",
+            "ride_length": 16,
+            "route": "152323",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "3980004",
+            "direction": 0,
+            "origin": "3980295",
+            "route": "152323",
+            "trip": "380816180"
+          },
+          "ok": true,
+          "text": "asked 3980295 -> 3980004 on 152323 d0 (stop 1 to stop 9 of a 16-stop ride): got 3980295 -> 3980004 on 152323 d0, trip 380816180"
+        },
+        {
+          "asked": {
+            "destination": "4015830",
+            "direction": 0,
+            "from_stop": 9,
+            "origin": "3980004",
+            "ride_length": 16,
+            "route": "152323",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "4015830",
+            "direction": 0,
+            "origin": "3980004",
+            "route": "152323",
+            "trip": "380816180"
+          },
+          "ok": true,
+          "text": "asked 3980004 -> 4015830 on 152323 d0 (stop 9 to stop 16 of a 16-stop ride): got 3980004 -> 4015830 on 152323 d0, trip 380816180"
+        },
+        {
+          "asked": {
+            "destination": "3979810",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981002",
+            "ride_length": 27,
+            "route": "152323",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "3979810",
+            "direction": 0,
+            "origin": "3981002",
+            "route": "152323",
+            "trip": "380877389"
+          },
+          "ok": true,
+          "text": "asked 3981002 -> 3979810 on 152323 d0 (stop 1 to stop 27 of a 27-stop ride): got 3981002 -> 3979810 on 152323 d0, trip 380877389"
+        },
+        {
+          "asked": {
+            "destination": "3980938",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981002",
+            "ride_length": 27,
+            "route": "152323",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "3980938",
+            "direction": 0,
+            "origin": "3981002",
+            "route": "152323",
+            "trip": "380877389"
+          },
+          "ok": true,
+          "text": "asked 3981002 -> 3980938 on 152323 d0 (stop 1 to stop 14 of a 27-stop ride): got 3981002 -> 3980938 on 152323 d0, trip 380877389"
+        },
+        {
+          "asked": {
+            "destination": "3979810",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "3980938",
+            "ride_length": 27,
+            "route": "152323",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "3979810",
+            "direction": 0,
+            "origin": "3980938",
+            "route": "152323",
+            "trip": "380877660"
+          },
+          "ok": true,
+          "text": "asked 3980938 -> 3979810 on 152323 d0 (stop 14 to stop 27 of a 27-stop ride): got 3980938 -> 3979810 on 152323 d0, trip 380877660"
+        },
+        {
+          "asked": {
+            "destination": "3979810",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981002",
+            "ride_length": 30,
+            "route": "152323",
+            "to_stop": 30
+          },
+          "got": {
+            "destination": "3979810",
+            "direction": 0,
+            "origin": "3981002",
+            "route": "152323",
+            "trip": "380832270"
+          },
+          "ok": true,
+          "text": "asked 3981002 -> 3979810 on 152323 d0 (stop 1 to stop 30 of a 30-stop ride): got 3981002 -> 3979810 on 152323 d0, trip 380832270"
+        },
+        {
+          "asked": {
+            "destination": "3980596",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981002",
+            "ride_length": 30,
+            "route": "152323",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3980596",
+            "direction": 0,
+            "origin": "3981002",
+            "route": "152323",
+            "trip": "380832270"
+          },
+          "ok": true,
+          "text": "asked 3981002 -> 3980596 on 152323 d0 (stop 1 to stop 16 of a 30-stop ride): got 3981002 -> 3980596 on 152323 d0, trip 380832270"
+        },
+        {
+          "asked": {
+            "destination": "3979810",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "3980596",
+            "ride_length": 30,
+            "route": "152323",
+            "to_stop": 30
+          },
+          "got": {
+            "destination": "3979810",
+            "direction": 0,
+            "origin": "3980596",
+            "route": "152323",
+            "trip": "380832270"
+          },
+          "ok": true,
+          "text": "asked 3980596 -> 3979810 on 152323 d0 (stop 16 to stop 30 of a 30-stop ride): got 3980596 -> 3979810 on 152323 d0, trip 380832270"
+        },
+        {
+          "asked": {
+            "destination": "3979810",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "4138837",
+            "ride_length": 12,
+            "route": "152323",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "3979810",
+            "direction": 0,
+            "origin": "4138837",
+            "route": "152323",
+            "trip": "380877097"
+          },
+          "ok": true,
+          "text": "asked 4138837 -> 3979810 on 152323 d0 (stop 1 to stop 12 of a 12-stop ride): got 4138837 -> 3979810 on 152323 d0, trip 380877097"
+        },
+        {
+          "asked": {
+            "destination": "3980814",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "4138837",
+            "ride_length": 12,
+            "route": "152323",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "3980814",
+            "direction": 0,
+            "origin": "4138837",
+            "route": "152323",
+            "trip": "380877097"
+          },
+          "ok": true,
+          "text": "asked 4138837 -> 3980814 on 152323 d0 (stop 1 to stop 7 of a 12-stop ride): got 4138837 -> 3980814 on 152323 d0, trip 380877097"
+        },
+        {
+          "asked": {
+            "destination": "3979810",
+            "direction": 0,
+            "from_stop": 7,
+            "origin": "3980814",
+            "ride_length": 12,
+            "route": "152323",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "3979810",
+            "direction": 0,
+            "origin": "3980814",
+            "route": "152323",
+            "trip": "380877097"
+          },
+          "ok": true,
+          "text": "asked 3980814 -> 3979810 on 152323 d0 (stop 7 to stop 12 of a 12-stop ride): got 3980814 -> 3979810 on 152323 d0, trip 380877097"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-1-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152323"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980295 .. 4015830"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3981002 .. 3979810"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 4138837 .. 3979810"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3981002 .. 3979810"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3979966 .. 3979810"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-1-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "route": "152323"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3979966",
+            "direction": 0,
+            "from_stop": 15,
+            "origin": "3979810",
+            "ride_length": 15,
+            "route": "152323",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979810 -> 3979966 on 152323 d0 (stop 15 to stop 1 of a 15-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979966",
+            "direction": 0,
+            "from_stop": 8,
+            "origin": "3979766",
+            "ride_length": 15,
+            "route": "152323",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979766 -> 3979966 on 152323 d0 (stop 8 to stop 1 of a 15-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979766",
+            "direction": 0,
+            "from_stop": 15,
+            "origin": "3979810",
+            "ride_length": 15,
+            "route": "152323",
+            "served": true,
+            "to_stop": 8
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979810 -> 3979766 on 152323 d0 (stop 15 to stop 8 of a 15-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980295",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "4015830",
+            "ride_length": 16,
+            "route": "152323",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 4015830 -> 3980295 on 152323 d0 (stop 16 to stop 1 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980295",
+            "direction": 0,
+            "from_stop": 9,
+            "origin": "3980004",
+            "ride_length": 16,
+            "route": "152323",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980004 -> 3980295 on 152323 d0 (stop 9 to stop 1 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980004",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "4015830",
+            "ride_length": 16,
+            "route": "152323",
+            "served": false,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 4015830 -> 3980004 on 152323 d0 (stop 16 to stop 9 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981002",
+            "direction": 0,
+            "from_stop": 27,
+            "origin": "3979810",
+            "ride_length": 27,
+            "route": "152323",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979810 -> 3981002 on 152323 d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981002",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "3980938",
+            "ride_length": 27,
+            "route": "152323",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980938 -> 3981002 on 152323 d0 (stop 14 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980938",
+            "direction": 0,
+            "from_stop": 27,
+            "origin": "3979810",
+            "ride_length": 27,
+            "route": "152323",
+            "served": true,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979810 -> 3980938 on 152323 d0 (stop 27 to stop 14 of a 27-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981002",
+            "direction": 0,
+            "from_stop": 30,
+            "origin": "3979810",
+            "ride_length": 30,
+            "route": "152323",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979810 -> 3981002 on 152323 d0 (stop 30 to stop 1 of a 30-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981002",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "3980596",
+            "ride_length": 30,
+            "route": "152323",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980596 -> 3981002 on 152323 d0 (stop 16 to stop 1 of a 30-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980596",
+            "direction": 0,
+            "from_stop": 30,
+            "origin": "3979810",
+            "ride_length": 30,
+            "route": "152323",
+            "served": false,
+            "to_stop": 16
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979810 -> 3980596 on 152323 d0 (stop 30 to stop 16 of a 30-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "4138837",
+            "direction": 0,
+            "from_stop": 12,
+            "origin": "3979810",
+            "ride_length": 12,
+            "route": "152323",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979810 -> 4138837 on 152323 d0 (stop 12 to stop 1 of a 12-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "4138837",
+            "direction": 0,
+            "from_stop": 7,
+            "origin": "3980814",
+            "ride_length": 12,
+            "route": "152323",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980814 -> 4138837 on 152323 d0 (stop 7 to stop 1 of a 12-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980814",
+            "direction": 0,
+            "from_stop": 12,
+            "origin": "3979810",
+            "ride_length": 12,
+            "route": "152323",
+            "served": true,
+            "to_stop": 7
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979810 -> 3980814 on 152323 d0 (stop 12 to stop 7 of a 12-stop ride): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-1-d0-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152323"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3980743",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3979725",
+            "ride_length": 12,
+            "route": "152323",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "3980743",
+            "direction": 1,
+            "origin": "3979725",
+            "route": "152323",
+            "trip": "380832451"
+          },
+          "ok": true,
+          "text": "asked 3979725 -> 3980743 on 152323 d1 (stop 1 to stop 12 of a 12-stop ride): got 3979725 -> 3980743 on 152323 d1, trip 380832451"
+        },
+        {
+          "asked": {
+            "destination": "3980204",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3979725",
+            "ride_length": 12,
+            "route": "152323",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "3980204",
+            "direction": 1,
+            "origin": "3979725",
+            "route": "152323",
+            "trip": "380832451"
+          },
+          "ok": true,
+          "text": "asked 3979725 -> 3980204 on 152323 d1 (stop 1 to stop 7 of a 12-stop ride): got 3979725 -> 3980204 on 152323 d1, trip 380832451"
+        },
+        {
+          "asked": {
+            "destination": "3980743",
+            "direction": 1,
+            "from_stop": 7,
+            "origin": "3980204",
+            "ride_length": 12,
+            "route": "152323",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "3980743",
+            "direction": 1,
+            "origin": "3980204",
+            "route": "152323",
+            "trip": "380832451"
+          },
+          "ok": true,
+          "text": "asked 3980204 -> 3980743 on 152323 d1 (stop 7 to stop 12 of a 12-stop ride): got 3980204 -> 3980743 on 152323 d1, trip 380832451"
+        },
+        {
+          "asked": {
+            "destination": "3979810",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3979966",
+            "ride_length": 15,
+            "route": "152323",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "3979810",
+            "direction": 1,
+            "origin": "3979966",
+            "route": "152323",
+            "trip": "380816281"
+          },
+          "ok": true,
+          "text": "asked 3979966 -> 3979810 on 152323 d1 (stop 1 to stop 15 of a 15-stop ride): got 3979966 -> 3979810 on 152323 d1, trip 380816281"
+        },
+        {
+          "asked": {
+            "destination": "3979766",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3979966",
+            "ride_length": 15,
+            "route": "152323",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3979766",
+            "direction": 1,
+            "origin": "3979966",
+            "route": "152323",
+            "trip": "380816281"
+          },
+          "ok": true,
+          "text": "asked 3979966 -> 3979766 on 152323 d1 (stop 1 to stop 8 of a 15-stop ride): got 3979966 -> 3979766 on 152323 d1, trip 380816281"
+        },
+        {
+          "asked": {
+            "destination": "3979810",
+            "direction": 1,
+            "from_stop": 8,
+            "origin": "3979766",
+            "ride_length": 15,
+            "route": "152323",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "3979810",
+            "direction": 1,
+            "origin": "3979766",
+            "route": "152323",
+            "trip": "380816281"
+          },
+          "ok": true,
+          "text": "asked 3979766 -> 3979810 on 152323 d1 (stop 8 to stop 15 of a 15-stop ride): got 3979766 -> 3979810 on 152323 d1, trip 380816281"
+        },
+        {
+          "asked": {
+            "destination": "3980743",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980295",
+            "ride_length": 30,
+            "route": "152323",
+            "to_stop": 30
+          },
+          "got": {
+            "destination": "3980743",
+            "direction": 1,
+            "origin": "3980295",
+            "route": "152323",
+            "trip": "380832271"
+          },
+          "ok": true,
+          "text": "asked 3980295 -> 3980743 on 152323 d1 (stop 1 to stop 30 of a 30-stop ride): got 3980295 -> 3980743 on 152323 d1, trip 380832271"
+        },
+        {
+          "asked": {
+            "destination": "3981140",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980295",
+            "ride_length": 30,
+            "route": "152323",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3981140",
+            "direction": 1,
+            "origin": "3980295",
+            "route": "152323",
+            "trip": "380832271"
+          },
+          "ok": true,
+          "text": "asked 3980295 -> 3981140 on 152323 d1 (stop 1 to stop 16 of a 30-stop ride): got 3980295 -> 3981140 on 152323 d1, trip 380832271"
+        },
+        {
+          "asked": {
+            "destination": "3980743",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "3981140",
+            "ride_length": 30,
+            "route": "152323",
+            "to_stop": 30
+          },
+          "got": {
+            "destination": "3980743",
+            "direction": 1,
+            "origin": "3981140",
+            "route": "152323",
+            "trip": "380832271"
+          },
+          "ok": true,
+          "text": "asked 3981140 -> 3980743 on 152323 d1 (stop 16 to stop 30 of a 30-stop ride): got 3981140 -> 3980743 on 152323 d1, trip 380832271"
+        },
+        {
+          "asked": {
+            "destination": "3980743",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980295",
+            "ride_length": 27,
+            "route": "152323",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "3980743",
+            "direction": 1,
+            "origin": "3980295",
+            "route": "152323",
+            "trip": "380877387"
+          },
+          "ok": true,
+          "text": "asked 3980295 -> 3980743 on 152323 d1 (stop 1 to stop 27 of a 27-stop ride): got 3980295 -> 3980743 on 152323 d1, trip 380877387"
+        },
+        {
+          "asked": {
+            "destination": "3981186",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980295",
+            "ride_length": 27,
+            "route": "152323",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "3981186",
+            "direction": 1,
+            "origin": "3980295",
+            "route": "152323",
+            "trip": "380877387"
+          },
+          "ok": true,
+          "text": "asked 3980295 -> 3981186 on 152323 d1 (stop 1 to stop 14 of a 27-stop ride): got 3980295 -> 3981186 on 152323 d1, trip 380877387"
+        },
+        {
+          "asked": {
+            "destination": "3980743",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "3981186",
+            "ride_length": 27,
+            "route": "152323",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "3980743",
+            "direction": 1,
+            "origin": "3981186",
+            "route": "152323",
+            "trip": "380877387"
+          },
+          "ok": true,
+          "text": "asked 3981186 -> 3980743 on 152323 d1 (stop 14 to stop 27 of a 27-stop ride): got 3981186 -> 3980743 on 152323 d1, trip 380877387"
+        },
+        {
+          "asked": {
+            "destination": "3979810",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "4132580",
+            "ride_length": 16,
+            "route": "152323",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3979810",
+            "direction": 1,
+            "origin": "4132580",
+            "route": "152323",
+            "trip": "380816081"
+          },
+          "ok": true,
+          "text": "asked 4132580 -> 3979810 on 152323 d1 (stop 1 to stop 16 of a 16-stop ride): got 4132580 -> 3979810 on 152323 d1, trip 380816081"
+        },
+        {
+          "asked": {
+            "destination": "3979766",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "4132580",
+            "ride_length": 16,
+            "route": "152323",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "3979766",
+            "direction": 1,
+            "origin": "4132580",
+            "route": "152323",
+            "trip": "380816081"
+          },
+          "ok": true,
+          "text": "asked 4132580 -> 3979766 on 152323 d1 (stop 1 to stop 9 of a 16-stop ride): got 4132580 -> 3979766 on 152323 d1, trip 380816081"
+        },
+        {
+          "asked": {
+            "destination": "3979810",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "3979766",
+            "ride_length": 16,
+            "route": "152323",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3979810",
+            "direction": 1,
+            "origin": "3979766",
+            "route": "152323",
+            "trip": "380816281"
+          },
+          "ok": true,
+          "text": "asked 3979766 -> 3979810 on 152323 d1 (stop 9 to stop 16 of a 16-stop ride): got 3979766 -> 3979810 on 152323 d1, trip 380816281"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-1-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152323"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": false,
+          "text": "the list offers one station twice in a row [('3979766', '3980631')]"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 4132580 .. 3979810"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3979966 .. 3979810"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980295 .. 3980743"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3979725 .. 3980743"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980295 .. 3980743"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-1-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "route": "152323"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3979725",
+            "direction": 1,
+            "from_stop": 12,
+            "origin": "3980743",
+            "ride_length": 12,
+            "route": "152323",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980743 -> 3979725 on 152323 d1 (stop 12 to stop 1 of a 12-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979725",
+            "direction": 1,
+            "from_stop": 7,
+            "origin": "3980204",
+            "ride_length": 12,
+            "route": "152323",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980204 -> 3979725 on 152323 d1 (stop 7 to stop 1 of a 12-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980204",
+            "direction": 1,
+            "from_stop": 12,
+            "origin": "3980743",
+            "ride_length": 12,
+            "route": "152323",
+            "served": false,
+            "to_stop": 7
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980743 -> 3980204 on 152323 d1 (stop 12 to stop 7 of a 12-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979966",
+            "direction": 1,
+            "from_stop": 15,
+            "origin": "3979810",
+            "ride_length": 15,
+            "route": "152323",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979810 -> 3979966 on 152323 d1 (stop 15 to stop 1 of a 15-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979966",
+            "direction": 1,
+            "from_stop": 8,
+            "origin": "3979766",
+            "ride_length": 15,
+            "route": "152323",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979766 -> 3979966 on 152323 d1 (stop 8 to stop 1 of a 15-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979766",
+            "direction": 1,
+            "from_stop": 15,
+            "origin": "3979810",
+            "ride_length": 15,
+            "route": "152323",
+            "served": true,
+            "to_stop": 8
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979810 -> 3979766 on 152323 d1 (stop 15 to stop 8 of a 15-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980295",
+            "direction": 1,
+            "from_stop": 30,
+            "origin": "3980743",
+            "ride_length": 30,
+            "route": "152323",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980743 -> 3980295 on 152323 d1 (stop 30 to stop 1 of a 30-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980295",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "3981140",
+            "ride_length": 30,
+            "route": "152323",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981140 -> 3980295 on 152323 d1 (stop 16 to stop 1 of a 30-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981140",
+            "direction": 1,
+            "from_stop": 30,
+            "origin": "3980743",
+            "ride_length": 30,
+            "route": "152323",
+            "served": false,
+            "to_stop": 16
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980743 -> 3981140 on 152323 d1 (stop 30 to stop 16 of a 30-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980295",
+            "direction": 1,
+            "from_stop": 27,
+            "origin": "3980743",
+            "ride_length": 27,
+            "route": "152323",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980743 -> 3980295 on 152323 d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980295",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "3981186",
+            "ride_length": 27,
+            "route": "152323",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981186 -> 3980295 on 152323 d1 (stop 14 to stop 1 of a 27-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981186",
+            "direction": 1,
+            "from_stop": 27,
+            "origin": "3980743",
+            "ride_length": 27,
+            "route": "152323",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980743 -> 3981186 on 152323 d1 (stop 27 to stop 14 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "4132580",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "3979810",
+            "ride_length": 16,
+            "route": "152323",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979810 -> 4132580 on 152323 d1 (stop 16 to stop 1 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "4132580",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "3979766",
+            "ride_length": 16,
+            "route": "152323",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979766 -> 4132580 on 152323 d1 (stop 9 to stop 1 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979766",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "3979810",
+            "ride_length": 16,
+            "route": "152323",
+            "served": true,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979810 -> 3979766 on 152323 d1 (stop 16 to stop 9 of a 16-stop ride): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-1-d1-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152323"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3981133",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3979794",
+            "ride_length": 13,
+            "route": "152330",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "3981133",
+            "direction": 0,
+            "origin": "3979794",
+            "route": "152330",
+            "trip": "380806958"
+          },
+          "ok": true,
+          "text": "asked 3979794 -> 3981133 on 152330 d0 (stop 1 to stop 13 of a 13-stop ride): got 3979794 -> 3981133 on 152330 d0, trip 380806958"
+        },
+        {
+          "asked": {
+            "destination": "3980268",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3979794",
+            "ride_length": 13,
+            "route": "152330",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "3980268",
+            "direction": 0,
+            "origin": "3979794",
+            "route": "152330",
+            "trip": "380806958"
+          },
+          "ok": true,
+          "text": "asked 3979794 -> 3980268 on 152330 d0 (stop 1 to stop 7 of a 13-stop ride): got 3979794 -> 3980268 on 152330 d0, trip 380806958"
+        },
+        {
+          "asked": {
+            "destination": "3981133",
+            "direction": 0,
+            "from_stop": 7,
+            "origin": "3980268",
+            "ride_length": 13,
+            "route": "152330",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "3981133",
+            "direction": 0,
+            "origin": "3980268",
+            "route": "152330",
+            "trip": "380806958"
+          },
+          "ok": true,
+          "text": "asked 3980268 -> 3981133 on 152330 d0 (stop 7 to stop 13 of a 13-stop ride): got 3980268 -> 3981133 on 152330 d0, trip 380806958"
+        },
+        {
+          "asked": {
+            "destination": "4149790",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981287",
+            "ride_length": 22,
+            "route": "152330",
+            "to_stop": 22
+          },
+          "got": {
+            "destination": "4149790",
+            "direction": 0,
+            "origin": "3981287",
+            "route": "152330",
+            "trip": "380856956"
+          },
+          "ok": true,
+          "text": "asked 3981287 -> 4149790 on 152330 d0 (stop 1 to stop 22 of a 22-stop ride): got 3981287 -> 4149790 on 152330 d0, trip 380856956"
+        },
+        {
+          "asked": {
+            "destination": "3980544",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981287",
+            "ride_length": 22,
+            "route": "152330",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "3980544",
+            "direction": 0,
+            "origin": "3981287",
+            "route": "152330",
+            "trip": "380856956"
+          },
+          "ok": true,
+          "text": "asked 3981287 -> 3980544 on 152330 d0 (stop 1 to stop 12 of a 22-stop ride): got 3981287 -> 3980544 on 152330 d0, trip 380856956"
+        },
+        {
+          "asked": {
+            "destination": "4149790",
+            "direction": 0,
+            "from_stop": 12,
+            "origin": "3980544",
+            "ride_length": 22,
+            "route": "152330",
+            "to_stop": 22
+          },
+          "got": {
+            "destination": "4149790",
+            "direction": 0,
+            "origin": "3980544",
+            "route": "152330",
+            "trip": "380856956"
+          },
+          "ok": true,
+          "text": "asked 3980544 -> 4149790 on 152330 d0 (stop 12 to stop 22 of a 22-stop ride): got 3980544 -> 4149790 on 152330 d0, trip 380856956"
+        },
+        {
+          "asked": {
+            "destination": "3981133",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981287",
+            "ride_length": 22,
+            "route": "152330",
+            "to_stop": 22
+          },
+          "got": {
+            "destination": "3981133",
+            "direction": 0,
+            "origin": "3981287",
+            "route": "152330",
+            "trip": "380806756"
+          },
+          "ok": true,
+          "text": "asked 3981287 -> 3981133 on 152330 d0 (stop 1 to stop 22 of a 22-stop ride): got 3981287 -> 3981133 on 152330 d0, trip 380806756"
+        },
+        {
+          "asked": {
+            "destination": "3980544",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981287",
+            "ride_length": 22,
+            "route": "152330",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "3980544",
+            "direction": 0,
+            "origin": "3981287",
+            "route": "152330",
+            "trip": "380806756"
+          },
+          "ok": true,
+          "text": "asked 3981287 -> 3980544 on 152330 d0 (stop 1 to stop 12 of a 22-stop ride): got 3981287 -> 3980544 on 152330 d0, trip 380806756"
+        },
+        {
+          "asked": {
+            "destination": "3981133",
+            "direction": 0,
+            "from_stop": 12,
+            "origin": "3980544",
+            "ride_length": 22,
+            "route": "152330",
+            "to_stop": 22
+          },
+          "got": {
+            "destination": "3981133",
+            "direction": 0,
+            "origin": "3980544",
+            "route": "152330",
+            "trip": "380806958"
+          },
+          "ok": true,
+          "text": "asked 3980544 -> 3981133 on 152330 d0 (stop 12 to stop 22 of a 22-stop ride): got 3980544 -> 3981133 on 152330 d0, trip 380806958"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-13-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152330"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": false,
+          "text": "the list offers one station twice in a row [('3980268', '3980182')]"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3981287 .. 3981133"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3979794 .. 3981133"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3981287 .. 4149790"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-13-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "route": "152330"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3979794",
+            "direction": 0,
+            "from_stop": 13,
+            "origin": "3981133",
+            "ride_length": 13,
+            "route": "152330",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981133 -> 3979794 on 152330 d0 (stop 13 to stop 1 of a 13-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979794",
+            "direction": 0,
+            "from_stop": 7,
+            "origin": "3980268",
+            "ride_length": 13,
+            "route": "152330",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980268 -> 3979794 on 152330 d0 (stop 7 to stop 1 of a 13-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980268",
+            "direction": 0,
+            "from_stop": 13,
+            "origin": "3981133",
+            "ride_length": 13,
+            "route": "152330",
+            "served": false,
+            "to_stop": 7
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981133 -> 3980268 on 152330 d0 (stop 13 to stop 7 of a 13-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981287",
+            "direction": 0,
+            "from_stop": 22,
+            "origin": "4149790",
+            "ride_length": 22,
+            "route": "152330",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 4149790 -> 3981287 on 152330 d0 (stop 22 to stop 1 of a 22-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981287",
+            "direction": 0,
+            "from_stop": 12,
+            "origin": "3980544",
+            "ride_length": 22,
+            "route": "152330",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980544 -> 3981287 on 152330 d0 (stop 12 to stop 1 of a 22-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980544",
+            "direction": 0,
+            "from_stop": 22,
+            "origin": "4149790",
+            "ride_length": 22,
+            "route": "152330",
+            "served": false,
+            "to_stop": 12
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 4149790 -> 3980544 on 152330 d0 (stop 22 to stop 12 of a 22-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981287",
+            "direction": 0,
+            "from_stop": 22,
+            "origin": "3981133",
+            "ride_length": 22,
+            "route": "152330",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981133 -> 3981287 on 152330 d0 (stop 22 to stop 1 of a 22-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981287",
+            "direction": 0,
+            "from_stop": 12,
+            "origin": "3980544",
+            "ride_length": 22,
+            "route": "152330",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980544 -> 3981287 on 152330 d0 (stop 12 to stop 1 of a 22-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980544",
+            "direction": 0,
+            "from_stop": 22,
+            "origin": "3981133",
+            "ride_length": 22,
+            "route": "152330",
+            "served": false,
+            "to_stop": 12
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981133 -> 3980544 on 152330 d0 (stop 22 to stop 12 of a 22-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-13-d0-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152330"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3980106",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3979948",
+            "ride_length": 22,
+            "route": "152330",
+            "to_stop": 22
+          },
+          "got": {
+            "destination": "3980106",
+            "direction": 1,
+            "origin": "3979948",
+            "route": "152330",
+            "trip": "380856952"
+          },
+          "ok": true,
+          "text": "asked 3979948 -> 3980106 on 152330 d1 (stop 1 to stop 22 of a 22-stop ride): got 3979948 -> 3980106 on 152330 d1, trip 380856952"
+        },
+        {
+          "asked": {
+            "destination": "3979733",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3979948",
+            "ride_length": 22,
+            "route": "152330",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "3979733",
+            "direction": 1,
+            "origin": "3979948",
+            "route": "152330",
+            "trip": "380856952"
+          },
+          "ok": true,
+          "text": "asked 3979948 -> 3979733 on 152330 d1 (stop 1 to stop 12 of a 22-stop ride): got 3979948 -> 3979733 on 152330 d1, trip 380856952"
+        },
+        {
+          "asked": {
+            "destination": "3980106",
+            "direction": 1,
+            "from_stop": 12,
+            "origin": "3979733",
+            "ride_length": 22,
+            "route": "152330",
+            "to_stop": 22
+          },
+          "got": {
+            "destination": "3980106",
+            "direction": 1,
+            "origin": "3979733",
+            "route": "152330",
+            "trip": "380856952"
+          },
+          "ok": true,
+          "text": "asked 3979733 -> 3980106 on 152330 d1 (stop 12 to stop 22 of a 22-stop ride): got 3979733 -> 3980106 on 152330 d1, trip 380856952"
+        },
+        {
+          "asked": {
+            "destination": "3980106",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980794",
+            "ride_length": 9,
+            "route": "152330",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "3980106",
+            "direction": 1,
+            "origin": "3980794",
+            "route": "152330",
+            "trip": "380806951"
+          },
+          "ok": true,
+          "text": "asked 3980794 -> 3980106 on 152330 d1 (stop 1 to stop 9 of a 9-stop ride): got 3980794 -> 3980106 on 152330 d1, trip 380806951"
+        },
+        {
+          "asked": {
+            "destination": "3980252",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980794",
+            "ride_length": 9,
+            "route": "152330",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "3980252",
+            "direction": 1,
+            "origin": "3980794",
+            "route": "152330",
+            "trip": "380806951"
+          },
+          "ok": true,
+          "text": "asked 3980794 -> 3980252 on 152330 d1 (stop 1 to stop 5 of a 9-stop ride): got 3980794 -> 3980252 on 152330 d1, trip 380806951"
+        },
+        {
+          "asked": {
+            "destination": "3980106",
+            "direction": 1,
+            "from_stop": 5,
+            "origin": "3980252",
+            "ride_length": 9,
+            "route": "152330",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "3980106",
+            "direction": 1,
+            "origin": "3980252",
+            "route": "152330",
+            "trip": "380806951"
+          },
+          "ok": true,
+          "text": "asked 3980252 -> 3980106 on 152330 d1 (stop 5 to stop 9 of a 9-stop ride): got 3980252 -> 3980106 on 152330 d1, trip 380806951"
+        },
+        {
+          "asked": {
+            "destination": "3980106",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3981133",
+            "ride_length": 22,
+            "route": "152330",
+            "to_stop": 22
+          },
+          "got": {
+            "destination": "3980106",
+            "direction": 1,
+            "origin": "3981133",
+            "route": "152330",
+            "trip": "380806750"
+          },
+          "ok": true,
+          "text": "asked 3981133 -> 3980106 on 152330 d1 (stop 1 to stop 22 of a 22-stop ride): got 3981133 -> 3980106 on 152330 d1, trip 380806750"
+        },
+        {
+          "asked": {
+            "destination": "3979733",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3981133",
+            "ride_length": 22,
+            "route": "152330",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "3979733",
+            "direction": 1,
+            "origin": "3981133",
+            "route": "152330",
+            "trip": "380806750"
+          },
+          "ok": true,
+          "text": "asked 3981133 -> 3979733 on 152330 d1 (stop 1 to stop 12 of a 22-stop ride): got 3981133 -> 3979733 on 152330 d1, trip 380806750"
+        },
+        {
+          "asked": {
+            "destination": "3980106",
+            "direction": 1,
+            "from_stop": 12,
+            "origin": "3979733",
+            "ride_length": 22,
+            "route": "152330",
+            "to_stop": 22
+          },
+          "got": {
+            "destination": "3980106",
+            "direction": 1,
+            "origin": "3979733",
+            "route": "152330",
+            "trip": "380806750"
+          },
+          "ok": true,
+          "text": "asked 3979733 -> 3980106 on 152330 d1 (stop 12 to stop 22 of a 22-stop ride): got 3979733 -> 3980106 on 152330 d1, trip 380806750"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-13-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152330"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3981133 .. 3980106"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980794 .. 3980106"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3979948 .. 3980106"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-13-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "route": "152330"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3979948",
+            "direction": 1,
+            "from_stop": 22,
+            "origin": "3980106",
+            "ride_length": 22,
+            "route": "152330",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980106 -> 3979948 on 152330 d1 (stop 22 to stop 1 of a 22-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979948",
+            "direction": 1,
+            "from_stop": 12,
+            "origin": "3979733",
+            "ride_length": 22,
+            "route": "152330",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979733 -> 3979948 on 152330 d1 (stop 12 to stop 1 of a 22-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979733",
+            "direction": 1,
+            "from_stop": 22,
+            "origin": "3980106",
+            "ride_length": 22,
+            "route": "152330",
+            "served": false,
+            "to_stop": 12
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980106 -> 3979733 on 152330 d1 (stop 22 to stop 12 of a 22-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980794",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "3980106",
+            "ride_length": 9,
+            "route": "152330",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980106 -> 3980794 on 152330 d1 (stop 9 to stop 1 of a 9-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980794",
+            "direction": 1,
+            "from_stop": 5,
+            "origin": "3980252",
+            "ride_length": 9,
+            "route": "152330",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980252 -> 3980794 on 152330 d1 (stop 5 to stop 1 of a 9-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980252",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "3980106",
+            "ride_length": 9,
+            "route": "152330",
+            "served": false,
+            "to_stop": 5
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980106 -> 3980252 on 152330 d1 (stop 9 to stop 5 of a 9-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981133",
+            "direction": 1,
+            "from_stop": 22,
+            "origin": "3980106",
+            "ride_length": 22,
+            "route": "152330",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980106 -> 3981133 on 152330 d1 (stop 22 to stop 1 of a 22-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981133",
+            "direction": 1,
+            "from_stop": 12,
+            "origin": "3979733",
+            "ride_length": 22,
+            "route": "152330",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979733 -> 3981133 on 152330 d1 (stop 12 to stop 1 of a 22-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979733",
+            "direction": 1,
+            "from_stop": 22,
+            "origin": "3980106",
+            "ride_length": 22,
+            "route": "152330",
+            "served": false,
+            "to_stop": 12
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980106 -> 3979733 on 152330 d1 (stop 22 to stop 12 of a 22-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-13-d1-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152330"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3980234",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3979805",
+            "ride_length": 4,
+            "route": "152331",
+            "to_stop": 4
+          },
+          "got": {
+            "destination": "3980234",
+            "direction": 0,
+            "origin": "3979805",
+            "route": "152331",
+            "trip": "380800805"
+          },
+          "ok": true,
+          "text": "asked 3979805 -> 3980234 on 152331 d0 (stop 1 to stop 4 of a 4-stop ride): got 3979805 -> 3980234 on 152331 d0, trip 380800805"
+        },
+        {
+          "asked": {
+            "destination": "3980826",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3979805",
+            "ride_length": 4,
+            "route": "152331",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "3980826",
+            "direction": 0,
+            "origin": "3979805",
+            "route": "152331",
+            "trip": "380800805"
+          },
+          "ok": true,
+          "text": "asked 3979805 -> 3980826 on 152331 d0 (stop 1 to stop 3 of a 4-stop ride): got 3979805 -> 3980826 on 152331 d0, trip 380800805"
+        },
+        {
+          "asked": {
+            "destination": "3980234",
+            "direction": 0,
+            "from_stop": 3,
+            "origin": "3980826",
+            "ride_length": 4,
+            "route": "152331",
+            "to_stop": 4
+          },
+          "got": {
+            "destination": "3980234",
+            "direction": 0,
+            "origin": "3980826",
+            "route": "152331",
+            "trip": "380800805"
+          },
+          "ok": true,
+          "text": "asked 3980826 -> 3980234 on 152331 d0 (stop 3 to stop 4 of a 4-stop ride): got 3980826 -> 3980234 on 152331 d0, trip 380800805"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3979805",
+            "ride_length": 8,
+            "route": "152331",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 0,
+            "origin": "3979805",
+            "route": "152331",
+            "trip": "380799228"
+          },
+          "ok": true,
+          "text": "asked 3979805 -> 3980992 on 152331 d0 (stop 1 to stop 8 of a 8-stop ride): got 3979805 -> 3980992 on 152331 d0, trip 380799228"
+        },
+        {
+          "asked": {
+            "destination": "3979931",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3979805",
+            "ride_length": 8,
+            "route": "152331",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "3979931",
+            "direction": 0,
+            "origin": "3979805",
+            "route": "152331",
+            "trip": "380799228"
+          },
+          "ok": true,
+          "text": "asked 3979805 -> 3979931 on 152331 d0 (stop 1 to stop 5 of a 8-stop ride): got 3979805 -> 3979931 on 152331 d0, trip 380799228"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 0,
+            "from_stop": 5,
+            "origin": "3979931",
+            "ride_length": 8,
+            "route": "152331",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 0,
+            "origin": "3979931",
+            "route": "152331",
+            "trip": "380799228"
+          },
+          "ok": true,
+          "text": "asked 3979931 -> 3980992 on 152331 d0 (stop 5 to stop 8 of a 8-stop ride): got 3979931 -> 3980992 on 152331 d0, trip 380799228"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980163",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3981274",
+            "direction": 0,
+            "origin": "3980163",
+            "route": "152331",
+            "trip": "380834569"
+          },
+          "ok": true,
+          "text": "asked 3980163 -> 3981274 on 152331 d0 (stop 1 to stop 16 of a 16-stop ride): got 3980163 -> 3981274 on 152331 d0, trip 380834569"
+        },
+        {
+          "asked": {
+            "destination": "3979768",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980163",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "3979768",
+            "direction": 0,
+            "origin": "3980163",
+            "route": "152331",
+            "trip": "380834463"
+          },
+          "ok": true,
+          "text": "asked 3980163 -> 3979768 on 152331 d0 (stop 1 to stop 9 of a 16-stop ride): got 3980163 -> 3979768 on 152331 d0, trip 380834463"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 0,
+            "from_stop": 9,
+            "origin": "3979768",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3981274",
+            "direction": 0,
+            "origin": "3979768",
+            "route": "152331",
+            "trip": "380834569"
+          },
+          "ok": true,
+          "text": "asked 3979768 -> 3981274 on 152331 d0 (stop 9 to stop 16 of a 16-stop ride): got 3979768 -> 3981274 on 152331 d0, trip 380834569"
+        },
+        {
+          "asked": {
+            "destination": "4045456",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980163",
+            "ride_length": 17,
+            "route": "152331",
+            "to_stop": 17
+          },
+          "got": {
+            "destination": "4045456",
+            "direction": 0,
+            "origin": "3980163",
+            "route": "152331",
+            "trip": "380834463"
+          },
+          "ok": true,
+          "text": "asked 3980163 -> 4045456 on 152331 d0 (stop 1 to stop 17 of a 17-stop ride): got 3980163 -> 4045456 on 152331 d0, trip 380834463"
+        },
+        {
+          "asked": {
+            "destination": "3979768",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980163",
+            "ride_length": 17,
+            "route": "152331",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "3979768",
+            "direction": 0,
+            "origin": "3980163",
+            "route": "152331",
+            "trip": "380834463"
+          },
+          "ok": true,
+          "text": "asked 3980163 -> 3979768 on 152331 d0 (stop 1 to stop 9 of a 17-stop ride): got 3980163 -> 3979768 on 152331 d0, trip 380834463"
+        },
+        {
+          "asked": {
+            "destination": "4045456",
+            "direction": 0,
+            "from_stop": 9,
+            "origin": "3979768",
+            "ride_length": 17,
+            "route": "152331",
+            "to_stop": 17
+          },
+          "got": {
+            "destination": "4045456",
+            "direction": 0,
+            "origin": "3979768",
+            "route": "152331",
+            "trip": "380834647"
+          },
+          "ok": true,
+          "text": "asked 3979768 -> 4045456 on 152331 d0 (stop 9 to stop 17 of a 17-stop ride): got 3979768 -> 4045456 on 152331 d0, trip 380834647"
+        },
+        {
+          "asked": {
+            "destination": "4045456",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980549",
+            "ride_length": 10,
+            "route": "152331",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "4045456",
+            "direction": 0,
+            "origin": "3980549",
+            "route": "152331",
+            "trip": "380834647"
+          },
+          "ok": true,
+          "text": "asked 3980549 -> 4045456 on 152331 d0 (stop 1 to stop 10 of a 10-stop ride): got 3980549 -> 4045456 on 152331 d0, trip 380834647"
+        },
+        {
+          "asked": {
+            "destination": "3979798",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980549",
+            "ride_length": 10,
+            "route": "152331",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "3979798",
+            "direction": 0,
+            "origin": "3980549",
+            "route": "152331",
+            "trip": "380834647"
+          },
+          "ok": true,
+          "text": "asked 3980549 -> 3979798 on 152331 d0 (stop 1 to stop 6 of a 10-stop ride): got 3980549 -> 3979798 on 152331 d0, trip 380834647"
+        },
+        {
+          "asked": {
+            "destination": "4045456",
+            "direction": 0,
+            "from_stop": 6,
+            "origin": "3979798",
+            "ride_length": 10,
+            "route": "152331",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "4045456",
+            "direction": 0,
+            "origin": "3979798",
+            "route": "152331",
+            "trip": "380834647"
+          },
+          "ok": true,
+          "text": "asked 3979798 -> 4045456 on 152331 d0 (stop 6 to stop 10 of a 10-stop ride): got 3979798 -> 4045456 on 152331 d0, trip 380834647"
+        },
+        {
+          "asked": {
+            "destination": "3980234",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981274",
+            "ride_length": 12,
+            "route": "152331",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "3980234",
+            "direction": 0,
+            "origin": "3981274",
+            "route": "152331",
+            "trip": "380800618"
+          },
+          "ok": true,
+          "text": "asked 3981274 -> 3980234 on 152331 d0 (stop 1 to stop 12 of a 12-stop ride): got 3981274 -> 3980234 on 152331 d0, trip 380800618"
+        },
+        {
+          "asked": {
+            "destination": "3980195",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981274",
+            "ride_length": 12,
+            "route": "152331",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "3980195",
+            "direction": 0,
+            "origin": "3981274",
+            "route": "152331",
+            "trip": "380800618"
+          },
+          "ok": true,
+          "text": "asked 3981274 -> 3980195 on 152331 d0 (stop 1 to stop 7 of a 12-stop ride): got 3981274 -> 3980195 on 152331 d0, trip 380800618"
+        },
+        {
+          "asked": {
+            "destination": "3980234",
+            "direction": 0,
+            "from_stop": 7,
+            "origin": "3980195",
+            "ride_length": 12,
+            "route": "152331",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "3980234",
+            "direction": 0,
+            "origin": "3980195",
+            "route": "152331",
+            "trip": "380800618"
+          },
+          "ok": true,
+          "text": "asked 3980195 -> 3980234 on 152331 d0 (stop 7 to stop 12 of a 12-stop ride): got 3980195 -> 3980234 on 152331 d0, trip 380800618"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981274",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 0,
+            "origin": "3981274",
+            "route": "152331",
+            "trip": "380799025"
+          },
+          "ok": true,
+          "text": "asked 3981274 -> 3980992 on 152331 d0 (stop 1 to stop 16 of a 16-stop ride): got 3981274 -> 3980992 on 152331 d0, trip 380799025"
+        },
+        {
+          "asked": {
+            "destination": "3979805",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981274",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "3979805",
+            "direction": 0,
+            "origin": "3981274",
+            "route": "152331",
+            "trip": "380799025"
+          },
+          "ok": true,
+          "text": "asked 3981274 -> 3979805 on 152331 d0 (stop 1 to stop 9 of a 16-stop ride): got 3981274 -> 3979805 on 152331 d0, trip 380799025"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 0,
+            "from_stop": 9,
+            "origin": "3979805",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 0,
+            "origin": "3979805",
+            "route": "152331",
+            "trip": "380799228"
+          },
+          "ok": true,
+          "text": "asked 3979805 -> 3980992 on 152331 d0 (stop 9 to stop 16 of a 16-stop ride): got 3979805 -> 3980992 on 152331 d0, trip 380799228"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-14-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152331"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": false,
+          "text": "the list offers one station twice in a row [('3980489', '3980251')]"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3981274 .. 3980992"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3979805 .. 3980992"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3979805 .. 3980234"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3981274 .. 3980234"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980163 .. 4045456"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980163 .. 3981274"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980549 .. 4045456"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-14-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "route": "152331"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3979805",
+            "direction": 0,
+            "from_stop": 4,
+            "origin": "3980234",
+            "ride_length": 4,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980234 -> 3979805 on 152331 d0 (stop 4 to stop 1 of a 4-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979805",
+            "direction": 0,
+            "from_stop": 3,
+            "origin": "3980826",
+            "ride_length": 4,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980826 -> 3979805 on 152331 d0 (stop 3 to stop 1 of a 4-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980826",
+            "direction": 0,
+            "from_stop": 4,
+            "origin": "3980234",
+            "ride_length": 4,
+            "route": "152331",
+            "served": true,
+            "to_stop": 3
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980234 -> 3980826 on 152331 d0 (stop 4 to stop 3 of a 4-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979805",
+            "direction": 0,
+            "from_stop": 8,
+            "origin": "3980992",
+            "ride_length": 8,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 3979805 on 152331 d0 (stop 8 to stop 1 of a 8-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979805",
+            "direction": 0,
+            "from_stop": 5,
+            "origin": "3979931",
+            "ride_length": 8,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979931 -> 3979805 on 152331 d0 (stop 5 to stop 1 of a 8-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979931",
+            "direction": 0,
+            "from_stop": 8,
+            "origin": "3980992",
+            "ride_length": 8,
+            "route": "152331",
+            "served": true,
+            "to_stop": 5
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 3979931 on 152331 d0 (stop 8 to stop 5 of a 8-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980163",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "3981274",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981274 -> 3980163 on 152331 d0 (stop 16 to stop 1 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980163",
+            "direction": 0,
+            "from_stop": 9,
+            "origin": "3979768",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979768 -> 3980163 on 152331 d0 (stop 9 to stop 1 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979768",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "3981274",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981274 -> 3979768 on 152331 d0 (stop 16 to stop 9 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980163",
+            "direction": 0,
+            "from_stop": 17,
+            "origin": "4045456",
+            "ride_length": 17,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 4045456 -> 3980163 on 152331 d0 (stop 17 to stop 1 of a 17-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980163",
+            "direction": 0,
+            "from_stop": 9,
+            "origin": "3979768",
+            "ride_length": 17,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979768 -> 3980163 on 152331 d0 (stop 9 to stop 1 of a 17-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979768",
+            "direction": 0,
+            "from_stop": 17,
+            "origin": "4045456",
+            "ride_length": 17,
+            "route": "152331",
+            "served": true,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 4045456 -> 3979768 on 152331 d0 (stop 17 to stop 9 of a 17-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980549",
+            "direction": 0,
+            "from_stop": 10,
+            "origin": "4045456",
+            "ride_length": 10,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 4045456 -> 3980549 on 152331 d0 (stop 10 to stop 1 of a 10-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980549",
+            "direction": 0,
+            "from_stop": 6,
+            "origin": "3979798",
+            "ride_length": 10,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979798 -> 3980549 on 152331 d0 (stop 6 to stop 1 of a 10-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979798",
+            "direction": 0,
+            "from_stop": 10,
+            "origin": "4045456",
+            "ride_length": 10,
+            "route": "152331",
+            "served": true,
+            "to_stop": 6
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 4045456 -> 3979798 on 152331 d0 (stop 10 to stop 6 of a 10-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 0,
+            "from_stop": 12,
+            "origin": "3980234",
+            "ride_length": 12,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "3981274",
+            "direction": 1,
+            "origin": "3980234",
+            "route": "152331",
+            "trip": "380800613"
+          },
+          "ok": true,
+          "text": "asked 3980234 -> 3981274 on 152331 d0 (stop 12 to stop 1 of a 12-stop ride): got 3980234 -> 3981274 on 152331 d1, trip 380800613"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 0,
+            "from_stop": 7,
+            "origin": "3980195",
+            "ride_length": 12,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980195 -> 3981274 on 152331 d0 (stop 7 to stop 1 of a 12-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980195",
+            "direction": 0,
+            "from_stop": 12,
+            "origin": "3980234",
+            "ride_length": 12,
+            "route": "152331",
+            "served": true,
+            "to_stop": 7
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980234 -> 3980195 on 152331 d0 (stop 12 to stop 7 of a 12-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "3980992",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 3981274 on 152331 d0 (stop 16 to stop 1 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 0,
+            "from_stop": 9,
+            "origin": "3979805",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979805 -> 3981274 on 152331 d0 (stop 9 to stop 1 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979805",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "3980992",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 3979805 on 152331 d0 (stop 16 to stop 9 of a 16-stop ride): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-14-d0-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152331"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3979805",
+            "ride_length": 8,
+            "route": "152331",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 1,
+            "origin": "3979805",
+            "route": "152331",
+            "trip": "380834648"
+          },
+          "ok": true,
+          "text": "asked 3979805 -> 3980992 on 152331 d1 (stop 1 to stop 8 of a 8-stop ride): got 3979805 -> 3980992 on 152331 d1, trip 380834648"
+        },
+        {
+          "asked": {
+            "destination": "3979931",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3979805",
+            "ride_length": 8,
+            "route": "152331",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "3979931",
+            "direction": 1,
+            "origin": "3979805",
+            "route": "152331",
+            "trip": "380834648"
+          },
+          "ok": true,
+          "text": "asked 3979805 -> 3979931 on 152331 d1 (stop 1 to stop 5 of a 8-stop ride): got 3979805 -> 3979931 on 152331 d1, trip 380834648"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 1,
+            "from_stop": 5,
+            "origin": "3979931",
+            "ride_length": 8,
+            "route": "152331",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 1,
+            "origin": "3979931",
+            "route": "152331",
+            "trip": "380834648"
+          },
+          "ok": true,
+          "text": "asked 3979931 -> 3980992 on 152331 d1 (stop 5 to stop 8 of a 8-stop ride): got 3979931 -> 3980992 on 152331 d1, trip 380834648"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980163",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3981274",
+            "direction": 1,
+            "origin": "3980163",
+            "route": "152331",
+            "trip": "380799022"
+          },
+          "ok": true,
+          "text": "asked 3980163 -> 3981274 on 152331 d1 (stop 1 to stop 16 of a 16-stop ride): got 3980163 -> 3981274 on 152331 d1, trip 380799022"
+        },
+        {
+          "asked": {
+            "destination": "3979768",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980163",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "3979768",
+            "direction": 1,
+            "origin": "3980163",
+            "route": "152331",
+            "trip": "380799022"
+          },
+          "ok": true,
+          "text": "asked 3980163 -> 3979768 on 152331 d1 (stop 1 to stop 9 of a 16-stop ride): got 3980163 -> 3979768 on 152331 d1, trip 380799022"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "3979768",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3981274",
+            "direction": 1,
+            "origin": "3979768",
+            "route": "152331",
+            "trip": "380799222"
+          },
+          "ok": true,
+          "text": "asked 3979768 -> 3981274 on 152331 d1 (stop 9 to stop 16 of a 16-stop ride): got 3979768 -> 3981274 on 152331 d1, trip 380799222"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980234",
+            "ride_length": 15,
+            "route": "152331",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "3981274",
+            "direction": 1,
+            "origin": "3980234",
+            "route": "152331",
+            "trip": "380800613"
+          },
+          "ok": true,
+          "text": "asked 3980234 -> 3981274 on 152331 d1 (stop 1 to stop 15 of a 15-stop ride): got 3980234 -> 3981274 on 152331 d1, trip 380800613"
+        },
+        {
+          "asked": {
+            "destination": "3979768",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980234",
+            "ride_length": 15,
+            "route": "152331",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3979768",
+            "direction": 1,
+            "origin": "3980234",
+            "route": "152331",
+            "trip": "380800613"
+          },
+          "ok": true,
+          "text": "asked 3980234 -> 3979768 on 152331 d1 (stop 1 to stop 8 of a 15-stop ride): got 3980234 -> 3979768 on 152331 d1, trip 380800613"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 1,
+            "from_stop": 8,
+            "origin": "3979768",
+            "ride_length": 15,
+            "route": "152331",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "3981274",
+            "direction": 1,
+            "origin": "3979768",
+            "route": "152331",
+            "trip": "380800613"
+          },
+          "ok": true,
+          "text": "asked 3979768 -> 3981274 on 152331 d1 (stop 8 to stop 15 of a 15-stop ride): got 3979768 -> 3981274 on 152331 d1, trip 380800613"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980549",
+            "ride_length": 9,
+            "route": "152331",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "3981274",
+            "direction": 1,
+            "origin": "3980549",
+            "route": "152331",
+            "trip": "380799222"
+          },
+          "ok": true,
+          "text": "asked 3980549 -> 3981274 on 152331 d1 (stop 1 to stop 9 of a 9-stop ride): got 3980549 -> 3981274 on 152331 d1, trip 380799222"
+        },
+        {
+          "asked": {
+            "destination": "3980239",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980549",
+            "ride_length": 9,
+            "route": "152331",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "3980239",
+            "direction": 1,
+            "origin": "3980549",
+            "route": "152331",
+            "trip": "380799222"
+          },
+          "ok": true,
+          "text": "asked 3980549 -> 3980239 on 152331 d1 (stop 1 to stop 5 of a 9-stop ride): got 3980549 -> 3980239 on 152331 d1, trip 380799222"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 1,
+            "from_stop": 5,
+            "origin": "3980239",
+            "ride_length": 9,
+            "route": "152331",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "3981274",
+            "direction": 1,
+            "origin": "3980239",
+            "route": "152331",
+            "trip": "380799222"
+          },
+          "ok": true,
+          "text": "asked 3980239 -> 3981274 on 152331 d1 (stop 5 to stop 9 of a 9-stop ride): got 3980239 -> 3981274 on 152331 d1, trip 380799222"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3981274",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 1,
+            "origin": "3981274",
+            "route": "152331",
+            "trip": "380834568"
+          },
+          "ok": true,
+          "text": "asked 3981274 -> 3980992 on 152331 d1 (stop 1 to stop 16 of a 16-stop ride): got 3981274 -> 3980992 on 152331 d1, trip 380834568"
+        },
+        {
+          "asked": {
+            "destination": "3979805",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3981274",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "3979805",
+            "direction": 1,
+            "origin": "3981274",
+            "route": "152331",
+            "trip": "380834568"
+          },
+          "ok": true,
+          "text": "asked 3981274 -> 3979805 on 152331 d1 (stop 1 to stop 9 of a 16-stop ride): got 3981274 -> 3979805 on 152331 d1, trip 380834568"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "3979805",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 1,
+            "origin": "3979805",
+            "route": "152331",
+            "trip": "380834648"
+          },
+          "ok": true,
+          "text": "asked 3979805 -> 3980992 on 152331 d1 (stop 9 to stop 16 of a 16-stop ride): got 3979805 -> 3980992 on 152331 d1, trip 380834648"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "4045456",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 1,
+            "origin": "4045456",
+            "route": "152331",
+            "trip": "380834461"
+          },
+          "ok": true,
+          "text": "asked 4045456 -> 3980992 on 152331 d1 (stop 1 to stop 16 of a 16-stop ride): got 4045456 -> 3980992 on 152331 d1, trip 380834461"
+        },
+        {
+          "asked": {
+            "destination": "3979805",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "4045456",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "3979805",
+            "direction": 1,
+            "origin": "4045456",
+            "route": "152331",
+            "trip": "380834461"
+          },
+          "ok": true,
+          "text": "asked 4045456 -> 3979805 on 152331 d1 (stop 1 to stop 9 of a 16-stop ride): got 4045456 -> 3979805 on 152331 d1, trip 380834461"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "3979805",
+            "ride_length": 16,
+            "route": "152331",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 1,
+            "origin": "3979805",
+            "route": "152331",
+            "trip": "380834648"
+          },
+          "ok": true,
+          "text": "asked 3979805 -> 3980992 on 152331 d1 (stop 9 to stop 16 of a 16-stop ride): got 3979805 -> 3980992 on 152331 d1, trip 380834648"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-14-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152331"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": false,
+          "text": "the list offers one station twice in a row [('4045456', '3981274')]"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980163 .. 3981274"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980549 .. 3981274"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": false,
+          "text": "the list contradicts the riding order 3980234 .. 3981274"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 4045456 .. 3980992"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": false,
+          "text": "the list contradicts the riding order 3981274 .. 3980992"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3979805 .. 3980992"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-14-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "route": "152331"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3979805",
+            "direction": 1,
+            "from_stop": 8,
+            "origin": "3980992",
+            "ride_length": 8,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 3979805 on 152331 d1 (stop 8 to stop 1 of a 8-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979805",
+            "direction": 1,
+            "from_stop": 5,
+            "origin": "3979931",
+            "ride_length": 8,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979931 -> 3979805 on 152331 d1 (stop 5 to stop 1 of a 8-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979931",
+            "direction": 1,
+            "from_stop": 8,
+            "origin": "3980992",
+            "ride_length": 8,
+            "route": "152331",
+            "served": true,
+            "to_stop": 5
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 3979931 on 152331 d1 (stop 8 to stop 5 of a 8-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980163",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "3981274",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981274 -> 3980163 on 152331 d1 (stop 16 to stop 1 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980163",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "3979768",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979768 -> 3980163 on 152331 d1 (stop 9 to stop 1 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979768",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "3981274",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981274 -> 3979768 on 152331 d1 (stop 16 to stop 9 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980234",
+            "direction": 1,
+            "from_stop": 15,
+            "origin": "3981274",
+            "ride_length": 15,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "3980234",
+            "direction": 0,
+            "origin": "3981274",
+            "route": "152331",
+            "trip": "380800618"
+          },
+          "ok": true,
+          "text": "asked 3981274 -> 3980234 on 152331 d1 (stop 15 to stop 1 of a 15-stop ride): got 3981274 -> 3980234 on 152331 d0, trip 380800618"
+        },
+        {
+          "asked": {
+            "destination": "3980234",
+            "direction": 1,
+            "from_stop": 8,
+            "origin": "3979768",
+            "ride_length": 15,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979768 -> 3980234 on 152331 d1 (stop 8 to stop 1 of a 15-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979768",
+            "direction": 1,
+            "from_stop": 15,
+            "origin": "3981274",
+            "ride_length": 15,
+            "route": "152331",
+            "served": true,
+            "to_stop": 8
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981274 -> 3979768 on 152331 d1 (stop 15 to stop 8 of a 15-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980549",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "3981274",
+            "ride_length": 9,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981274 -> 3980549 on 152331 d1 (stop 9 to stop 1 of a 9-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980549",
+            "direction": 1,
+            "from_stop": 5,
+            "origin": "3980239",
+            "ride_length": 9,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980239 -> 3980549 on 152331 d1 (stop 5 to stop 1 of a 9-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980239",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "3981274",
+            "ride_length": 9,
+            "route": "152331",
+            "served": true,
+            "to_stop": 5
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981274 -> 3980239 on 152331 d1 (stop 9 to stop 5 of a 9-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "3980992",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 3981274 on 152331 d1 (stop 16 to stop 1 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981274",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "3979805",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979805 -> 3981274 on 152331 d1 (stop 9 to stop 1 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979805",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "3980992",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 3979805 on 152331 d1 (stop 16 to stop 9 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "4045456",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "3980992",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 4045456 on 152331 d1 (stop 16 to stop 1 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "4045456",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "3979805",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979805 -> 4045456 on 152331 d1 (stop 9 to stop 1 of a 16-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979805",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "3980992",
+            "ride_length": 16,
+            "route": "152331",
+            "served": true,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 3979805 on 152331 d1 (stop 16 to stop 9 of a 16-stop ride): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-14-d1-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152331"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3979881",
+            "ride_length": 24,
+            "route": "152324",
+            "to_stop": 24
+          },
+          "got": {
+            "destination": "3981271",
+            "direction": 0,
+            "origin": "3979881",
+            "route": "152324",
+            "trip": "380815267"
+          },
+          "ok": true,
+          "text": "asked 3979881 -> 3981271 on 152324 d0 (stop 1 to stop 24 of a 24-stop ride): got 3979881 -> 3981271 on 152324 d0, trip 380815267"
+        },
+        {
+          "asked": {
+            "destination": "3980752",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3979881",
+            "ride_length": 24,
+            "route": "152324",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "3980752",
+            "direction": 0,
+            "origin": "3979881",
+            "route": "152324",
+            "trip": "380815267"
+          },
+          "ok": true,
+          "text": "asked 3979881 -> 3980752 on 152324 d0 (stop 1 to stop 13 of a 24-stop ride): got 3979881 -> 3980752 on 152324 d0, trip 380815267"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 0,
+            "from_stop": 13,
+            "origin": "3980752",
+            "ride_length": 24,
+            "route": "152324",
+            "to_stop": 24
+          },
+          "got": {
+            "destination": "3981271",
+            "direction": 0,
+            "origin": "3980752",
+            "route": "152324",
+            "trip": "380815549"
+          },
+          "ok": true,
+          "text": "asked 3980752 -> 3981271 on 152324 d0 (stop 13 to stop 24 of a 24-stop ride): got 3980752 -> 3981271 on 152324 d0, trip 380815549"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980305",
+            "ride_length": 14,
+            "route": "152324",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "3981271",
+            "direction": 0,
+            "origin": "3980305",
+            "route": "152324",
+            "trip": "380815549"
+          },
+          "ok": true,
+          "text": "asked 3980305 -> 3981271 on 152324 d0 (stop 1 to stop 14 of a 14-stop ride): got 3980305 -> 3981271 on 152324 d0, trip 380815549"
+        },
+        {
+          "asked": {
+            "destination": "3979912",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980305",
+            "ride_length": 14,
+            "route": "152324",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3979912",
+            "direction": 0,
+            "origin": "3980305",
+            "route": "152324",
+            "trip": "380815549"
+          },
+          "ok": true,
+          "text": "asked 3980305 -> 3979912 on 152324 d0 (stop 1 to stop 8 of a 14-stop ride): got 3980305 -> 3979912 on 152324 d0, trip 380815549"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 0,
+            "from_stop": 8,
+            "origin": "3979912",
+            "ride_length": 14,
+            "route": "152324",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "3981271",
+            "direction": 0,
+            "origin": "3979912",
+            "route": "152324",
+            "trip": "380815549"
+          },
+          "ok": true,
+          "text": "asked 3979912 -> 3981271 on 152324 d0 (stop 8 to stop 14 of a 14-stop ride): got 3979912 -> 3981271 on 152324 d0, trip 380815549"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980599",
+            "ride_length": 8,
+            "route": "152324",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3981271",
+            "direction": 0,
+            "origin": "3980599",
+            "route": "152324",
+            "trip": "380840045"
+          },
+          "ok": true,
+          "text": "asked 3980599 -> 3981271 on 152324 d0 (stop 1 to stop 8 of a 8-stop ride): got 3980599 -> 3981271 on 152324 d0, trip 380840045"
+        },
+        {
+          "asked": {
+            "destination": "3980023",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980599",
+            "ride_length": 8,
+            "route": "152324",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "3980023",
+            "direction": 0,
+            "origin": "3980599",
+            "route": "152324",
+            "trip": "380840045"
+          },
+          "ok": true,
+          "text": "asked 3980599 -> 3980023 on 152324 d0 (stop 1 to stop 5 of a 8-stop ride): got 3980599 -> 3980023 on 152324 d0, trip 380840045"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 0,
+            "from_stop": 5,
+            "origin": "3980023",
+            "ride_length": 8,
+            "route": "152324",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3981271",
+            "direction": 0,
+            "origin": "3980023",
+            "route": "152324",
+            "trip": "380840045"
+          },
+          "ok": true,
+          "text": "asked 3980023 -> 3981271 on 152324 d0 (stop 5 to stop 8 of a 8-stop ride): got 3980023 -> 3981271 on 152324 d0, trip 380840045"
+        },
+        {
+          "asked": {
+            "destination": "4132580",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981271",
+            "ride_length": 15,
+            "route": "152324",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "4132580",
+            "direction": 0,
+            "origin": "3981271",
+            "route": "152324",
+            "trip": "380816284"
+          },
+          "ok": true,
+          "text": "asked 3981271 -> 4132580 on 152324 d0 (stop 1 to stop 15 of a 15-stop ride): got 3981271 -> 4132580 on 152324 d0, trip 380816284"
+        },
+        {
+          "asked": {
+            "destination": "3980180",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981271",
+            "ride_length": 15,
+            "route": "152324",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3980180",
+            "direction": 0,
+            "origin": "3981271",
+            "route": "152324",
+            "trip": "380816284"
+          },
+          "ok": true,
+          "text": "asked 3981271 -> 3980180 on 152324 d0 (stop 1 to stop 8 of a 15-stop ride): got 3981271 -> 3980180 on 152324 d0, trip 380816284"
+        },
+        {
+          "asked": {
+            "destination": "4132580",
+            "direction": 0,
+            "from_stop": 8,
+            "origin": "3980180",
+            "ride_length": 15,
+            "route": "152324",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "4132580",
+            "direction": 0,
+            "origin": "3980180",
+            "route": "152324",
+            "trip": "380816284"
+          },
+          "ok": true,
+          "text": "asked 3980180 -> 4132580 on 152324 d0 (stop 8 to stop 15 of a 15-stop ride): got 3980180 -> 4132580 on 152324 d0, trip 380816284"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-17-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152324"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": false,
+          "text": "the list offers one station twice in a row [('3981140', '3980752')]"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3979881 .. 3981271"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980305 .. 3981271"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": false,
+          "text": "the list contradicts the riding order 3981271 .. 4132580"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980599 .. 3981271"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-17-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "route": "152324"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3979881",
+            "direction": 0,
+            "from_stop": 24,
+            "origin": "3981271",
+            "ride_length": 24,
+            "route": "152324",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981271 -> 3979881 on 152324 d0 (stop 24 to stop 1 of a 24-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979881",
+            "direction": 0,
+            "from_stop": 13,
+            "origin": "3980752",
+            "ride_length": 24,
+            "route": "152324",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980752 -> 3979881 on 152324 d0 (stop 13 to stop 1 of a 24-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980752",
+            "direction": 0,
+            "from_stop": 24,
+            "origin": "3981271",
+            "ride_length": 24,
+            "route": "152324",
+            "served": true,
+            "to_stop": 13
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981271 -> 3980752 on 152324 d0 (stop 24 to stop 13 of a 24-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980305",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "3981271",
+            "ride_length": 14,
+            "route": "152324",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981271 -> 3980305 on 152324 d0 (stop 14 to stop 1 of a 14-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980305",
+            "direction": 0,
+            "from_stop": 8,
+            "origin": "3979912",
+            "ride_length": 14,
+            "route": "152324",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979912 -> 3980305 on 152324 d0 (stop 8 to stop 1 of a 14-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979912",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "3981271",
+            "ride_length": 14,
+            "route": "152324",
+            "served": true,
+            "to_stop": 8
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981271 -> 3979912 on 152324 d0 (stop 14 to stop 8 of a 14-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980599",
+            "direction": 0,
+            "from_stop": 8,
+            "origin": "3981271",
+            "ride_length": 8,
+            "route": "152324",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981271 -> 3980599 on 152324 d0 (stop 8 to stop 1 of a 8-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980599",
+            "direction": 0,
+            "from_stop": 5,
+            "origin": "3980023",
+            "ride_length": 8,
+            "route": "152324",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980023 -> 3980599 on 152324 d0 (stop 5 to stop 1 of a 8-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980023",
+            "direction": 0,
+            "from_stop": 8,
+            "origin": "3981271",
+            "ride_length": 8,
+            "route": "152324",
+            "served": true,
+            "to_stop": 5
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981271 -> 3980023 on 152324 d0 (stop 8 to stop 5 of a 8-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 0,
+            "from_stop": 15,
+            "origin": "4132580",
+            "ride_length": 15,
+            "route": "152324",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 4132580 -> 3981271 on 152324 d0 (stop 15 to stop 1 of a 15-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 0,
+            "from_stop": 8,
+            "origin": "3980180",
+            "ride_length": 15,
+            "route": "152324",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980180 -> 3981271 on 152324 d0 (stop 8 to stop 1 of a 15-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980180",
+            "direction": 0,
+            "from_stop": 15,
+            "origin": "4132580",
+            "ride_length": 15,
+            "route": "152324",
+            "served": true,
+            "to_stop": 8
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 4132580 -> 3980180 on 152324 d0 (stop 15 to stop 8 of a 15-stop ride): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-17-d0-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152324"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3980351",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3979725",
+            "ride_length": 10,
+            "route": "152324",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "3980351",
+            "direction": 1,
+            "origin": "3979725",
+            "route": "152324",
+            "trip": "380815541"
+          },
+          "ok": true,
+          "text": "asked 3979725 -> 3980351 on 152324 d1 (stop 1 to stop 10 of a 10-stop ride): got 3979725 -> 3980351 on 152324 d1, trip 380815541"
+        },
+        {
+          "asked": {
+            "destination": "3980933",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3979725",
+            "ride_length": 10,
+            "route": "152324",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "3980933",
+            "direction": 1,
+            "origin": "3979725",
+            "route": "152324",
+            "trip": "380815541"
+          },
+          "ok": true,
+          "text": "asked 3979725 -> 3980933 on 152324 d1 (stop 1 to stop 6 of a 10-stop ride): got 3979725 -> 3980933 on 152324 d1, trip 380815541"
+        },
+        {
+          "asked": {
+            "destination": "3980351",
+            "direction": 1,
+            "from_stop": 6,
+            "origin": "3980933",
+            "ride_length": 10,
+            "route": "152324",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "3980351",
+            "direction": 1,
+            "origin": "3980933",
+            "route": "152324",
+            "trip": "380815541"
+          },
+          "ok": true,
+          "text": "asked 3980933 -> 3980351 on 152324 d1 (stop 6 to stop 10 of a 10-stop ride): got 3980933 -> 3980351 on 152324 d1, trip 380815541"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980599",
+            "ride_length": 8,
+            "route": "152324",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3981271",
+            "direction": 1,
+            "origin": "3980599",
+            "route": "152324",
+            "trip": "380816483"
+          },
+          "ok": true,
+          "text": "asked 3980599 -> 3981271 on 152324 d1 (stop 1 to stop 8 of a 8-stop ride): got 3980599 -> 3981271 on 152324 d1, trip 380816483"
+        },
+        {
+          "asked": {
+            "destination": "3980023",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980599",
+            "ride_length": 8,
+            "route": "152324",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "3980023",
+            "direction": 1,
+            "origin": "3980599",
+            "route": "152324",
+            "trip": "380816483"
+          },
+          "ok": true,
+          "text": "asked 3980599 -> 3980023 on 152324 d1 (stop 1 to stop 5 of a 8-stop ride): got 3980599 -> 3980023 on 152324 d1, trip 380816483"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 1,
+            "from_stop": 5,
+            "origin": "3980023",
+            "ride_length": 8,
+            "route": "152324",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3981271",
+            "direction": 1,
+            "origin": "3980023",
+            "route": "152324",
+            "trip": "380816483"
+          },
+          "ok": true,
+          "text": "asked 3980023 -> 3981271 on 152324 d1 (stop 5 to stop 8 of a 8-stop ride): got 3980023 -> 3981271 on 152324 d1, trip 380816483"
+        },
+        {
+          "asked": {
+            "destination": "3980351",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3981271",
+            "ride_length": 24,
+            "route": "152324",
+            "to_stop": 24
+          },
+          "got": {
+            "destination": "3980351",
+            "direction": 1,
+            "origin": "3981271",
+            "route": "152324",
+            "trip": "380815266"
+          },
+          "ok": true,
+          "text": "asked 3981271 -> 3980351 on 152324 d1 (stop 1 to stop 24 of a 24-stop ride): got 3981271 -> 3980351 on 152324 d1, trip 380815266"
+        },
+        {
+          "asked": {
+            "destination": "3980714",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3981271",
+            "ride_length": 24,
+            "route": "152324",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "3980714",
+            "direction": 1,
+            "origin": "3981271",
+            "route": "152324",
+            "trip": "380815266"
+          },
+          "ok": true,
+          "text": "asked 3981271 -> 3980714 on 152324 d1 (stop 1 to stop 13 of a 24-stop ride): got 3981271 -> 3980714 on 152324 d1, trip 380815266"
+        },
+        {
+          "asked": {
+            "destination": "3980351",
+            "direction": 1,
+            "from_stop": 13,
+            "origin": "3980714",
+            "ride_length": 24,
+            "route": "152324",
+            "to_stop": 24
+          },
+          "got": {
+            "destination": "3980351",
+            "direction": 1,
+            "origin": "3980714",
+            "route": "152324",
+            "trip": "380815266"
+          },
+          "ok": true,
+          "text": "asked 3980714 -> 3980351 on 152324 d1 (stop 13 to stop 24 of a 24-stop ride): got 3980714 -> 3980351 on 152324 d1, trip 380815266"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "4015830",
+            "ride_length": 15,
+            "route": "152324",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "3981271",
+            "direction": 1,
+            "origin": "4015830",
+            "route": "152324",
+            "trip": "380816385"
+          },
+          "ok": true,
+          "text": "asked 4015830 -> 3981271 on 152324 d1 (stop 1 to stop 15 of a 15-stop ride): got 4015830 -> 3981271 on 152324 d1, trip 380816385"
+        },
+        {
+          "asked": {
+            "destination": "3980599",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "4015830",
+            "ride_length": 15,
+            "route": "152324",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "3980599",
+            "direction": 1,
+            "origin": "4015830",
+            "route": "152324",
+            "trip": "380816385"
+          },
+          "ok": true,
+          "text": "asked 4015830 -> 3980599 on 152324 d1 (stop 1 to stop 8 of a 15-stop ride): got 4015830 -> 3980599 on 152324 d1, trip 380816385"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 1,
+            "from_stop": 8,
+            "origin": "3980599",
+            "ride_length": 15,
+            "route": "152324",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "3981271",
+            "direction": 1,
+            "origin": "3980599",
+            "route": "152324",
+            "trip": "380816483"
+          },
+          "ok": true,
+          "text": "asked 3980599 -> 3981271 on 152324 d1 (stop 8 to stop 15 of a 15-stop ride): got 3980599 -> 3981271 on 152324 d1, trip 380816483"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-17-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152324"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": false,
+          "text": "the list offers one station twice in a row [('3980573', '3980418')]"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": false,
+          "text": "the list contradicts the riding order 3981271 .. 3980351"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3979725 .. 3980351"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 4015830 .. 3981271"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980599 .. 3981271"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-17-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "route": "152324"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3979725",
+            "direction": 1,
+            "from_stop": 10,
+            "origin": "3980351",
+            "ride_length": 10,
+            "route": "152324",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980351 -> 3979725 on 152324 d1 (stop 10 to stop 1 of a 10-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979725",
+            "direction": 1,
+            "from_stop": 6,
+            "origin": "3980933",
+            "ride_length": 10,
+            "route": "152324",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980933 -> 3979725 on 152324 d1 (stop 6 to stop 1 of a 10-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980933",
+            "direction": 1,
+            "from_stop": 10,
+            "origin": "3980351",
+            "ride_length": 10,
+            "route": "152324",
+            "served": false,
+            "to_stop": 6
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980351 -> 3980933 on 152324 d1 (stop 10 to stop 6 of a 10-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980599",
+            "direction": 1,
+            "from_stop": 8,
+            "origin": "3981271",
+            "ride_length": 8,
+            "route": "152324",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981271 -> 3980599 on 152324 d1 (stop 8 to stop 1 of a 8-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980599",
+            "direction": 1,
+            "from_stop": 5,
+            "origin": "3980023",
+            "ride_length": 8,
+            "route": "152324",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980023 -> 3980599 on 152324 d1 (stop 5 to stop 1 of a 8-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980023",
+            "direction": 1,
+            "from_stop": 8,
+            "origin": "3981271",
+            "ride_length": 8,
+            "route": "152324",
+            "served": true,
+            "to_stop": 5
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981271 -> 3980023 on 152324 d1 (stop 8 to stop 5 of a 8-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 1,
+            "from_stop": 24,
+            "origin": "3980351",
+            "ride_length": 24,
+            "route": "152324",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980351 -> 3981271 on 152324 d1 (stop 24 to stop 1 of a 24-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981271",
+            "direction": 1,
+            "from_stop": 13,
+            "origin": "3980714",
+            "ride_length": 24,
+            "route": "152324",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980714 -> 3981271 on 152324 d1 (stop 13 to stop 1 of a 24-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980714",
+            "direction": 1,
+            "from_stop": 24,
+            "origin": "3980351",
+            "ride_length": 24,
+            "route": "152324",
+            "served": false,
+            "to_stop": 13
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980351 -> 3980714 on 152324 d1 (stop 24 to stop 13 of a 24-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "4015830",
+            "direction": 1,
+            "from_stop": 15,
+            "origin": "3981271",
+            "ride_length": 15,
+            "route": "152324",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981271 -> 4015830 on 152324 d1 (stop 15 to stop 1 of a 15-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "4015830",
+            "direction": 1,
+            "from_stop": 8,
+            "origin": "3980599",
+            "ride_length": 15,
+            "route": "152324",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980599 -> 4015830 on 152324 d1 (stop 8 to stop 1 of a 15-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980599",
+            "direction": 1,
+            "from_stop": 15,
+            "origin": "3981271",
+            "ride_length": 15,
+            "route": "152324",
+            "served": true,
+            "to_stop": 8
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3981271 -> 3980599 on 152324 d1 (stop 15 to stop 8 of a 15-stop ride): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-17-d1-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152324"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3980102",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980004",
+            "ride_length": 20,
+            "route": "152328",
+            "to_stop": 20
+          },
+          "got": {
+            "destination": "3980102",
+            "direction": 0,
+            "origin": "3980004",
+            "route": "152328",
+            "trip": "380786681"
+          },
+          "ok": true,
+          "text": "asked 3980004 -> 3980102 on 152328 d0 (stop 1 to stop 20 of a 20-stop ride): got 3980004 -> 3980102 on 152328 d0, trip 380786681"
+        },
+        {
+          "asked": {
+            "destination": "3979816",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980004",
+            "ride_length": 20,
+            "route": "152328",
+            "to_stop": 11
+          },
+          "got": {
+            "destination": "3979816",
+            "direction": 0,
+            "origin": "3980004",
+            "route": "152328",
+            "trip": "380786681"
+          },
+          "ok": true,
+          "text": "asked 3980004 -> 3979816 on 152328 d0 (stop 1 to stop 11 of a 20-stop ride): got 3980004 -> 3979816 on 152328 d0, trip 380786681"
+        },
+        {
+          "asked": {
+            "destination": "3980102",
+            "direction": 0,
+            "from_stop": 11,
+            "origin": "3979816",
+            "ride_length": 20,
+            "route": "152328",
+            "to_stop": 20
+          },
+          "got": {
+            "destination": "3980102",
+            "direction": 0,
+            "origin": "3979816",
+            "route": "152328",
+            "trip": "380786681"
+          },
+          "ok": true,
+          "text": "asked 3979816 -> 3980102 on 152328 d0 (stop 11 to stop 20 of a 20-stop ride): got 3979816 -> 3980102 on 152328 d0, trip 380786681"
+        },
+        {
+          "asked": {
+            "destination": "3979878",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980102",
+            "ride_length": 23,
+            "route": "152328",
+            "to_stop": 23
+          },
+          "got": {
+            "destination": "3979878",
+            "direction": 0,
+            "origin": "3980102",
+            "route": "152328",
+            "trip": "380799711"
+          },
+          "ok": true,
+          "text": "asked 3980102 -> 3979878 on 152328 d0 (stop 1 to stop 23 of a 23-stop ride): got 3980102 -> 3979878 on 152328 d0, trip 380799711"
+        },
+        {
+          "asked": {
+            "destination": "3980752",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980102",
+            "ride_length": 23,
+            "route": "152328",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "3980752",
+            "direction": 0,
+            "origin": "3980102",
+            "route": "152328",
+            "trip": "380799711"
+          },
+          "ok": true,
+          "text": "asked 3980102 -> 3980752 on 152328 d0 (stop 1 to stop 12 of a 23-stop ride): got 3980102 -> 3980752 on 152328 d0, trip 380799711"
+        },
+        {
+          "asked": {
+            "destination": "3979878",
+            "direction": 0,
+            "from_stop": 12,
+            "origin": "3980752",
+            "ride_length": 23,
+            "route": "152328",
+            "to_stop": 23
+          },
+          "got": {
+            "destination": "3979878",
+            "direction": 0,
+            "origin": "3980752",
+            "route": "152328",
+            "trip": "380799711"
+          },
+          "ok": true,
+          "text": "asked 3980752 -> 3979878 on 152328 d0 (stop 12 to stop 23 of a 23-stop ride): got 3980752 -> 3979878 on 152328 d0, trip 380799711"
+        },
+        {
+          "asked": {
+            "destination": "3980102",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980163",
+            "ride_length": 30,
+            "route": "152328",
+            "to_stop": 30
+          },
+          "got": {
+            "destination": "3980102",
+            "direction": 0,
+            "origin": "3980163",
+            "route": "152328",
+            "trip": "380786506"
+          },
+          "ok": true,
+          "text": "asked 3980163 -> 3980102 on 152328 d0 (stop 1 to stop 30 of a 30-stop ride): got 3980163 -> 3980102 on 152328 d0, trip 380786506"
+        },
+        {
+          "asked": {
+            "destination": "3980831",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3980163",
+            "ride_length": 30,
+            "route": "152328",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "3980831",
+            "direction": 0,
+            "origin": "3980163",
+            "route": "152328",
+            "trip": "380786506"
+          },
+          "ok": true,
+          "text": "asked 3980163 -> 3980831 on 152328 d0 (stop 1 to stop 16 of a 30-stop ride): got 3980163 -> 3980831 on 152328 d0, trip 380786506"
+        },
+        {
+          "asked": {
+            "destination": "3980102",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "3980831",
+            "ride_length": 30,
+            "route": "152328",
+            "to_stop": 30
+          },
+          "got": {
+            "destination": "3980102",
+            "direction": 0,
+            "origin": "3980831",
+            "route": "152328",
+            "trip": "380786681"
+          },
+          "ok": true,
+          "text": "asked 3980831 -> 3980102 on 152328 d0 (stop 16 to stop 30 of a 30-stop ride): got 3980831 -> 3980102 on 152328 d0, trip 380786681"
+        },
+        {
+          "asked": {
+            "destination": "3979878",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981181",
+            "ride_length": 5,
+            "route": "152328",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "3979878",
+            "direction": 0,
+            "origin": "3981181",
+            "route": "152328",
+            "trip": "380799995"
+          },
+          "ok": true,
+          "text": "asked 3981181 -> 3979878 on 152328 d0 (stop 1 to stop 5 of a 5-stop ride): got 3981181 -> 3979878 on 152328 d0, trip 380799995"
+        },
+        {
+          "asked": {
+            "destination": "3980735",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "3981181",
+            "ride_length": 5,
+            "route": "152328",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "3980735",
+            "direction": 0,
+            "origin": "3981181",
+            "route": "152328",
+            "trip": "380799995"
+          },
+          "ok": true,
+          "text": "asked 3981181 -> 3980735 on 152328 d0 (stop 1 to stop 3 of a 5-stop ride): got 3981181 -> 3980735 on 152328 d0, trip 380799995"
+        },
+        {
+          "asked": {
+            "destination": "3979878",
+            "direction": 0,
+            "from_stop": 3,
+            "origin": "3980735",
+            "ride_length": 5,
+            "route": "152328",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "3979878",
+            "direction": 0,
+            "origin": "3980735",
+            "route": "152328",
+            "trip": "380799995"
+          },
+          "ok": true,
+          "text": "asked 3980735 -> 3979878 on 152328 d0 (stop 3 to stop 5 of a 5-stop ride): got 3980735 -> 3979878 on 152328 d0, trip 380799995"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-7-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152328"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": false,
+          "text": "the list offers one station twice in a row [('3980060', '3980854')]"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980163 .. 3980102"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980004 .. 3980102"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": false,
+          "text": "the list contradicts the riding order 3980102 .. 3979878"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3981181 .. 3979878"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-7-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "route": "152328"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3980004",
+            "direction": 0,
+            "from_stop": 20,
+            "origin": "3980102",
+            "ride_length": 20,
+            "route": "152328",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980102 -> 3980004 on 152328 d0 (stop 20 to stop 1 of a 20-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980004",
+            "direction": 0,
+            "from_stop": 11,
+            "origin": "3979816",
+            "ride_length": 20,
+            "route": "152328",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979816 -> 3980004 on 152328 d0 (stop 11 to stop 1 of a 20-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979816",
+            "direction": 0,
+            "from_stop": 20,
+            "origin": "3980102",
+            "ride_length": 20,
+            "route": "152328",
+            "served": true,
+            "to_stop": 11
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980102 -> 3979816 on 152328 d0 (stop 20 to stop 11 of a 20-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980102",
+            "direction": 0,
+            "from_stop": 23,
+            "origin": "3979878",
+            "ride_length": 23,
+            "route": "152328",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "3980102",
+            "direction": 1,
+            "origin": "3979878",
+            "route": "152328",
+            "trip": "380799628"
+          },
+          "ok": false,
+          "text": "asked 3979878 -> 3980102 on 152328 d0 (stop 23 to stop 1 of a 23-stop ride, this direction does not make it): got 3979878 -> 3980102 on 152328 d1, trip 380799628"
+        },
+        {
+          "asked": {
+            "destination": "3980102",
+            "direction": 0,
+            "from_stop": 12,
+            "origin": "3980752",
+            "ride_length": 23,
+            "route": "152328",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980752 -> 3980102 on 152328 d0 (stop 12 to stop 1 of a 23-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980752",
+            "direction": 0,
+            "from_stop": 23,
+            "origin": "3979878",
+            "ride_length": 23,
+            "route": "152328",
+            "served": false,
+            "to_stop": 12
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979878 -> 3980752 on 152328 d0 (stop 23 to stop 12 of a 23-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980163",
+            "direction": 0,
+            "from_stop": 30,
+            "origin": "3980102",
+            "ride_length": 30,
+            "route": "152328",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980102 -> 3980163 on 152328 d0 (stop 30 to stop 1 of a 30-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980163",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "3980831",
+            "ride_length": 30,
+            "route": "152328",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980831 -> 3980163 on 152328 d0 (stop 16 to stop 1 of a 30-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980831",
+            "direction": 0,
+            "from_stop": 30,
+            "origin": "3980102",
+            "ride_length": 30,
+            "route": "152328",
+            "served": true,
+            "to_stop": 16
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980102 -> 3980831 on 152328 d0 (stop 30 to stop 16 of a 30-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981181",
+            "direction": 0,
+            "from_stop": 5,
+            "origin": "3979878",
+            "ride_length": 5,
+            "route": "152328",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979878 -> 3981181 on 152328 d0 (stop 5 to stop 1 of a 5-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981181",
+            "direction": 0,
+            "from_stop": 3,
+            "origin": "3980735",
+            "ride_length": 5,
+            "route": "152328",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980735 -> 3981181 on 152328 d0 (stop 3 to stop 1 of a 5-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980735",
+            "direction": 0,
+            "from_stop": 5,
+            "origin": "3979878",
+            "ride_length": 5,
+            "route": "152328",
+            "served": false,
+            "to_stop": 3
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979878 -> 3980735 on 152328 d0 (stop 5 to stop 3 of a 5-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-7-d0-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "152328"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3980102",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3979878",
+            "ride_length": 24,
+            "route": "152328",
+            "to_stop": 24
+          },
+          "got": {
+            "destination": "3980102",
+            "direction": 1,
+            "origin": "3979878",
+            "route": "152328",
+            "trip": "380799628"
+          },
+          "ok": true,
+          "text": "asked 3979878 -> 3980102 on 152328 d1 (stop 1 to stop 24 of a 24-stop ride): got 3979878 -> 3980102 on 152328 d1, trip 380799628"
+        },
+        {
+          "asked": {
+            "destination": "3980270",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3979878",
+            "ride_length": 24,
+            "route": "152328",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "3980270",
+            "direction": 1,
+            "origin": "3979878",
+            "route": "152328",
+            "trip": "380799628"
+          },
+          "ok": true,
+          "text": "asked 3979878 -> 3980270 on 152328 d1 (stop 1 to stop 13 of a 24-stop ride): got 3979878 -> 3980270 on 152328 d1, trip 380799628"
+        },
+        {
+          "asked": {
+            "destination": "3980102",
+            "direction": 1,
+            "from_stop": 13,
+            "origin": "3980270",
+            "ride_length": 24,
+            "route": "152328",
+            "to_stop": 24
+          },
+          "got": {
+            "destination": "3980102",
+            "direction": 1,
+            "origin": "3980270",
+            "route": "152328",
+            "trip": "380799801"
+          },
+          "ok": true,
+          "text": "asked 3980270 -> 3980102 on 152328 d1 (stop 13 to stop 24 of a 24-stop ride): got 3980270 -> 3980102 on 152328 d1, trip 380799801"
+        },
+        {
+          "asked": {
+            "destination": "3980102",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980004",
+            "ride_length": 20,
+            "route": "152328",
+            "to_stop": 20
+          },
+          "got": {
+            "destination": "3980102",
+            "direction": 1,
+            "origin": "3980004",
+            "route": "152328",
+            "trip": "380799801"
+          },
+          "ok": true,
+          "text": "asked 3980004 -> 3980102 on 152328 d1 (stop 1 to stop 20 of a 20-stop ride): got 3980004 -> 3980102 on 152328 d1, trip 380799801"
+        },
+        {
+          "asked": {
+            "destination": "3979816",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980004",
+            "ride_length": 20,
+            "route": "152328",
+            "to_stop": 11
+          },
+          "got": {
+            "destination": "3979816",
+            "direction": 1,
+            "origin": "3980004",
+            "route": "152328",
+            "trip": "380799801"
+          },
+          "ok": true,
+          "text": "asked 3980004 -> 3979816 on 152328 d1 (stop 1 to stop 11 of a 20-stop ride): got 3980004 -> 3979816 on 152328 d1, trip 380799801"
+        },
+        {
+          "asked": {
+            "destination": "3980102",
+            "direction": 1,
+            "from_stop": 11,
+            "origin": "3979816",
+            "ride_length": 20,
+            "route": "152328",
+            "to_stop": 20
+          },
+          "got": {
+            "destination": "3980102",
+            "direction": 1,
+            "origin": "3979816",
+            "route": "152328",
+            "trip": "380799801"
+          },
+          "ok": true,
+          "text": "asked 3979816 -> 3980102 on 152328 d1 (stop 11 to stop 20 of a 20-stop ride): got 3979816 -> 3980102 on 152328 d1, trip 380799801"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980102",
+            "ride_length": 29,
+            "route": "152328",
+            "to_stop": 29
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 1,
+            "origin": "3980102",
+            "route": "152328",
+            "trip": "380786518"
+          },
+          "ok": true,
+          "text": "asked 3980102 -> 3980992 on 152328 d1 (stop 1 to stop 29 of a 29-stop ride): got 3980102 -> 3980992 on 152328 d1, trip 380786518"
+        },
+        {
+          "asked": {
+            "destination": "3980182",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3980102",
+            "ride_length": 29,
+            "route": "152328",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "3980182",
+            "direction": 1,
+            "origin": "3980102",
+            "route": "152328",
+            "trip": "380786518"
+          },
+          "ok": true,
+          "text": "asked 3980102 -> 3980182 on 152328 d1 (stop 1 to stop 15 of a 29-stop ride): got 3980102 -> 3980182 on 152328 d1, trip 380786518"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 1,
+            "from_stop": 15,
+            "origin": "3980182",
+            "ride_length": 29,
+            "route": "152328",
+            "to_stop": 29
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 1,
+            "origin": "3980182",
+            "route": "152328",
+            "trip": "380786518"
+          },
+          "ok": true,
+          "text": "asked 3980182 -> 3980992 on 152328 d1 (stop 15 to stop 29 of a 29-stop ride): got 3980182 -> 3980992 on 152328 d1, trip 380786518"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3981181",
+            "ride_length": 11,
+            "route": "152328",
+            "to_stop": 11
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 1,
+            "origin": "3981181",
+            "route": "152328",
+            "trip": "380786685"
+          },
+          "ok": true,
+          "text": "asked 3981181 -> 3980992 on 152328 d1 (stop 1 to stop 11 of a 11-stop ride): got 3981181 -> 3980992 on 152328 d1, trip 380786685"
+        },
+        {
+          "asked": {
+            "destination": "4015723",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "3981181",
+            "ride_length": 11,
+            "route": "152328",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "4015723",
+            "direction": 1,
+            "origin": "3981181",
+            "route": "152328",
+            "trip": "380786685"
+          },
+          "ok": true,
+          "text": "asked 3981181 -> 4015723 on 152328 d1 (stop 1 to stop 6 of a 11-stop ride): got 3981181 -> 4015723 on 152328 d1, trip 380786685"
+        },
+        {
+          "asked": {
+            "destination": "3980992",
+            "direction": 1,
+            "from_stop": 6,
+            "origin": "4015723",
+            "ride_length": 11,
+            "route": "152328",
+            "to_stop": 11
+          },
+          "got": {
+            "destination": "3980992",
+            "direction": 1,
+            "origin": "4015723",
+            "route": "152328",
+            "trip": "380786685"
+          },
+          "ok": true,
+          "text": "asked 4015723 -> 3980992 on 152328 d1 (stop 6 to stop 11 of a 11-stop ride): got 4015723 -> 3980992 on 152328 d1, trip 380786685"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-7-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152328"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": false,
+          "text": "the list offers one station twice in a row [('3980752', '3981140')]"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": false,
+          "text": "the list contradicts the riding order 3980102 .. 3980992"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3981181 .. 3980992"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3979878 .. 3980102"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order 3980004 .. 3980102"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-7-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "route": "152328"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "3979878",
+            "direction": 1,
+            "from_stop": 24,
+            "origin": "3980102",
+            "ride_length": 24,
+            "route": "152328",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "3979878",
+            "direction": 0,
+            "origin": "3980102",
+            "route": "152328",
+            "trip": "380799711"
+          },
+          "ok": false,
+          "text": "asked 3980102 -> 3979878 on 152328 d1 (stop 24 to stop 1 of a 24-stop ride, this direction does not make it): got 3980102 -> 3979878 on 152328 d0, trip 380799711"
+        },
+        {
+          "asked": {
+            "destination": "3979878",
+            "direction": 1,
+            "from_stop": 13,
+            "origin": "3980270",
+            "ride_length": 24,
+            "route": "152328",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980270 -> 3979878 on 152328 d1 (stop 13 to stop 1 of a 24-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980270",
+            "direction": 1,
+            "from_stop": 24,
+            "origin": "3980102",
+            "ride_length": 24,
+            "route": "152328",
+            "served": false,
+            "to_stop": 13
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980102 -> 3980270 on 152328 d1 (stop 24 to stop 13 of a 24-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980004",
+            "direction": 1,
+            "from_stop": 20,
+            "origin": "3980102",
+            "ride_length": 20,
+            "route": "152328",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980102 -> 3980004 on 152328 d1 (stop 20 to stop 1 of a 20-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980004",
+            "direction": 1,
+            "from_stop": 11,
+            "origin": "3979816",
+            "ride_length": 20,
+            "route": "152328",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3979816 -> 3980004 on 152328 d1 (stop 11 to stop 1 of a 20-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3979816",
+            "direction": 1,
+            "from_stop": 20,
+            "origin": "3980102",
+            "ride_length": 20,
+            "route": "152328",
+            "served": true,
+            "to_stop": 11
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980102 -> 3979816 on 152328 d1 (stop 20 to stop 11 of a 20-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980102",
+            "direction": 1,
+            "from_stop": 29,
+            "origin": "3980992",
+            "ride_length": 29,
+            "route": "152328",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 3980102 on 152328 d1 (stop 29 to stop 1 of a 29-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980102",
+            "direction": 1,
+            "from_stop": 15,
+            "origin": "3980182",
+            "ride_length": 29,
+            "route": "152328",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980182 -> 3980102 on 152328 d1 (stop 15 to stop 1 of a 29-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3980182",
+            "direction": 1,
+            "from_stop": 29,
+            "origin": "3980992",
+            "ride_length": 29,
+            "route": "152328",
+            "served": false,
+            "to_stop": 15
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 3980182 on 152328 d1 (stop 29 to stop 15 of a 29-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981181",
+            "direction": 1,
+            "from_stop": 11,
+            "origin": "3980992",
+            "ride_length": 11,
+            "route": "152328",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 3981181 on 152328 d1 (stop 11 to stop 1 of a 11-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "3981181",
+            "direction": 1,
+            "from_stop": 6,
+            "origin": "4015723",
+            "ride_length": 11,
+            "route": "152328",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 4015723 -> 3981181 on 152328 d1 (stop 6 to stop 1 of a 11-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "4015723",
+            "direction": 1,
+            "from_stop": 11,
+            "origin": "3980992",
+            "ride_length": 11,
+            "route": "152328",
+            "served": false,
+            "to_stop": 6
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked 3980992 -> 4015723 on 152328 d1 (stop 11 to stop 6 of a 11-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-7-d1-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "152328"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "HDV08R",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "HDV08A",
+            "ride_length": 26,
+            "route": "21",
+            "to_stop": 26
+          },
+          "got": {
+            "destination": "HDV08R",
+            "direction": 0,
+            "origin": "HDV08A",
+            "route": "21",
+            "trip": "14183637641000"
+          },
+          "ok": true,
+          "text": "asked HDV08A -> HDV08R on 21 d0 (stop 1 to stop 26 of a 26-stop ride): got HDV08A -> HDV08R on 21 d0, trip 14183637641000"
+        },
+        {
+          "asked": {
+            "destination": "GAZ01B",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "HDV08A",
+            "ride_length": 26,
+            "route": "21",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "GAZ01B",
+            "direction": 0,
+            "origin": "HDV08A",
+            "route": "21",
+            "trip": "14183637641000"
+          },
+          "ok": true,
+          "text": "asked HDV08A -> GAZ01B on 21 d0 (stop 1 to stop 14 of a 26-stop ride): got HDV08A -> GAZ01B on 21 d0, trip 14183637641000"
+        },
+        {
+          "asked": {
+            "destination": "HDV08R",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "GAZ01B",
+            "ride_length": 26,
+            "route": "21",
+            "to_stop": 26
+          },
+          "got": {
+            "destination": "HDV08R",
+            "direction": 0,
+            "origin": "GAZ01B",
+            "route": "21",
+            "trip": "14183637641000"
+          },
+          "ok": true,
+          "text": "asked GAZ01B -> HDV08R on 21 d0 (stop 14 to stop 26 of a 26-stop ride): got GAZ01B -> HDV08R on 21 d0, trip 14183637641000"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-21-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "21"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order HDV08A .. HDV08R"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-21-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "passed",
+      "reason": null,
+      "route": "21"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "HDV08A",
+            "direction": 0,
+            "from_stop": 26,
+            "origin": "HDV08R",
+            "ride_length": 26,
+            "route": "21",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked HDV08R -> HDV08A on 21 d0 (stop 26 to stop 1 of a 26-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "HDV08A",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "GAZ01B",
+            "ride_length": 26,
+            "route": "21",
+            "served": true,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GAZ01B -> HDV08A on 21 d0 (stop 14 to stop 1 of a 26-stop ride): no departure"
+        },
+        {
+          "asked": {
+            "destination": "GAZ01B",
+            "direction": 0,
+            "from_stop": 26,
+            "origin": "HDV08R",
+            "ride_length": 26,
+            "route": "21",
+            "served": true,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked HDV08R -> GAZ01B on 21 d0 (stop 26 to stop 14 of a 26-stop ride): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-21-d0-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "21"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "THEC0A",
+            "ride_length": 27,
+            "route": "22",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "origin": "THEC0A",
+            "route": "22",
+            "trip": "14369421591943"
+          },
+          "ok": true,
+          "text": "asked THEC0A -> GSNF0R on 22 d0 (stop 1 to stop 27 of a 27-stop ride): got THEC0A -> GSNF0R on 22 d0, trip 14369421591943"
+        },
+        {
+          "asked": {
+            "destination": "KI310A",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "THEC0A",
+            "ride_length": 27,
+            "route": "22",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "KI310A",
+            "direction": 0,
+            "origin": "THEC0A",
+            "route": "22",
+            "trip": "14369421591943"
+          },
+          "ok": true,
+          "text": "asked THEC0A -> KI310A on 22 d0 (stop 1 to stop 14 of a 27-stop ride): got THEC0A -> KI310A on 22 d0, trip 14369421591943"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "KI310A",
+            "ride_length": 27,
+            "route": "22",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "origin": "KI310A",
+            "route": "22",
+            "trip": "14369421591943"
+          },
+          "ok": true,
+          "text": "asked KI310A -> GSNF0R on 22 d0 (stop 14 to stop 27 of a 27-stop ride): got KI310A -> GSNF0R on 22 d0, trip 14369421591943"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "TRAY0R",
+            "ride_length": 39,
+            "route": "22",
+            "to_stop": 39
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "origin": "TRAY0R",
+            "route": "22",
+            "trip": "14183637641125"
+          },
+          "ok": true,
+          "text": "asked TRAY0R -> GSNF0R on 22 d0 (stop 1 to stop 39 of a 39-stop ride): got TRAY0R -> GSNF0R on 22 d0, trip 14183637641125"
+        },
+        {
+          "asked": {
+            "destination": "RPO16A",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "TRAY0R",
+            "ride_length": 39,
+            "route": "22",
+            "to_stop": 20
+          },
+          "got": {
+            "destination": "RPO16A",
+            "direction": 0,
+            "origin": "TRAY0R",
+            "route": "22",
+            "trip": "14183637641125"
+          },
+          "ok": true,
+          "text": "asked TRAY0R -> RPO16A on 22 d0 (stop 1 to stop 20 of a 39-stop ride): got TRAY0R -> RPO16A on 22 d0, trip 14183637641125"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "from_stop": 20,
+            "origin": "RPO16A",
+            "ride_length": 39,
+            "route": "22",
+            "to_stop": 39
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "origin": "RPO16A",
+            "route": "22",
+            "trip": "1418363764269"
+          },
+          "ok": true,
+          "text": "asked RPO16A -> GSNF0R on 22 d0 (stop 20 to stop 39 of a 39-stop ride): got RPO16A -> GSNF0R on 22 d0, trip 1418363764269"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-22-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "22"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order TRAY0R .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order THEC0A .. GSNF0R"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-22-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "route": "22"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "THEC0A",
+            "direction": 0,
+            "from_stop": 27,
+            "origin": "GSNF0R",
+            "ride_length": 27,
+            "route": "22",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GSNF0R -> THEC0A on 22 d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "THEC0A",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "KI310A",
+            "ride_length": 27,
+            "route": "22",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked KI310A -> THEC0A on 22 d0 (stop 14 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "KI310A",
+            "direction": 0,
+            "from_stop": 27,
+            "origin": "GSNF0R",
+            "ride_length": 27,
+            "route": "22",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GSNF0R -> KI310A on 22 d0 (stop 27 to stop 14 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "TRAY0R",
+            "direction": 0,
+            "from_stop": 39,
+            "origin": "GSNF0R",
+            "ride_length": 39,
+            "route": "22",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GSNF0R -> TRAY0R on 22 d0 (stop 39 to stop 1 of a 39-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "TRAY0R",
+            "direction": 0,
+            "from_stop": 20,
+            "origin": "RPO16A",
+            "ride_length": 39,
+            "route": "22",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked RPO16A -> TRAY0R on 22 d0 (stop 20 to stop 1 of a 39-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "RPO16A",
+            "direction": 0,
+            "from_stop": 39,
+            "origin": "GSNF0R",
+            "ride_length": 39,
+            "route": "22",
+            "served": false,
+            "to_stop": 20
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GSNF0R -> RPO16A on 22 d0 (stop 39 to stop 20 of a 39-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-22-d0-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "22"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "THEC0Z",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "GSNF0R",
+            "ride_length": 26,
+            "route": "22",
+            "to_stop": 26
+          },
+          "got": {
+            "destination": "THEC0Z",
+            "direction": 1,
+            "origin": "GSNF0R",
+            "route": "22",
+            "trip": "14369421591674"
+          },
+          "ok": true,
+          "text": "asked GSNF0R -> THEC0Z on 22 d1 (stop 1 to stop 26 of a 26-stop ride): got GSNF0R -> THEC0Z on 22 d1, trip 14369421591674"
+        },
+        {
+          "asked": {
+            "destination": "CMID0R",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "GSNF0R",
+            "ride_length": 26,
+            "route": "22",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "CMID0R",
+            "direction": 1,
+            "origin": "GSNF0R",
+            "route": "22",
+            "trip": "14369421591674"
+          },
+          "ok": true,
+          "text": "asked GSNF0R -> CMID0R on 22 d1 (stop 1 to stop 14 of a 26-stop ride): got GSNF0R -> CMID0R on 22 d1, trip 14369421591674"
+        },
+        {
+          "asked": {
+            "destination": "THEC0Z",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "CMID0R",
+            "ride_length": 26,
+            "route": "22",
+            "to_stop": 26
+          },
+          "got": {
+            "destination": "THEC0Z",
+            "direction": 1,
+            "origin": "CMID0R",
+            "route": "22",
+            "trip": "14369421591674"
+          },
+          "ok": true,
+          "text": "asked CMID0R -> THEC0Z on 22 d1 (stop 14 to stop 26 of a 26-stop ride): got CMID0R -> THEC0Z on 22 d1, trip 14369421591674"
+        },
+        {
+          "asked": {
+            "destination": "TRAY0A",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "GSNF0R",
+            "ride_length": 38,
+            "route": "22",
+            "to_stop": 38
+          },
+          "got": {
+            "destination": "TRAY0A",
+            "direction": 1,
+            "origin": "GSNF0R",
+            "route": "22",
+            "trip": "1418363764259"
+          },
+          "ok": true,
+          "text": "asked GSNF0R -> TRAY0A on 22 d1 (stop 1 to stop 38 of a 38-stop ride): got GSNF0R -> TRAY0A on 22 d1, trip 1418363764259"
+        },
+        {
+          "asked": {
+            "destination": "PNA16R",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "GSNF0R",
+            "ride_length": 38,
+            "route": "22",
+            "to_stop": 20
+          },
+          "got": {
+            "destination": "PNA16R",
+            "direction": 1,
+            "origin": "GSNF0R",
+            "route": "22",
+            "trip": "1418363764259"
+          },
+          "ok": true,
+          "text": "asked GSNF0R -> PNA16R on 22 d1 (stop 1 to stop 20 of a 38-stop ride): got GSNF0R -> PNA16R on 22 d1, trip 1418363764259"
+        },
+        {
+          "asked": {
+            "destination": "TRAY0A",
+            "direction": 1,
+            "from_stop": 20,
+            "origin": "PNA16R",
+            "ride_length": 38,
+            "route": "22",
+            "to_stop": 38
+          },
+          "got": {
+            "destination": "TRAY0A",
+            "direction": 1,
+            "origin": "PNA16R",
+            "route": "22",
+            "trip": "1418363764259"
+          },
+          "ok": true,
+          "text": "asked PNA16R -> TRAY0A on 22 d1 (stop 20 to stop 38 of a 38-stop ride): got PNA16R -> TRAY0A on 22 d1, trip 1418363764259"
+        }
+      ],
+      "direction": 1,
+      "fixture": "palmbus",
+      "id": "palmbus-22-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "22"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order GSNF0R .. TRAY0A"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order GSNF0R .. THEC0Z"
+        }
+      ],
+      "direction": 1,
+      "fixture": "palmbus",
+      "id": "palmbus-22-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "passed",
+      "reason": null,
+      "route": "22"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "from_stop": 26,
+            "origin": "THEC0Z",
+            "ride_length": 26,
+            "route": "22",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked THEC0Z -> GSNF0R on 22 d1 (stop 26 to stop 1 of a 26-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "CMID0R",
+            "ride_length": 26,
+            "route": "22",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked CMID0R -> GSNF0R on 22 d1 (stop 14 to stop 1 of a 26-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "CMID0R",
+            "direction": 1,
+            "from_stop": 26,
+            "origin": "THEC0Z",
+            "ride_length": 26,
+            "route": "22",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked THEC0Z -> CMID0R on 22 d1 (stop 26 to stop 14 of a 26-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "from_stop": 38,
+            "origin": "TRAY0A",
+            "ride_length": 38,
+            "route": "22",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked TRAY0A -> GSNF0R on 22 d1 (stop 38 to stop 1 of a 38-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "from_stop": 20,
+            "origin": "PNA16R",
+            "ride_length": 38,
+            "route": "22",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked PNA16R -> GSNF0R on 22 d1 (stop 20 to stop 1 of a 38-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "PNA16R",
+            "direction": 1,
+            "from_stop": 38,
+            "origin": "TRAY0A",
+            "ride_length": 38,
+            "route": "22",
+            "served": false,
+            "to_stop": 20
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked TRAY0A -> PNA16R on 22 d1 (stop 38 to stop 20 of a 38-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "palmbus",
+      "id": "palmbus-22-d1-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "22"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "GSNF0A",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "CCO15A",
+            "ride_length": 35,
+            "route": "A",
+            "to_stop": 35
+          },
+          "got": {
+            "destination": "GSNF0A",
+            "direction": 0,
+            "origin": "CCO15A",
+            "route": "A",
+            "trip": "1418363764404"
+          },
+          "ok": true,
+          "text": "asked CCO15A -> GSNF0A on A d0 (stop 1 to stop 35 of a 35-stop ride): got CCO15A -> GSNF0A on A d0, trip 1418363764404"
+        },
+        {
+          "asked": {
+            "destination": "COU0AR",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "CCO15A",
+            "ride_length": 35,
+            "route": "A",
+            "to_stop": 18
+          },
+          "got": {
+            "destination": "COU0AR",
+            "direction": 0,
+            "origin": "CCO15A",
+            "route": "A",
+            "trip": "1418363764404"
+          },
+          "ok": true,
+          "text": "asked CCO15A -> COU0AR on A d0 (stop 1 to stop 18 of a 35-stop ride): got CCO15A -> COU0AR on A d0, trip 1418363764404"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0A",
+            "direction": 0,
+            "from_stop": 18,
+            "origin": "COU0AR",
+            "ride_length": 35,
+            "route": "A",
+            "to_stop": 35
+          },
+          "got": {
+            "destination": "GSNF0A",
+            "direction": 0,
+            "origin": "COU0AR",
+            "route": "A",
+            "trip": "1418363764404"
+          },
+          "ok": true,
+          "text": "asked COU0AR -> GSNF0A on A d0 (stop 18 to stop 35 of a 35-stop ride): got COU0AR -> GSNF0A on A d0, trip 1418363764404"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-A-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "A"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order CCO15A .. GSNF0A"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-A-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "passed",
+      "reason": null,
+      "route": "A"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "CCO15A",
+            "direction": 0,
+            "from_stop": 35,
+            "origin": "GSNF0A",
+            "ride_length": 35,
+            "route": "A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "CCO15A",
+            "direction": 1,
+            "origin": "GSNF0A",
+            "route": "A",
+            "trip": "1418363764878"
+          },
+          "ok": false,
+          "text": "asked GSNF0A -> CCO15A on A d0 (stop 35 to stop 1 of a 35-stop ride, this direction does not make it): got GSNF0A -> CCO15A on A d1, trip 1418363764878"
+        },
+        {
+          "asked": {
+            "destination": "CCO15A",
+            "direction": 0,
+            "from_stop": 18,
+            "origin": "COU0AR",
+            "ride_length": 35,
+            "route": "A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked COU0AR -> CCO15A on A d0 (stop 18 to stop 1 of a 35-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "COU0AR",
+            "direction": 0,
+            "from_stop": 35,
+            "origin": "GSNF0A",
+            "ride_length": 35,
+            "route": "A",
+            "served": false,
+            "to_stop": 18
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GSNF0A -> COU0AR on A d0 (stop 35 to stop 18 of a 35-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-A-d0-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "A"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "CCO15A",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "GSNF0A",
+            "ride_length": 36,
+            "route": "A",
+            "to_stop": 36
+          },
+          "got": {
+            "destination": "CCO15A",
+            "direction": 1,
+            "origin": "GSNF0A",
+            "route": "A",
+            "trip": "1418363764878"
+          },
+          "ok": true,
+          "text": "asked GSNF0A -> CCO15A on A d1 (stop 1 to stop 36 of a 36-stop ride): got GSNF0A -> CCO15A on A d1, trip 1418363764878"
+        },
+        {
+          "asked": {
+            "destination": "PPO20A",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "GSNF0A",
+            "ride_length": 36,
+            "route": "A",
+            "to_stop": 19
+          },
+          "got": {
+            "destination": "PPO20A",
+            "direction": 1,
+            "origin": "GSNF0A",
+            "route": "A",
+            "trip": "1418363764878"
+          },
+          "ok": true,
+          "text": "asked GSNF0A -> PPO20A on A d1 (stop 1 to stop 19 of a 36-stop ride): got GSNF0A -> PPO20A on A d1, trip 1418363764878"
+        },
+        {
+          "asked": {
+            "destination": "CCO15A",
+            "direction": 1,
+            "from_stop": 19,
+            "origin": "PPO20A",
+            "ride_length": 36,
+            "route": "A",
+            "to_stop": 36
+          },
+          "got": {
+            "destination": "CCO15A",
+            "direction": 1,
+            "origin": "PPO20A",
+            "route": "A",
+            "trip": "1418363764878"
+          },
+          "ok": true,
+          "text": "asked PPO20A -> CCO15A on A d1 (stop 19 to stop 36 of a 36-stop ride): got PPO20A -> CCO15A on A d1, trip 1418363764878"
+        }
+      ],
+      "direction": 1,
+      "fixture": "palmbus",
+      "id": "palmbus-A-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "A"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order GSNF0A .. CCO15A"
+        }
+      ],
+      "direction": 1,
+      "fixture": "palmbus",
+      "id": "palmbus-A-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "passed",
+      "reason": null,
+      "route": "A"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "GSNF0A",
+            "direction": 1,
+            "from_stop": 36,
+            "origin": "CCO15A",
+            "ride_length": 36,
+            "route": "A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "GSNF0A",
+            "direction": 0,
+            "origin": "CCO15A",
+            "route": "A",
+            "trip": "1418363764404"
+          },
+          "ok": false,
+          "text": "asked CCO15A -> GSNF0A on A d1 (stop 36 to stop 1 of a 36-stop ride, this direction does not make it): got CCO15A -> GSNF0A on A d0, trip 1418363764404"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0A",
+            "direction": 1,
+            "from_stop": 19,
+            "origin": "PPO20A",
+            "ride_length": 36,
+            "route": "A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked PPO20A -> GSNF0A on A d1 (stop 19 to stop 1 of a 36-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "PPO20A",
+            "direction": 1,
+            "from_stop": 36,
+            "origin": "CCO15A",
+            "ride_length": 36,
+            "route": "A",
+            "served": false,
+            "to_stop": 19
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked CCO15A -> PPO20A on A d1 (stop 36 to stop 19 of a 36-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "palmbus",
+      "id": "palmbus-A-d1-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "A"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "BLAN0D",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "GSNF0R",
+            "ride_length": 17,
+            "route": "B",
+            "to_stop": 17
+          },
+          "got": {
+            "destination": "BLAN0D",
+            "direction": 0,
+            "origin": "GSNF0R",
+            "route": "B",
+            "trip": "14369421592922"
+          },
+          "ok": true,
+          "text": "asked GSNF0R -> BLAN0D on B d0 (stop 1 to stop 17 of a 17-stop ride): got GSNF0R -> BLAN0D on B d0, trip 14369421592922"
+        },
+        {
+          "asked": {
+            "destination": "NDAN6R",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "GSNF0R",
+            "ride_length": 17,
+            "route": "B",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "NDAN6R",
+            "direction": 0,
+            "origin": "GSNF0R",
+            "route": "B",
+            "trip": "14369421592922"
+          },
+          "ok": true,
+          "text": "asked GSNF0R -> NDAN6R on B d0 (stop 1 to stop 9 of a 17-stop ride): got GSNF0R -> NDAN6R on B d0, trip 14369421592922"
+        },
+        {
+          "asked": {
+            "destination": "BLAN0D",
+            "direction": 0,
+            "from_stop": 9,
+            "origin": "NDAN6R",
+            "ride_length": 17,
+            "route": "B",
+            "to_stop": 17
+          },
+          "got": {
+            "destination": "BLAN0D",
+            "direction": 0,
+            "origin": "NDAN6R",
+            "route": "B",
+            "trip": "14369421592922"
+          },
+          "ok": true,
+          "text": "asked NDAN6R -> BLAN0D on B d0 (stop 9 to stop 17 of a 17-stop ride): got NDAN6R -> BLAN0D on B d0, trip 14369421592922"
+        },
+        {
+          "asked": {
+            "destination": "TOUR0R",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "GSNF0R",
+            "ride_length": 25,
+            "route": "B",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "TOUR0R",
+            "direction": 0,
+            "origin": "GSNF0R",
+            "route": "B",
+            "trip": "14369421592922"
+          },
+          "ok": true,
+          "text": "asked GSNF0R -> TOUR0R on B d0 (stop 1 to stop 25 of a 25-stop ride): got GSNF0R -> TOUR0R on B d0, trip 14369421592922"
+        },
+        {
+          "asked": {
+            "destination": "LIC01R",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "GSNF0R",
+            "ride_length": 25,
+            "route": "B",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "LIC01R",
+            "direction": 0,
+            "origin": "GSNF0R",
+            "route": "B",
+            "trip": "14369421592922"
+          },
+          "ok": true,
+          "text": "asked GSNF0R -> LIC01R on B d0 (stop 1 to stop 13 of a 25-stop ride): got GSNF0R -> LIC01R on B d0, trip 14369421592922"
+        },
+        {
+          "asked": {
+            "destination": "TOUR0R",
+            "direction": 0,
+            "from_stop": 13,
+            "origin": "LIC01R",
+            "ride_length": 25,
+            "route": "B",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "TOUR0R",
+            "direction": 0,
+            "origin": "LIC01R",
+            "route": "B",
+            "trip": "14369421592922"
+          },
+          "ok": true,
+          "text": "asked LIC01R -> TOUR0R on B d0 (stop 13 to stop 25 of a 25-stop ride): got LIC01R -> TOUR0R on B d0, trip 14369421592922"
+        },
+        {
+          "asked": {
+            "destination": "MSCE0A",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "GSNF0R",
+            "ride_length": 29,
+            "route": "B",
+            "to_stop": 29
+          },
+          "got": {
+            "destination": "MSCE0A",
+            "direction": 0,
+            "origin": "GSNF0R",
+            "route": "B",
+            "trip": "1418363764271"
+          },
+          "ok": true,
+          "text": "asked GSNF0R -> MSCE0A on B d0 (stop 1 to stop 29 of a 29-stop ride): got GSNF0R -> MSCE0A on B d0, trip 1418363764271"
+        },
+        {
+          "asked": {
+            "destination": "CJA01R",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "GSNF0R",
+            "ride_length": 29,
+            "route": "B",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "CJA01R",
+            "direction": 0,
+            "origin": "GSNF0R",
+            "route": "B",
+            "trip": "1418363764271"
+          },
+          "ok": true,
+          "text": "asked GSNF0R -> CJA01R on B d0 (stop 1 to stop 15 of a 29-stop ride): got GSNF0R -> CJA01R on B d0, trip 1418363764271"
+        },
+        {
+          "asked": {
+            "destination": "MSCE0A",
+            "direction": 0,
+            "from_stop": 15,
+            "origin": "CJA01R",
+            "ride_length": 29,
+            "route": "B",
+            "to_stop": 29
+          },
+          "got": {
+            "destination": "MSCE0A",
+            "direction": 0,
+            "origin": "CJA01R",
+            "route": "B",
+            "trip": "1418363764271"
+          },
+          "ok": true,
+          "text": "asked CJA01R -> MSCE0A on B d0 (stop 15 to stop 29 of a 29-stop ride): got CJA01R -> MSCE0A on B d0, trip 1418363764271"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-B-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "B"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order GSNF0R .. MSCE0A"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order GSNF0R .. BLAN0D"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order GSNF0R .. TOUR0R"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-B-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "passed",
+      "reason": null,
+      "route": "B"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "from_stop": 17,
+            "origin": "BLAN0D",
+            "ride_length": 17,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked BLAN0D -> GSNF0R on B d0 (stop 17 to stop 1 of a 17-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "from_stop": 9,
+            "origin": "NDAN6R",
+            "ride_length": 17,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked NDAN6R -> GSNF0R on B d0 (stop 9 to stop 1 of a 17-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "NDAN6R",
+            "direction": 0,
+            "from_stop": 17,
+            "origin": "BLAN0D",
+            "ride_length": 17,
+            "route": "B",
+            "served": false,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked BLAN0D -> NDAN6R on B d0 (stop 17 to stop 9 of a 17-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "from_stop": 25,
+            "origin": "TOUR0R",
+            "ride_length": 25,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked TOUR0R -> GSNF0R on B d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "from_stop": 13,
+            "origin": "LIC01R",
+            "ride_length": 25,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked LIC01R -> GSNF0R on B d0 (stop 13 to stop 1 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "LIC01R",
+            "direction": 0,
+            "from_stop": 25,
+            "origin": "TOUR0R",
+            "ride_length": 25,
+            "route": "B",
+            "served": false,
+            "to_stop": 13
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked TOUR0R -> LIC01R on B d0 (stop 25 to stop 13 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "from_stop": 29,
+            "origin": "MSCE0A",
+            "ride_length": 29,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "origin": "MSCE0A",
+            "route": "B",
+            "trip": "1418363764159"
+          },
+          "ok": false,
+          "text": "asked MSCE0A -> GSNF0R on B d0 (stop 29 to stop 1 of a 29-stop ride, this direction does not make it): got MSCE0A -> GSNF0R on B d1, trip 1418363764159"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 0,
+            "from_stop": 15,
+            "origin": "CJA01R",
+            "ride_length": 29,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked CJA01R -> GSNF0R on B d0 (stop 15 to stop 1 of a 29-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "CJA01R",
+            "direction": 0,
+            "from_stop": 29,
+            "origin": "MSCE0A",
+            "ride_length": 29,
+            "route": "B",
+            "served": false,
+            "to_stop": 15
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked MSCE0A -> CJA01R on B d0 (stop 29 to stop 15 of a 29-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-B-d0-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "B"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "BLAN0C",
+            "ride_length": 17,
+            "route": "B",
+            "to_stop": 17
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "origin": "BLAN0C",
+            "route": "B",
+            "trip": "14369421591576"
+          },
+          "ok": true,
+          "text": "asked BLAN0C -> GSNF0R on B d1 (stop 1 to stop 17 of a 17-stop ride): got BLAN0C -> GSNF0R on B d1, trip 14369421591576"
+        },
+        {
+          "asked": {
+            "destination": "NDAN6A",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "BLAN0C",
+            "ride_length": 17,
+            "route": "B",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "NDAN6A",
+            "direction": 1,
+            "origin": "BLAN0C",
+            "route": "B",
+            "trip": "14369421591576"
+          },
+          "ok": true,
+          "text": "asked BLAN0C -> NDAN6A on B d1 (stop 1 to stop 9 of a 17-stop ride): got BLAN0C -> NDAN6A on B d1, trip 14369421591576"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "NDAN6A",
+            "ride_length": 17,
+            "route": "B",
+            "to_stop": 17
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "origin": "NDAN6A",
+            "route": "B",
+            "trip": "14369421593068"
+          },
+          "ok": true,
+          "text": "asked NDAN6A -> GSNF0R on B d1 (stop 9 to stop 17 of a 17-stop ride): got NDAN6A -> GSNF0R on B d1, trip 14369421593068"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "MSCE0A",
+            "ride_length": 27,
+            "route": "B",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "origin": "MSCE0A",
+            "route": "B",
+            "trip": "1418363764159"
+          },
+          "ok": true,
+          "text": "asked MSCE0A -> GSNF0R on B d1 (stop 1 to stop 27 of a 27-stop ride): got MSCE0A -> GSNF0R on B d1, trip 1418363764159"
+        },
+        {
+          "asked": {
+            "destination": "LRO01A",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "MSCE0A",
+            "ride_length": 27,
+            "route": "B",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "LRO01A",
+            "direction": 1,
+            "origin": "MSCE0A",
+            "route": "B",
+            "trip": "1418363764159"
+          },
+          "ok": true,
+          "text": "asked MSCE0A -> LRO01A on B d1 (stop 1 to stop 14 of a 27-stop ride): got MSCE0A -> LRO01A on B d1, trip 1418363764159"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "LRO01A",
+            "ride_length": 27,
+            "route": "B",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "origin": "LRO01A",
+            "route": "B",
+            "trip": "1418363764159"
+          },
+          "ok": true,
+          "text": "asked LRO01A -> GSNF0R on B d1 (stop 14 to stop 27 of a 27-stop ride): got LRO01A -> GSNF0R on B d1, trip 1418363764159"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "OLI01A",
+            "ride_length": 13,
+            "route": "B",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "origin": "OLI01A",
+            "route": "B",
+            "trip": "14369421591576"
+          },
+          "ok": true,
+          "text": "asked OLI01A -> GSNF0R on B d1 (stop 1 to stop 13 of a 13-stop ride): got OLI01A -> GSNF0R on B d1, trip 14369421591576"
+        },
+        {
+          "asked": {
+            "destination": "SEV06A",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "OLI01A",
+            "ride_length": 13,
+            "route": "B",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "SEV06A",
+            "direction": 1,
+            "origin": "OLI01A",
+            "route": "B",
+            "trip": "14369421591576"
+          },
+          "ok": true,
+          "text": "asked OLI01A -> SEV06A on B d1 (stop 1 to stop 7 of a 13-stop ride): got OLI01A -> SEV06A on B d1, trip 14369421591576"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "from_stop": 7,
+            "origin": "SEV06A",
+            "ride_length": 13,
+            "route": "B",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "origin": "SEV06A",
+            "route": "B",
+            "trip": "14369421591576"
+          },
+          "ok": true,
+          "text": "asked SEV06A -> GSNF0R on B d1 (stop 7 to stop 13 of a 13-stop ride): got SEV06A -> GSNF0R on B d1, trip 14369421591576"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "TOUR0A",
+            "ride_length": 23,
+            "route": "B",
+            "to_stop": 23
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "origin": "TOUR0A",
+            "route": "B",
+            "trip": "14369421591576"
+          },
+          "ok": true,
+          "text": "asked TOUR0A -> GSNF0R on B d1 (stop 1 to stop 23 of a 23-stop ride): got TOUR0A -> GSNF0R on B d1, trip 14369421591576"
+        },
+        {
+          "asked": {
+            "destination": "LIC01A",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "TOUR0A",
+            "ride_length": 23,
+            "route": "B",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "LIC01A",
+            "direction": 1,
+            "origin": "TOUR0A",
+            "route": "B",
+            "trip": "14369421591576"
+          },
+          "ok": true,
+          "text": "asked TOUR0A -> LIC01A on B d1 (stop 1 to stop 12 of a 23-stop ride): got TOUR0A -> LIC01A on B d1, trip 14369421591576"
+        },
+        {
+          "asked": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "from_stop": 12,
+            "origin": "LIC01A",
+            "ride_length": 23,
+            "route": "B",
+            "to_stop": 23
+          },
+          "got": {
+            "destination": "GSNF0R",
+            "direction": 1,
+            "origin": "LIC01A",
+            "route": "B",
+            "trip": "14369421591576"
+          },
+          "ok": true,
+          "text": "asked LIC01A -> GSNF0R on B d1 (stop 12 to stop 23 of a 23-stop ride): got LIC01A -> GSNF0R on B d1, trip 14369421591576"
+        }
+      ],
+      "direction": 1,
+      "fixture": "palmbus",
+      "id": "palmbus-B-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "B"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order MSCE0A .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order TOUR0A .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order BLAN0C .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order OLI01A .. GSNF0R"
+        }
+      ],
+      "direction": 1,
+      "fixture": "palmbus",
+      "id": "palmbus-B-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "route": "B"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "BLAN0C",
+            "direction": 1,
+            "from_stop": 17,
+            "origin": "GSNF0R",
+            "ride_length": 17,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GSNF0R -> BLAN0C on B d1 (stop 17 to stop 1 of a 17-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "BLAN0C",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "NDAN6A",
+            "ride_length": 17,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked NDAN6A -> BLAN0C on B d1 (stop 9 to stop 1 of a 17-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "NDAN6A",
+            "direction": 1,
+            "from_stop": 17,
+            "origin": "GSNF0R",
+            "ride_length": 17,
+            "route": "B",
+            "served": false,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GSNF0R -> NDAN6A on B d1 (stop 17 to stop 9 of a 17-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "MSCE0A",
+            "direction": 1,
+            "from_stop": 27,
+            "origin": "GSNF0R",
+            "ride_length": 27,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "MSCE0A",
+            "direction": 0,
+            "origin": "GSNF0R",
+            "route": "B",
+            "trip": "1418363764271"
+          },
+          "ok": false,
+          "text": "asked GSNF0R -> MSCE0A on B d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got GSNF0R -> MSCE0A on B d0, trip 1418363764271"
+        },
+        {
+          "asked": {
+            "destination": "MSCE0A",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "LRO01A",
+            "ride_length": 27,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked LRO01A -> MSCE0A on B d1 (stop 14 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "LRO01A",
+            "direction": 1,
+            "from_stop": 27,
+            "origin": "GSNF0R",
+            "ride_length": 27,
+            "route": "B",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GSNF0R -> LRO01A on B d1 (stop 27 to stop 14 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "OLI01A",
+            "direction": 1,
+            "from_stop": 13,
+            "origin": "GSNF0R",
+            "ride_length": 13,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GSNF0R -> OLI01A on B d1 (stop 13 to stop 1 of a 13-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "OLI01A",
+            "direction": 1,
+            "from_stop": 7,
+            "origin": "SEV06A",
+            "ride_length": 13,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked SEV06A -> OLI01A on B d1 (stop 7 to stop 1 of a 13-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "SEV06A",
+            "direction": 1,
+            "from_stop": 13,
+            "origin": "GSNF0R",
+            "ride_length": 13,
+            "route": "B",
+            "served": false,
+            "to_stop": 7
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GSNF0R -> SEV06A on B d1 (stop 13 to stop 7 of a 13-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "TOUR0A",
+            "direction": 1,
+            "from_stop": 23,
+            "origin": "GSNF0R",
+            "ride_length": 23,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GSNF0R -> TOUR0A on B d1 (stop 23 to stop 1 of a 23-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "TOUR0A",
+            "direction": 1,
+            "from_stop": 12,
+            "origin": "LIC01A",
+            "ride_length": 23,
+            "route": "B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked LIC01A -> TOUR0A on B d1 (stop 12 to stop 1 of a 23-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "LIC01A",
+            "direction": 1,
+            "from_stop": 23,
+            "origin": "GSNF0R",
+            "ride_length": 23,
+            "route": "B",
+            "served": false,
+            "to_stop": 12
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked GSNF0R -> LIC01A on B d1 (stop 23 to stop 12 of a 23-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "palmbus",
+      "id": "palmbus-B-d1-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "B"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris-Austerlitz Routiere",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Paris-Austerlitz Routiere",
+            "route": "K8+",
+            "trip": "OCESN425001R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87737429:87543009:3:945:20261206"
+          },
+          "ok": true,
+          "text": "asked Paris-Austerlitz Routiere -> Orléans on K8+ (stop 1 to stop 3 of a 3-stop ride): got Paris-Austerlitz Routiere -> Orléans on K8+ d0, trip OCESN425001R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87737429:87543009:3:945:20261206"
+        },
+        {
+          "asked": {
+            "destination": "Les Aubrais Gare Routière",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris-Austerlitz Routiere",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 2
+          },
+          "got": {
+            "destination": "Les Aubrais Gare Routière",
+            "direction": 0,
+            "origin": "Paris-Austerlitz Routiere",
+            "route": "K8+",
+            "trip": "OCESN425001R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87737429:87543009:3:945:20261206"
+          },
+          "ok": true,
+          "text": "asked Paris-Austerlitz Routiere -> Les Aubrais Gare Routière on K8+ (stop 1 to stop 2 of a 3-stop ride): got Paris-Austerlitz Routiere -> Les Aubrais Gare Routière on K8+ d0, trip OCESN425001R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87737429:87543009:3:945:20261206"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 2,
+            "origin": "Les Aubrais Gare Routière",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Les Aubrais Gare Routière",
+            "route": "K8+",
+            "trip": "OCESN425001R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87737429:87543009:3:945:20261206"
+          },
+          "ok": true,
+          "text": "asked Les Aubrais Gare Routière -> Orléans on K8+ (stop 2 to stop 3 of a 3-stop ride): got Les Aubrais Gare Routière -> Orléans on K8+ d0, trip OCESN425001R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87737429:87543009:3:945:20261206"
+        },
+        {
+          "asked": {
+            "destination": "Les Aubrais",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 2,
+            "route": "K8+",
+            "to_stop": 2
+          },
+          "got": {
+            "destination": "Les Aubrais",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": false,
+          "text": "asked Paris Austerlitz -> Les Aubrais on K8+ (stop 1 to stop 2 of a 2-stop ride): got Paris Austerlitz -> Les Aubrais on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": false,
+          "text": "asked Paris Austerlitz -> Orléans on K8+ (stop 1 to stop 3 of a 3-stop ride): got Paris Austerlitz -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Les Aubrais",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 2
+          },
+          "got": {
+            "destination": "Les Aubrais",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": false,
+          "text": "asked Paris Austerlitz -> Les Aubrais on K8+ (stop 1 to stop 2 of a 3-stop ride): got Paris Austerlitz -> Les Aubrais on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 2,
+            "origin": "Les Aubrais",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Les Aubrais",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": false,
+          "text": "asked Les Aubrais -> Orléans on K8+ (stop 2 to stop 3 of a 3-stop ride): got Les Aubrais -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Bercy Bourg. Pays d'Auv.",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Paris Bercy Bourg. Pays d'Auv.",
+            "route": "K8+",
+            "trip": "OCESN860513F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87686667:87543009:3:1126:20261003"
+          },
+          "ok": true,
+          "text": "asked Paris Bercy Bourg. Pays d'Auv. -> Orléans on K8+ (stop 1 to stop 3 of a 3-stop ride): got Paris Bercy Bourg. Pays d'Auv. -> Orléans on K8+ d0, trip OCESN860513F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87686667:87543009:3:1126:20261003"
+        },
+        {
+          "asked": {
+            "destination": "Les Aubrais",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Bercy Bourg. Pays d'Auv.",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 2
+          },
+          "got": {
+            "destination": "Les Aubrais",
+            "direction": 0,
+            "origin": "Paris Bercy Bourg. Pays d'Auv.",
+            "route": "K8+",
+            "trip": "OCESN860513F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87686667:87543009:3:1126:20261003"
+          },
+          "ok": true,
+          "text": "asked Paris Bercy Bourg. Pays d'Auv. -> Les Aubrais on K8+ (stop 1 to stop 2 of a 3-stop ride): got Paris Bercy Bourg. Pays d'Auv. -> Les Aubrais on K8+ d0, trip OCESN860513F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87686667:87543009:3:1126:20261003"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 2,
+            "origin": "Les Aubrais",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Les Aubrais",
+            "route": "K8+",
+            "trip": "OCESN860509F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87547000:87543009:3:926:20261003"
+          },
+          "ok": true,
+          "text": "asked Les Aubrais -> Orléans on K8+ (stop 2 to stop 3 of a 3-stop ride): got Les Aubrais -> Orléans on K8+ d0, trip OCESN860509F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87547000:87543009:3:926:20261003"
+        }
+      ],
+      "direction": 0,
+      "fixture": "sncf-journeys",
+      "id": "sncf-journeys-K8+-d0-pairs",
+      "kind": "pairs",
+      "outcome": "xfailed",
+      "reason": "a train journey is matched by stop name prefix on any line, not the asked one",
+      "route": "FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532:"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "Paris-Austerlitz Routiere",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Paris-Austerlitz Routiere",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN425012R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87737429:3:1500:20261106"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Paris-Austerlitz Routiere on K8+ (stop 1 to stop 3 of a 3-stop ride): got Orléans -> Paris-Austerlitz Routiere on K8+ d1, trip OCESN425012R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87737429:3:1500:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Les Aubrais Gare Routière",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 2
+          },
+          "got": {
+            "destination": "Les Aubrais Gare Routière",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN424586R1187_R:CTE:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87543090:8:1350:20261211"
+          },
+          "ok": false,
+          "text": "asked Orléans -> Les Aubrais Gare Routière on K8+ (stop 1 to stop 2 of a 3-stop ride): got Orléans -> Les Aubrais Gare Routière on P8 d1, trip OCESN424586R1187_R:CTE:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87543090:8:1350:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris-Austerlitz Routiere",
+            "direction": null,
+            "from_stop": 2,
+            "origin": "Les Aubrais Gare Routière",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Paris-Austerlitz Routiere",
+            "direction": 1,
+            "origin": "Les Aubrais Gare Routière",
+            "route": "K8+",
+            "trip": "OCESN425012R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87737429:3:1500:20261106"
+          },
+          "ok": true,
+          "text": "asked Les Aubrais Gare Routière -> Paris-Austerlitz Routiere on K8+ (stop 2 to stop 3 of a 3-stop ride): got Les Aubrais Gare Routière -> Paris-Austerlitz Routiere on K8+ d1, trip OCESN425012R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87737429:3:1500:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Paris-Austerlitz Routiere",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 2,
+            "route": "K8+",
+            "to_stop": 2
+          },
+          "got": {
+            "destination": "Paris-Austerlitz Routiere",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN425116R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87737429:2:1330:20261206"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Paris-Austerlitz Routiere on K8+ (stop 1 to stop 2 of a 2-stop ride): got Orléans -> Paris-Austerlitz Routiere on K8+ d1, trip OCESN425116R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87737429:2:1330:20261206"
+        },
+        {
+          "asked": {
+            "destination": "Paris-Austerlitz Routiere",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Les Aubrais Gare Routière",
+            "ride_length": 2,
+            "route": "K8+",
+            "to_stop": 2
+          },
+          "got": {
+            "destination": "Paris-Austerlitz Routiere",
+            "direction": 1,
+            "origin": "Les Aubrais Gare Routière",
+            "route": "K8+",
+            "trip": "OCESN425114R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87737411:87737429:2:1230:20261206"
+          },
+          "ok": true,
+          "text": "asked Les Aubrais Gare Routière -> Paris-Austerlitz Routiere on K8+ (stop 1 to stop 2 of a 2-stop ride): got Les Aubrais Gare Routière -> Paris-Austerlitz Routiere on K8+ d1, trip OCESN425114R1187_R:CTE:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87737411:87737429:2:1230:20261206"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Paris Austerlitz on K8+ (stop 1 to stop 3 of a 3-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+        },
+        {
+          "asked": {
+            "destination": "Les Aubrais",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 2
+          },
+          "got": {
+            "destination": "Les Aubrais",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Les Aubrais on K8+ (stop 1 to stop 2 of a 3-stop ride): got Orléans -> Les Aubrais on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 2,
+            "origin": "Les Aubrais",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Les Aubrais",
+            "route": "K8+",
+            "trip": "OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+          },
+          "ok": true,
+          "text": "asked Les Aubrais -> Paris Austerlitz on K8+ (stop 2 to stop 3 of a 3-stop ride): got Les Aubrais -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+        },
+        {
+          "asked": {
+            "destination": "Paris Bercy Bourg. Pays d'Auv.",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Paris Bercy Bourg. Pays d'Auv.",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN860510F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87686667:3:957:20261003"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Paris Bercy Bourg. Pays d'Auv. on K8+ (stop 1 to stop 3 of a 3-stop ride): got Orléans -> Paris Bercy Bourg. Pays d'Auv. on K8+ d1, trip OCESN860510F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87686667:3:957:20261003"
+        },
+        {
+          "asked": {
+            "destination": "Les Aubrais",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 2
+          },
+          "got": {
+            "destination": "Les Aubrais",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN860510F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87686667:3:957:20261003"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Les Aubrais on K8+ (stop 1 to stop 2 of a 3-stop ride): got Orléans -> Les Aubrais on K8+ d1, trip OCESN860510F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87686667:3:957:20261003"
+        },
+        {
+          "asked": {
+            "destination": "Paris Bercy Bourg. Pays d'Auv.",
+            "direction": null,
+            "from_stop": 2,
+            "origin": "Les Aubrais",
+            "ride_length": 3,
+            "route": "K8+",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Paris Bercy Bourg. Pays d'Auv.",
+            "direction": 1,
+            "origin": "Les Aubrais",
+            "route": "K8+",
+            "trip": "OCESN860510F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87686667:3:957:20261003"
+          },
+          "ok": true,
+          "text": "asked Les Aubrais -> Paris Bercy Bourg. Pays d'Auv. on K8+ (stop 2 to stop 3 of a 3-stop ride): got Les Aubrais -> Paris Bercy Bourg. Pays d'Auv. on K8+ d1, trip OCESN860510F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87686667:3:957:20261003"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Les Aubrais",
+            "ride_length": 2,
+            "route": "K8+",
+            "to_stop": 2
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Les Aubrais",
+            "route": "K8+",
+            "trip": "OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+          },
+          "ok": true,
+          "text": "asked Les Aubrais -> Paris Austerlitz on K8+ (stop 1 to stop 2 of a 2-stop ride): got Les Aubrais -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+        }
+      ],
+      "direction": 1,
+      "fixture": "sncf-journeys",
+      "id": "sncf-journeys-K8+-d1-pairs",
+      "kind": "pairs",
+      "outcome": "xfailed",
+      "reason": "a train journey is matched by stop name prefix on any line, not the asked one",
+      "route": "FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532:"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "Nîmes Centre",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Le Grau-du-Roi",
+            "ride_length": 7,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Nîmes Centre",
+            "direction": 0,
+            "origin": "Le Grau-du-Roi",
+            "route": "P8",
+            "trip": "OCESN877554F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775866:87775007:7:1251:20260927"
+          },
+          "ok": true,
+          "text": "asked Le Grau-du-Roi -> Nîmes Centre on P8 (stop 1 to stop 7 of a 7-stop ride): got Le Grau-du-Roi -> Nîmes Centre on P8 d0, trip OCESN877554F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775866:87775007:7:1251:20260927"
+        },
+        {
+          "asked": {
+            "destination": "Le Cailar",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Le Grau-du-Roi",
+            "ride_length": 7,
+            "route": "P8",
+            "to_stop": 4
+          },
+          "got": {
+            "destination": "Le Cailar",
+            "direction": 0,
+            "origin": "Le Grau-du-Roi",
+            "route": "P8",
+            "trip": "OCESN877554F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775866:87775007:7:1251:20260927"
+          },
+          "ok": true,
+          "text": "asked Le Grau-du-Roi -> Le Cailar on P8 (stop 1 to stop 4 of a 7-stop ride): got Le Grau-du-Roi -> Le Cailar on P8 d0, trip OCESN877554F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775866:87775007:7:1251:20260927"
+        },
+        {
+          "asked": {
+            "destination": "Nîmes Centre",
+            "direction": null,
+            "from_stop": 4,
+            "origin": "Le Cailar",
+            "ride_length": 7,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Nîmes Centre",
+            "direction": 0,
+            "origin": "Le Cailar",
+            "route": "P8",
+            "trip": "OCESN877554F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775866:87775007:7:1251:20260927"
+          },
+          "ok": true,
+          "text": "asked Le Cailar -> Nîmes Centre on P8 (stop 4 to stop 7 of a 7-stop ride): got Le Cailar -> Nîmes Centre on P8 d0, trip OCESN877554F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775866:87775007:7:1251:20260927"
+        },
+        {
+          "asked": {
+            "destination": "Nîmes Centre",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Le Grau-du-Roi",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "Nîmes Centre",
+            "direction": 0,
+            "origin": "Le Grau-du-Roi",
+            "route": "P8",
+            "trip": "OCESN877550F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775866:87775007:10:734:20261207"
+          },
+          "ok": true,
+          "text": "asked Le Grau-du-Roi -> Nîmes Centre on P8 (stop 1 to stop 10 of a 10-stop ride): got Le Grau-du-Roi -> Nîmes Centre on P8 d0, trip OCESN877550F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775866:87775007:10:734:20261207"
+        },
+        {
+          "asked": {
+            "destination": "Vauvert",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Le Grau-du-Roi",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Vauvert",
+            "direction": 0,
+            "origin": "Le Grau-du-Roi",
+            "route": "P8",
+            "trip": "OCESN877550F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775866:87775007:10:734:20261207"
+          },
+          "ok": true,
+          "text": "asked Le Grau-du-Roi -> Vauvert on P8 (stop 1 to stop 6 of a 10-stop ride): got Le Grau-du-Roi -> Vauvert on P8 d0, trip OCESN877550F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775866:87775007:10:734:20261207"
+        },
+        {
+          "asked": {
+            "destination": "Nîmes Centre",
+            "direction": null,
+            "from_stop": 6,
+            "origin": "Vauvert",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "Nîmes Centre",
+            "direction": 0,
+            "origin": "Vauvert",
+            "route": "P8",
+            "trip": "OCESN877550F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775866:87775007:10:734:20261207"
+          },
+          "ok": true,
+          "text": "asked Vauvert -> Nîmes Centre on P8 (stop 6 to stop 10 of a 10-stop ride): got Vauvert -> Nîmes Centre on P8 d0, trip OCESN877550F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775866:87775007:10:734:20261207"
+        }
+      ],
+      "direction": 0,
+      "fixture": "sncf-journeys",
+      "id": "sncf-journeys-P8(924A148:)-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148:"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "Le Grau-du-Roi",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Nîmes Centre",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "Le Grau-du-Roi",
+            "direction": 1,
+            "origin": "Nîmes Centre",
+            "route": "P8",
+            "trip": "OCESN877553F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775007:87775866:10:1134:20261211"
+          },
+          "ok": true,
+          "text": "asked Nîmes Centre -> Le Grau-du-Roi on P8 (stop 1 to stop 10 of a 10-stop ride): got Nîmes Centre -> Le Grau-du-Roi on P8 d1, trip OCESN877553F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775007:87775866:10:1134:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Le Cailar",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Nîmes Centre",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Le Cailar",
+            "direction": 1,
+            "origin": "Nîmes Centre",
+            "route": "P8",
+            "trip": "OCESN877553F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775007:87775866:10:1134:20261211"
+          },
+          "ok": true,
+          "text": "asked Nîmes Centre -> Le Cailar on P8 (stop 1 to stop 6 of a 10-stop ride): got Nîmes Centre -> Le Cailar on P8 d1, trip OCESN877553F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775007:87775866:10:1134:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Le Grau-du-Roi",
+            "direction": null,
+            "from_stop": 6,
+            "origin": "Le Cailar",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "Le Grau-du-Roi",
+            "direction": 1,
+            "origin": "Le Cailar",
+            "route": "P8",
+            "trip": "OCESN877553F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775007:87775866:10:1134:20261211"
+          },
+          "ok": true,
+          "text": "asked Le Cailar -> Le Grau-du-Roi on P8 (stop 6 to stop 10 of a 10-stop ride): got Le Cailar -> Le Grau-du-Roi on P8 d1, trip OCESN877553F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775007:87775866:10:1134:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Le Grau-du-Roi",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Nîmes Centre",
+            "ride_length": 7,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Le Grau-du-Roi",
+            "direction": 1,
+            "origin": "Nîmes Centre",
+            "route": "P8",
+            "trip": "OCESN877553F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775007:87775866:10:1134:20261210"
+          },
+          "ok": true,
+          "text": "asked Nîmes Centre -> Le Grau-du-Roi on P8 (stop 1 to stop 7 of a 7-stop ride): got Nîmes Centre -> Le Grau-du-Roi on P8 d1, trip OCESN877553F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775007:87775866:10:1134:20261210"
+        },
+        {
+          "asked": {
+            "destination": "Le Cailar",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Nîmes Centre",
+            "ride_length": 7,
+            "route": "P8",
+            "to_stop": 4
+          },
+          "got": {
+            "destination": "Le Cailar",
+            "direction": 1,
+            "origin": "Nîmes Centre",
+            "route": "P8",
+            "trip": "OCESN877553F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775007:87775866:10:1134:20261210"
+          },
+          "ok": true,
+          "text": "asked Nîmes Centre -> Le Cailar on P8 (stop 1 to stop 4 of a 7-stop ride): got Nîmes Centre -> Le Cailar on P8 d1, trip OCESN877553F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775007:87775866:10:1134:20261210"
+        },
+        {
+          "asked": {
+            "destination": "Le Grau-du-Roi",
+            "direction": null,
+            "from_stop": 4,
+            "origin": "Le Cailar",
+            "ride_length": 7,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Le Grau-du-Roi",
+            "direction": 1,
+            "origin": "Le Cailar",
+            "route": "P8",
+            "trip": "OCESN877553F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775007:87775866:10:1134:20261210"
+          },
+          "ok": true,
+          "text": "asked Le Cailar -> Le Grau-du-Roi on P8 (stop 4 to stop 7 of a 7-stop ride): got Le Cailar -> Le Grau-du-Roi on P8 d1, trip OCESN877553F1187_F:TER:FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148::87775007:87775866:10:1134:20261210"
+        }
+      ],
+      "direction": 1,
+      "fixture": "sncf-journeys",
+      "id": "sncf-journeys-P8(924A148:)-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "FR:Line::9F9C7618-AF98-47D8-BFB4-0B1C2924A148:"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "Mouchard",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Dole",
+            "ride_length": 2,
+            "route": "P8",
+            "to_stop": 2
+          },
+          "got": {
+            "destination": "Mouchard",
+            "direction": 0,
+            "origin": "Dole",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Dole -> Mouchard on P8 (stop 1 to stop 2 of a 2-stop ride): got Dole -> Mouchard on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Andelot",
+            "ride_length": 7,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "Andelot",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Andelot -> Saint-Claude on P8 (stop 1 to stop 7 of a 7-stop ride): got Andelot -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Laurent-en-Grandvaux",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Andelot",
+            "ride_length": 7,
+            "route": "P8",
+            "to_stop": 4
+          },
+          "got": {
+            "destination": "Saint-Laurent-en-Grandvaux",
+            "direction": 0,
+            "origin": "Andelot",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Andelot -> Saint-Laurent-en-Grandvaux on P8 (stop 1 to stop 4 of a 7-stop ride): got Andelot -> Saint-Laurent-en-Grandvaux on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 4,
+            "origin": "Saint-Laurent-en-Grandvaux",
+            "ride_length": 7,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "Saint-Laurent-en-Grandvaux",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Saint-Laurent-en-Grandvaux -> Saint-Claude on P8 (stop 4 to stop 7 of a 7-stop ride): got Saint-Laurent-en-Grandvaux -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Champagnole",
+            "ride_length": 7,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "Champagnole",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Champagnole -> Saint-Claude on P8 (stop 1 to stop 7 of a 7-stop ride): got Champagnole -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Laurent-en-Grandvaux",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Champagnole",
+            "ride_length": 7,
+            "route": "P8",
+            "to_stop": 4
+          },
+          "got": {
+            "destination": "Saint-Laurent-en-Grandvaux",
+            "direction": 0,
+            "origin": "Champagnole",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Champagnole -> Saint-Laurent-en-Grandvaux on P8 (stop 1 to stop 4 of a 7-stop ride): got Champagnole -> Saint-Laurent-en-Grandvaux on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 4,
+            "origin": "Saint-Laurent-en-Grandvaux",
+            "ride_length": 7,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "Saint-Laurent-en-Grandvaux",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Saint-Laurent-en-Grandvaux -> Saint-Claude on P8 (stop 4 to stop 7 of a 7-stop ride): got Saint-Laurent-en-Grandvaux -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Mouchard",
+            "ride_length": 6,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "Mouchard",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Mouchard -> Saint-Claude on P8 (stop 1 to stop 6 of a 6-stop ride): got Mouchard -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Morbier",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Mouchard",
+            "ride_length": 6,
+            "route": "P8",
+            "to_stop": 4
+          },
+          "got": {
+            "destination": "Morbier",
+            "direction": 0,
+            "origin": "Mouchard",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Mouchard -> Morbier on P8 (stop 1 to stop 4 of a 6-stop ride): got Mouchard -> Morbier on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 4,
+            "origin": "Morbier",
+            "ride_length": 6,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "Morbier",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Morbier -> Saint-Claude on P8 (stop 4 to stop 6 of a 6-stop ride): got Morbier -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Dole",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "Dole",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Dole -> Saint-Claude on P8 (stop 1 to stop 13 of a 13-stop ride): got Dole -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Champagnole Paul-Émile Victor",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Dole",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Champagnole Paul-Émile Victor",
+            "direction": 0,
+            "origin": "Dole",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Dole -> Champagnole Paul-Émile Victor on P8 (stop 1 to stop 7 of a 13-stop ride): got Dole -> Champagnole Paul-Émile Victor on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 7,
+            "origin": "Champagnole Paul-Émile Victor",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "Champagnole Paul-Émile Victor",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Champagnole Paul-Émile Victor -> Saint-Claude on P8 (stop 7 to stop 13 of a 13-stop ride): got Champagnole Paul-Émile Victor -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Andelot",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "Andelot",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Andelot -> Saint-Claude on P8 (stop 1 to stop 9 of a 9-stop ride): got Andelot -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "La Chaumusse - Fort-du-Plasne",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Andelot",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "La Chaumusse - Fort-du-Plasne",
+            "direction": 0,
+            "origin": "Andelot",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Andelot -> La Chaumusse - Fort-du-Plasne on P8 (stop 1 to stop 5 of a 9-stop ride): got Andelot -> La Chaumusse - Fort-du-Plasne on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 5,
+            "origin": "La Chaumusse - Fort-du-Plasne",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "La Chaumusse - Fort-du-Plasne",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked La Chaumusse - Fort-du-Plasne -> Saint-Claude on P8 (stop 5 to stop 9 of a 9-stop ride): got La Chaumusse - Fort-du-Plasne -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Champagnole",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "Champagnole",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Champagnole -> Saint-Claude on P8 (stop 1 to stop 8 of a 8-stop ride): got Champagnole -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Laurent-en-Grandvaux",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Champagnole",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "Saint-Laurent-en-Grandvaux",
+            "direction": 0,
+            "origin": "Champagnole",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Champagnole -> Saint-Laurent-en-Grandvaux on P8 (stop 1 to stop 5 of a 8-stop ride): got Champagnole -> Saint-Laurent-en-Grandvaux on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 5,
+            "origin": "Saint-Laurent-en-Grandvaux",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "Saint-Laurent-en-Grandvaux",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked Saint-Laurent-en-Grandvaux -> Saint-Claude on P8 (stop 5 to stop 8 of a 8-stop ride): got Saint-Laurent-en-Grandvaux -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Besançon Viotte",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "Besançon Viotte",
+            "route": "P8",
+            "trip": "OCESN895507F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87718007:87743633:12:1925:20261211"
+          },
+          "ok": true,
+          "text": "asked Besançon Viotte -> Saint-Claude on P8 (stop 1 to stop 12 of a 12-stop ride): got Besançon Viotte -> Saint-Claude on P8 d0, trip OCESN895507F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87718007:87743633:12:1925:20261211"
+        },
+        {
+          "asked": {
+            "destination": "La Chaux-des-Crotenay",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Besançon Viotte",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "La Chaux-des-Crotenay",
+            "direction": 0,
+            "origin": "Besançon Viotte",
+            "route": "P8",
+            "trip": "OCESN895507F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87718007:87743633:12:1925:20261211"
+          },
+          "ok": true,
+          "text": "asked Besançon Viotte -> La Chaux-des-Crotenay on P8 (stop 1 to stop 7 of a 12-stop ride): got Besançon Viotte -> La Chaux-des-Crotenay on P8 d0, trip OCESN895507F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87718007:87743633:12:1925:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Claude",
+            "direction": null,
+            "from_stop": 7,
+            "origin": "La Chaux-des-Crotenay",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "Saint-Claude",
+            "direction": 0,
+            "origin": "La Chaux-des-Crotenay",
+            "route": "P8",
+            "trip": "OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+          },
+          "ok": true,
+          "text": "asked La Chaux-des-Crotenay -> Saint-Claude on P8 (stop 7 to stop 12 of a 12-stop ride): got La Chaux-des-Crotenay -> Saint-Claude on P8 d0, trip OCESN895501F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87713412:87743633:13:912:20261211"
+        }
+      ],
+      "direction": 0,
+      "fixture": "sncf-journeys",
+      "id": "sncf-journeys-P8(A594575:)-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575:"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "Dole",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Champagnole Paul-Émile Victor",
+            "ride_length": 5,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "Dole",
+            "direction": 1,
+            "origin": "Champagnole Paul-Émile Victor",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Champagnole Paul-Émile Victor -> Dole on P8 (stop 1 to stop 5 of a 5-stop ride): got Champagnole Paul-Émile Victor -> Dole on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Andelot",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Champagnole Paul-Émile Victor",
+            "ride_length": 5,
+            "route": "P8",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Andelot",
+            "direction": 1,
+            "origin": "Champagnole Paul-Émile Victor",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Champagnole Paul-Émile Victor -> Andelot on P8 (stop 1 to stop 3 of a 5-stop ride): got Champagnole Paul-Émile Victor -> Andelot on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Dole",
+            "direction": null,
+            "from_stop": 3,
+            "origin": "Andelot",
+            "ride_length": 5,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "Dole",
+            "direction": 1,
+            "origin": "Andelot",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Andelot -> Dole on P8 (stop 3 to stop 5 of a 5-stop ride): got Andelot -> Dole on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Dole",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Mouchard",
+            "ride_length": 2,
+            "route": "P8",
+            "to_stop": 2
+          },
+          "got": {
+            "destination": "Dole",
+            "direction": 1,
+            "origin": "Mouchard",
+            "route": "P8",
+            "trip": "OCESN36516R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87718833:87713412:2:549:20261211"
+          },
+          "ok": true,
+          "text": "asked Mouchard -> Dole on P8 (stop 1 to stop 2 of a 2-stop ride): got Mouchard -> Dole on P8 d1, trip OCESN36516R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87718833:87713412:2:549:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Mouchard",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 6,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Mouchard",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN36582R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718833:6:650:20261207"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Mouchard on P8 (stop 1 to stop 6 of a 6-stop ride): got Saint-Claude -> Mouchard on P8 d1, trip OCESN36582R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718833:6:650:20261207"
+        },
+        {
+          "asked": {
+            "destination": "Saint-Laurent-en-Grandvaux",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 6,
+            "route": "P8",
+            "to_stop": 4
+          },
+          "got": {
+            "destination": "Saint-Laurent-en-Grandvaux",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN36582R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718833:6:650:20261207"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Saint-Laurent-en-Grandvaux on P8 (stop 1 to stop 4 of a 6-stop ride): got Saint-Claude -> Saint-Laurent-en-Grandvaux on P8 d1, trip OCESN36582R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718833:6:650:20261207"
+        },
+        {
+          "asked": {
+            "destination": "Mouchard",
+            "direction": null,
+            "from_stop": 4,
+            "origin": "Saint-Laurent-en-Grandvaux",
+            "ride_length": 6,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Mouchard",
+            "direction": 1,
+            "origin": "Saint-Laurent-en-Grandvaux",
+            "route": "P8",
+            "trip": "OCESN36582R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718833:6:650:20261207"
+          },
+          "ok": true,
+          "text": "asked Saint-Laurent-en-Grandvaux -> Mouchard on P8 (stop 4 to stop 6 of a 6-stop ride): got Saint-Laurent-en-Grandvaux -> Mouchard on P8 d1, trip OCESN36582R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718833:6:650:20261207"
+        },
+        {
+          "asked": {
+            "destination": "Andelot",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "Andelot",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Andelot on P8 (stop 1 to stop 9 of a 9-stop ride): got Saint-Claude -> Andelot on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "La Chaumusse - Fort-du-Plasne",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "La Chaumusse - Fort-du-Plasne",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> La Chaumusse - Fort-du-Plasne on P8 (stop 1 to stop 5 of a 9-stop ride): got Saint-Claude -> La Chaumusse - Fort-du-Plasne on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Andelot",
+            "direction": null,
+            "from_stop": 5,
+            "origin": "La Chaumusse - Fort-du-Plasne",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "Andelot",
+            "direction": 1,
+            "origin": "La Chaumusse - Fort-du-Plasne",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked La Chaumusse - Fort-du-Plasne -> Andelot on P8 (stop 5 to stop 9 of a 9-stop ride): got La Chaumusse - Fort-du-Plasne -> Andelot on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Dole",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "Dole",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN36558R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:851:20261030"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Dole on P8 (stop 1 to stop 13 of a 13-stop ride): got Saint-Claude -> Dole on P8 d1, trip OCESN36558R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:851:20261030"
+        },
+        {
+          "asked": {
+            "destination": "Champagnole Paul-Émile Victor",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Champagnole Paul-Émile Victor",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN36558R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:851:20261030"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Champagnole Paul-Émile Victor on P8 (stop 1 to stop 7 of a 13-stop ride): got Saint-Claude -> Champagnole Paul-Émile Victor on P8 d1, trip OCESN36558R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:851:20261030"
+        },
+        {
+          "asked": {
+            "destination": "Dole",
+            "direction": null,
+            "from_stop": 7,
+            "origin": "Champagnole Paul-Émile Victor",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "Dole",
+            "direction": 1,
+            "origin": "Champagnole Paul-Émile Victor",
+            "route": "P8",
+            "trip": "OCESN36558R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:851:20261030"
+          },
+          "ok": true,
+          "text": "asked Champagnole Paul-Émile Victor -> Dole on P8 (stop 7 to stop 13 of a 13-stop ride): got Champagnole Paul-Émile Victor -> Dole on P8 d1, trip OCESN36558R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:851:20261030"
+        },
+        {
+          "asked": {
+            "destination": "Champagnole",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "Champagnole",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN36582R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718833:6:650:20261207"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Champagnole on P8 (stop 1 to stop 8 of a 8-stop ride): got Saint-Claude -> Champagnole on P8 d1, trip OCESN36582R1187_R:CTE:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718833:6:650:20261207"
+        },
+        {
+          "asked": {
+            "destination": "La Chaumusse - Fort-du-Plasne",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "La Chaumusse - Fort-du-Plasne",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> La Chaumusse - Fort-du-Plasne on P8 (stop 1 to stop 5 of a 8-stop ride): got Saint-Claude -> La Chaumusse - Fort-du-Plasne on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Champagnole",
+            "direction": null,
+            "from_stop": 5,
+            "origin": "La Chaumusse - Fort-du-Plasne",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "Champagnole Paul-Émile Victor",
+            "direction": 1,
+            "origin": "La Chaumusse - Fort-du-Plasne",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": false,
+          "text": "asked La Chaumusse - Fort-du-Plasne -> Champagnole on P8 (stop 5 to stop 8 of a 8-stop ride): got La Chaumusse - Fort-du-Plasne -> Champagnole Paul-Émile Victor on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Andelot",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "Andelot",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Andelot on P8 (stop 1 to stop 9 of a 9-stop ride): got Saint-Claude -> Andelot on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "La Chaumusse - Fort-du-Plasne",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "La Chaumusse - Fort-du-Plasne",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> La Chaumusse - Fort-du-Plasne on P8 (stop 1 to stop 5 of a 9-stop ride): got Saint-Claude -> La Chaumusse - Fort-du-Plasne on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Andelot",
+            "direction": null,
+            "from_stop": 5,
+            "origin": "La Chaumusse - Fort-du-Plasne",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "Andelot",
+            "direction": 1,
+            "origin": "La Chaumusse - Fort-du-Plasne",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked La Chaumusse - Fort-du-Plasne -> Andelot on P8 (stop 5 to stop 9 of a 9-stop ride): got La Chaumusse - Fort-du-Plasne -> Andelot on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Besançon Viotte",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "Besançon Viotte",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN895516F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718007:12:1738:20261211"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Besançon Viotte on P8 (stop 1 to stop 12 of a 12-stop ride): got Saint-Claude -> Besançon Viotte on P8 d1, trip OCESN895516F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718007:12:1738:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Champagnole Paul-Émile Victor",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Champagnole Paul-Émile Victor",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Champagnole Paul-Émile Victor on P8 (stop 1 to stop 7 of a 12-stop ride): got Saint-Claude -> Champagnole Paul-Émile Victor on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Besançon Viotte",
+            "direction": null,
+            "from_stop": 7,
+            "origin": "Champagnole Paul-Émile Victor",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "Besançon Viotte",
+            "direction": 1,
+            "origin": "Champagnole Paul-Émile Victor",
+            "route": "P8",
+            "trip": "OCESN895516F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718007:12:1738:20261211"
+          },
+          "ok": true,
+          "text": "asked Champagnole Paul-Émile Victor -> Besançon Viotte on P8 (stop 7 to stop 12 of a 12-stop ride): got Champagnole Paul-Émile Victor -> Besançon Viotte on P8 d1, trip OCESN895516F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718007:12:1738:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Besançon Viotte",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "Besançon Viotte",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN895518F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718007:13:1959:20261210"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Besançon Viotte on P8 (stop 1 to stop 13 of a 13-stop ride): got Saint-Claude -> Besançon Viotte on P8 d1, trip OCESN895518F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718007:13:1959:20261210"
+        },
+        {
+          "asked": {
+            "destination": "Champagnole Paul-Émile Victor",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Champagnole Paul-Émile Victor",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Champagnole Paul-Émile Victor on P8 (stop 1 to stop 7 of a 13-stop ride): got Saint-Claude -> Champagnole Paul-Émile Victor on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Besançon Viotte",
+            "direction": null,
+            "from_stop": 7,
+            "origin": "Champagnole Paul-Émile Victor",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "Besançon Viotte",
+            "direction": 1,
+            "origin": "Champagnole Paul-Émile Victor",
+            "route": "P8",
+            "trip": "OCESN895518F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718007:13:1959:20261210"
+          },
+          "ok": true,
+          "text": "asked Champagnole Paul-Émile Victor -> Besançon Viotte on P8 (stop 7 to stop 13 of a 13-stop ride): got Champagnole Paul-Émile Victor -> Besançon Viotte on P8 d1, trip OCESN895518F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87718007:13:1959:20261210"
+        },
+        {
+          "asked": {
+            "destination": "Dole",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "Dole",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Dole on P8 (stop 1 to stop 13 of a 13-stop ride): got Saint-Claude -> Dole on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Champagnole Paul-Émile Victor",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Saint-Claude",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Champagnole Paul-Émile Victor",
+            "direction": 1,
+            "origin": "Saint-Claude",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Saint-Claude -> Champagnole Paul-Émile Victor on P8 (stop 1 to stop 7 of a 13-stop ride): got Saint-Claude -> Champagnole Paul-Émile Victor on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        },
+        {
+          "asked": {
+            "destination": "Dole",
+            "direction": null,
+            "from_stop": 7,
+            "origin": "Champagnole Paul-Émile Victor",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "Dole",
+            "direction": 1,
+            "origin": "Champagnole Paul-Émile Victor",
+            "route": "P8",
+            "trip": "OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+          },
+          "ok": true,
+          "text": "asked Champagnole Paul-Émile Victor -> Dole on P8 (stop 7 to stop 13 of a 13-stop ride): got Champagnole Paul-Émile Victor -> Dole on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212"
+        }
+      ],
+      "direction": 1,
+      "fixture": "sncf-journeys",
+      "id": "sncf-journeys-P8(A594575:)-d1-pairs",
+      "kind": "pairs",
+      "outcome": "xfailed",
+      "reason": "a train journey is matched by stop name prefix on any line, not the asked one",
+      "route": "FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575:"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Angerville",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Angerville",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Angerville -> Orléans on P8 (stop 1 to stop 8 of a 8-stop ride): got Angerville -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Chevilly",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Angerville",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "Chevilly",
+            "direction": 0,
+            "origin": "Angerville",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Angerville -> Chevilly on P8 (stop 1 to stop 5 of a 8-stop ride): got Angerville -> Chevilly on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 5,
+            "origin": "Chevilly",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Chevilly",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Chevilly -> Orléans on P8 (stop 5 to stop 8 of a 8-stop ride): got Chevilly -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Orléans on P8 (stop 1 to stop 9 of a 9-stop ride): got Paris Austerlitz -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Artenay",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "Artenay",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Artenay on P8 (stop 1 to stop 5 of a 9-stop ride): got Paris Austerlitz -> Artenay on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 5,
+            "origin": "Artenay",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Artenay",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Artenay -> Orléans on P8 (stop 5 to stop 9 of a 9-stop ride): got Artenay -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 11,
+            "route": "P8",
+            "to_stop": 11
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Orléans on P8 (stop 1 to stop 11 of a 11-stop ride): got Paris Austerlitz -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Château-Gaillard",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 11,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Château-Gaillard",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Château-Gaillard on P8 (stop 1 to stop 6 of a 11-stop ride): got Paris Austerlitz -> Château-Gaillard on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 6,
+            "origin": "Château-Gaillard",
+            "ride_length": 11,
+            "route": "P8",
+            "to_stop": 11
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Château-Gaillard",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Château-Gaillard -> Orléans on P8 (stop 6 to stop 11 of a 11-stop ride): got Château-Gaillard -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860591F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:10:1915:20261108"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Orléans on P8 (stop 1 to stop 10 of a 10-stop ride): got Paris Austerlitz -> Orléans on P8 d0, trip OCESN860591F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:10:1915:20261108"
+        },
+        {
+          "asked": {
+            "destination": "Toury",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Toury",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860591F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:10:1915:20261108"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Toury on P8 (stop 1 to stop 6 of a 10-stop ride): got Paris Austerlitz -> Toury on P8 d0, trip OCESN860591F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:10:1915:20261108"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 6,
+            "origin": "Toury",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Toury",
+            "route": "P8",
+            "trip": "OCESN860591F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:10:1915:20261108"
+          },
+          "ok": true,
+          "text": "asked Toury -> Orléans on P8 (stop 6 to stop 10 of a 10-stop ride): got Toury -> Orléans on P8 d0, trip OCESN860591F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:10:1915:20261108"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Orléans on P8 (stop 1 to stop 12 of a 12-stop ride): got Paris Austerlitz -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Château-Gaillard",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Château-Gaillard",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Château-Gaillard on P8 (stop 1 to stop 7 of a 12-stop ride): got Paris Austerlitz -> Château-Gaillard on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 7,
+            "origin": "Château-Gaillard",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Château-Gaillard",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Château-Gaillard -> Orléans on P8 (stop 7 to stop 12 of a 12-stop ride): got Château-Gaillard -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Orléans on P8 (stop 1 to stop 10 of a 10-stop ride): got Paris Austerlitz -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Boisseaux",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Boisseaux",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Boisseaux on P8 (stop 1 to stop 6 of a 10-stop ride): got Paris Austerlitz -> Boisseaux on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 6,
+            "origin": "Boisseaux",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Boisseaux",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Boisseaux -> Orléans on P8 (stop 6 to stop 10 of a 10-stop ride): got Boisseaux -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Orléans on P8 (stop 1 to stop 12 of a 12-stop ride): got Paris Austerlitz -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Toury",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Toury",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Toury on P8 (stop 1 to stop 7 of a 12-stop ride): got Paris Austerlitz -> Toury on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 7,
+            "origin": "Toury",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Toury",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Toury -> Orléans on P8 (stop 7 to stop 12 of a 12-stop ride): got Toury -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Orléans on P8 (stop 1 to stop 13 of a 13-stop ride): got Paris Austerlitz -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Toury",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Paris Austerlitz",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Toury",
+            "direction": 0,
+            "origin": "Paris Austerlitz",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Paris Austerlitz -> Toury on P8 (stop 1 to stop 7 of a 13-stop ride): got Paris Austerlitz -> Toury on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        },
+        {
+          "asked": {
+            "destination": "Orléans",
+            "direction": null,
+            "from_stop": 7,
+            "origin": "Toury",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "Orléans",
+            "direction": 0,
+            "origin": "Toury",
+            "route": "P8",
+            "trip": "OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+          },
+          "ok": true,
+          "text": "asked Toury -> Orléans on P8 (stop 7 to stop 13 of a 13-stop ride): got Toury -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106"
+        }
+      ],
+      "direction": 0,
+      "fixture": "sncf-journeys",
+      "id": "sncf-journeys-P8(CDD3F95:)-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95:"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "Château-Gaillard",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 6,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Château-Gaillard",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Château-Gaillard on P8 (stop 1 to stop 6 of a 6-stop ride): got Orléans -> Château-Gaillard on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Chevilly",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 6,
+            "route": "P8",
+            "to_stop": 4
+          },
+          "got": {
+            "destination": "Chevilly",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Chevilly on P8 (stop 1 to stop 4 of a 6-stop ride): got Orléans -> Chevilly on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Château-Gaillard",
+            "direction": null,
+            "from_stop": 4,
+            "origin": "Chevilly",
+            "ride_length": 6,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Château-Gaillard",
+            "direction": 1,
+            "origin": "Chevilly",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Chevilly -> Château-Gaillard on P8 (stop 4 to stop 6 of a 6-stop ride): got Chevilly -> Château-Gaillard on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Angerville",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "Angerville",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Angerville on P8 (stop 1 to stop 8 of a 8-stop ride): got Orléans -> Angerville on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Artenay",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "Artenay",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Artenay on P8 (stop 1 to stop 5 of a 8-stop ride): got Orléans -> Artenay on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Angerville",
+            "direction": null,
+            "from_stop": 5,
+            "origin": "Artenay",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "Angerville",
+            "direction": 1,
+            "origin": "Artenay",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Artenay -> Angerville on P8 (stop 5 to stop 8 of a 8-stop ride): got Artenay -> Angerville on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860586F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:13:1219:20261115"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 13 of a 13-stop ride): got Orléans -> Paris Austerlitz on P8 d1, trip OCESN860586F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:13:1219:20261115"
+        },
+        {
+          "asked": {
+            "destination": "Toury",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Toury",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860586F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:13:1219:20261115"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Toury on P8 (stop 1 to stop 7 of a 13-stop ride): got Orléans -> Toury on P8 d1, trip OCESN860586F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:13:1219:20261115"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 7,
+            "origin": "Toury",
+            "ride_length": 13,
+            "route": "P8",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Toury",
+            "route": "P8",
+            "trip": "OCESN860586F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:13:1219:20261115"
+          },
+          "ok": true,
+          "text": "asked Toury -> Paris Austerlitz on P8 (stop 7 to stop 13 of a 13-stop ride): got Toury -> Paris Austerlitz on P8 d1, trip OCESN860586F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:13:1219:20261115"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 11,
+            "route": "P8",
+            "to_stop": 11
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+          },
+          "ok": false,
+          "text": "asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 11 of a 11-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+        },
+        {
+          "asked": {
+            "destination": "Château-Gaillard",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 11,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Château-Gaillard",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Château-Gaillard on P8 (stop 1 to stop 6 of a 11-stop ride): got Orléans -> Château-Gaillard on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 6,
+            "origin": "Château-Gaillard",
+            "ride_length": 11,
+            "route": "P8",
+            "to_stop": 11
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Château-Gaillard",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Château-Gaillard -> Paris Austerlitz on P8 (stop 6 to stop 11 of a 11-stop ride): got Château-Gaillard -> Paris Austerlitz on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+          },
+          "ok": false,
+          "text": "asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 12 of a 12-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+        },
+        {
+          "asked": {
+            "destination": "Toury",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 7
+          },
+          "got": {
+            "destination": "Toury",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Toury on P8 (stop 1 to stop 7 of a 12-stop ride): got Orléans -> Toury on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 7,
+            "origin": "Toury",
+            "ride_length": 12,
+            "route": "P8",
+            "to_stop": 12
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Toury",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Toury -> Paris Austerlitz on P8 (stop 7 to stop 12 of a 12-stop ride): got Toury -> Paris Austerlitz on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+          },
+          "ok": false,
+          "text": "asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 10 of a 10-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+        },
+        {
+          "asked": {
+            "destination": "Château-Gaillard",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Château-Gaillard",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Château-Gaillard on P8 (stop 1 to stop 6 of a 10-stop ride): got Orléans -> Château-Gaillard on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 6,
+            "origin": "Château-Gaillard",
+            "ride_length": 10,
+            "route": "P8",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Château-Gaillard",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Château-Gaillard -> Paris Austerlitz on P8 (stop 6 to stop 10 of a 10-stop ride): got Château-Gaillard -> Paris Austerlitz on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+          },
+          "ok": false,
+          "text": "asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 9 of a 9-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+        },
+        {
+          "asked": {
+            "destination": "Artenay",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "Artenay",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Artenay on P8 (stop 1 to stop 5 of a 9-stop ride): got Orléans -> Artenay on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 5,
+            "origin": "Artenay",
+            "ride_length": 9,
+            "route": "P8",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Artenay",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Artenay -> Paris Austerlitz on P8 (stop 5 to stop 9 of a 9-stop ride): got Artenay -> Paris Austerlitz on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 11,
+            "route": "P8",
+            "to_stop": 11
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+          },
+          "ok": false,
+          "text": "asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 11 of a 11-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+        },
+        {
+          "asked": {
+            "destination": "Toury",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 11,
+            "route": "P8",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "Toury",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Toury on P8 (stop 1 to stop 6 of a 11-stop ride): got Orléans -> Toury on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 6,
+            "origin": "Toury",
+            "ride_length": 11,
+            "route": "P8",
+            "to_stop": 11
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Toury",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Toury -> Paris Austerlitz on P8 (stop 6 to stop 11 of a 11-stop ride): got Toury -> Paris Austerlitz on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+          },
+          "ok": false,
+          "text": "asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 8 of a 8-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+        },
+        {
+          "asked": {
+            "destination": "Monnerville",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "Monnerville",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Monnerville on P8 (stop 1 to stop 5 of a 8-stop ride): got Orléans -> Monnerville on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 5,
+            "origin": "Monnerville",
+            "ride_length": 8,
+            "route": "P8",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Monnerville",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Monnerville -> Paris Austerlitz on P8 (stop 5 to stop 8 of a 8-stop ride): got Monnerville -> Paris Austerlitz on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 5,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "K8+",
+            "trip": "OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+          },
+          "ok": false,
+          "text": "asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 5 of a 5-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119"
+        },
+        {
+          "asked": {
+            "destination": "Toury",
+            "direction": null,
+            "from_stop": 1,
+            "origin": "Orléans",
+            "ride_length": 5,
+            "route": "P8",
+            "to_stop": 3
+          },
+          "got": {
+            "destination": "Toury",
+            "direction": 1,
+            "origin": "Orléans",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Orléans -> Toury on P8 (stop 1 to stop 3 of a 5-stop ride): got Orléans -> Toury on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        },
+        {
+          "asked": {
+            "destination": "Paris Austerlitz",
+            "direction": null,
+            "from_stop": 3,
+            "origin": "Toury",
+            "ride_length": 5,
+            "route": "P8",
+            "to_stop": 5
+          },
+          "got": {
+            "destination": "Paris Austerlitz",
+            "direction": 1,
+            "origin": "Toury",
+            "route": "P8",
+            "trip": "OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+          },
+          "ok": true,
+          "text": "asked Toury -> Paris Austerlitz on P8 (stop 3 to stop 5 of a 5-stop ride): got Toury -> Paris Austerlitz on P8 d1, trip OCESN860582F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87547000:12:801:20261211"
+        }
+      ],
+      "direction": 1,
+      "fixture": "sncf-journeys",
+      "id": "sncf-journeys-P8(CDD3F95:)-d1-pairs",
+      "kind": "pairs",
+      "outcome": "xfailed",
+      "reason": "a train journey is matched by stop name prefix on any line, not the asked one",
+      "route": "FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95:"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:06001010",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01001010",
+            "ride_length": 32,
+            "route": "ORLEANS:Line:22",
+            "to_stop": 32
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:06001010",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01001010",
+            "route": "ORLEANS:Line:22",
+            "trip": "ORLEANS:VehicleJourney:22_R_100_10_2280_1_062801"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001010 -> ORLEANS:StopArea:06001010 on ORLEANS:Line:22 d0 (stop 1 to stop 32 of a 32-stop ride): got ORLEANS:StopArea:01001010 -> ORLEANS:StopArea:06001010 on ORLEANS:Line:22 d1, trip ORLEANS:VehicleJourney:22_R_100_10_2280_1_062801"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00027702",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01001010",
+            "ride_length": 32,
+            "route": "ORLEANS:Line:22",
+            "to_stop": 17
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00027702",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:01001010",
+            "route": "ORLEANS:Line:22",
+            "trip": "ORLEANS:VehicleJourney:22_A_98_10_2281_1_064001"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001010 -> ORLEANS:StopArea:00027702 on ORLEANS:Line:22 d0 (stop 1 to stop 17 of a 32-stop ride): got ORLEANS:StopArea:01001010 -> ORLEANS:StopArea:00027702 on ORLEANS:Line:22 d0, trip ORLEANS:VehicleJourney:22_A_98_10_2281_1_064001"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:06001010",
+            "direction": 0,
+            "from_stop": 17,
+            "origin": "ORLEANS:StopArea:00027702",
+            "ride_length": 32,
+            "route": "ORLEANS:Line:22",
+            "to_stop": 32
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:06001010",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:00027702",
+            "route": "ORLEANS:Line:22",
+            "trip": "ORLEANS:VehicleJourney:22_A_98_10_2281_1_064001"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00027702 -> ORLEANS:StopArea:06001010 on ORLEANS:Line:22 d0 (stop 17 to stop 32 of a 32-stop ride): got ORLEANS:StopArea:00027702 -> ORLEANS:StopArea:06001010 on ORLEANS:Line:22 d0, trip ORLEANS:VehicleJourney:22_A_98_10_2281_1_064001"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-22-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:22"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:01001010 .. ORLEANS:StopArea:06001010"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-22-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:22"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001010",
+            "direction": 0,
+            "from_stop": 32,
+            "origin": "ORLEANS:StopArea:06001010",
+            "ride_length": 32,
+            "route": "ORLEANS:Line:22",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:06001010 -> ORLEANS:StopArea:01001010 on ORLEANS:Line:22 d0 (stop 32 to stop 1 of a 32-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001010",
+            "direction": 0,
+            "from_stop": 17,
+            "origin": "ORLEANS:StopArea:00027702",
+            "ride_length": 32,
+            "route": "ORLEANS:Line:22",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00027702 -> ORLEANS:StopArea:01001010 on ORLEANS:Line:22 d0 (stop 17 to stop 1 of a 32-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00027702",
+            "direction": 0,
+            "from_stop": 32,
+            "origin": "ORLEANS:StopArea:06001010",
+            "ride_length": 32,
+            "route": "ORLEANS:Line:22",
+            "served": false,
+            "to_stop": 17
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:06001010 -> ORLEANS:StopArea:00027702 on ORLEANS:Line:22 d0 (stop 32 to stop 17 of a 32-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-22-d0-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:22"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:06001010",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01001010",
+            "ride_length": 32,
+            "route": "ORLEANS:Line:22",
+            "to_stop": 32
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:06001010",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01001010",
+            "route": "ORLEANS:Line:22",
+            "trip": "ORLEANS:VehicleJourney:22_R_100_10_2280_1_062801"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001010 -> ORLEANS:StopArea:06001010 on ORLEANS:Line:22 d1 (stop 1 to stop 32 of a 32-stop ride): got ORLEANS:StopArea:01001010 -> ORLEANS:StopArea:06001010 on ORLEANS:Line:22 d1, trip ORLEANS:VehicleJourney:22_R_100_10_2280_1_062801"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01042303",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01001010",
+            "ride_length": 32,
+            "route": "ORLEANS:Line:22",
+            "to_stop": 17
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01042303",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01001010",
+            "route": "ORLEANS:Line:22",
+            "trip": "ORLEANS:VehicleJourney:22_R_100_10_2280_1_062801"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001010 -> ORLEANS:StopArea:01042303 on ORLEANS:Line:22 d1 (stop 1 to stop 17 of a 32-stop ride): got ORLEANS:StopArea:01001010 -> ORLEANS:StopArea:01042303 on ORLEANS:Line:22 d1, trip ORLEANS:VehicleJourney:22_R_100_10_2280_1_062801"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:06001010",
+            "direction": 1,
+            "from_stop": 17,
+            "origin": "ORLEANS:StopArea:01042303",
+            "ride_length": 32,
+            "route": "ORLEANS:Line:22",
+            "to_stop": 32
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:06001010",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01042303",
+            "route": "ORLEANS:Line:22",
+            "trip": "ORLEANS:VehicleJourney:22_R_100_10_2280_1_062801"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01042303 -> ORLEANS:StopArea:06001010 on ORLEANS:Line:22 d1 (stop 17 to stop 32 of a 32-stop ride): got ORLEANS:StopArea:01042303 -> ORLEANS:StopArea:06001010 on ORLEANS:Line:22 d1, trip ORLEANS:VehicleJourney:22_R_100_10_2280_1_062801"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-22-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:22"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:01001010 .. ORLEANS:StopArea:06001010"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-22-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:22"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001010",
+            "direction": 1,
+            "from_stop": 32,
+            "origin": "ORLEANS:StopArea:06001010",
+            "ride_length": 32,
+            "route": "ORLEANS:Line:22",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:06001010 -> ORLEANS:StopArea:01001010 on ORLEANS:Line:22 d1 (stop 32 to stop 1 of a 32-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001010",
+            "direction": 1,
+            "from_stop": 17,
+            "origin": "ORLEANS:StopArea:01042303",
+            "ride_length": 32,
+            "route": "ORLEANS:Line:22",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01042303 -> ORLEANS:StopArea:01001010 on ORLEANS:Line:22 d1 (stop 17 to stop 1 of a 32-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01042303",
+            "direction": 1,
+            "from_stop": 32,
+            "origin": "ORLEANS:StopArea:06001010",
+            "ride_length": 32,
+            "route": "ORLEANS:Line:22",
+            "served": false,
+            "to_stop": 17
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:06001010 -> ORLEANS:StopArea:01042303 on ORLEANS:Line:22 d1 (stop 32 to stop 17 of a 32-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-22-d1-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:22"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:00007923",
+            "ride_length": 15,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:00007923",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_A_57_10_113_1_063501"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00007923 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0 (stop 1 to stop 15 of a 15-stop ride): got ORLEANS:StopArea:00007923 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0, trip ORLEANS:VehicleJourney:40_A_57_10_113_1_063501"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00005500",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:00007923",
+            "ride_length": 15,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 8
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00005500",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:00007923",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_A_57_10_113_1_063501"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00007923 -> ORLEANS:StopArea:00005500 on ORLEANS:Line:40 d0 (stop 1 to stop 8 of a 15-stop ride): got ORLEANS:StopArea:00007923 -> ORLEANS:StopArea:00005500 on ORLEANS:Line:40 d0, trip ORLEANS:VehicleJourney:40_A_57_10_113_1_063501"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 0,
+            "from_stop": 8,
+            "origin": "ORLEANS:StopArea:00005500",
+            "ride_length": 15,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 15
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:00005500",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_A_57_10_113_1_063501"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00005500 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0 (stop 8 to stop 15 of a 15-stop ride): got ORLEANS:StopArea:00005500 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0, trip ORLEANS:VehicleJourney:40_A_57_10_113_1_063501"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:00035910",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:00035910",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_A_86_10_4002_1_070100"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0 (stop 1 to stop 25 of a 25-stop ride): got ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0, trip ORLEANS:VehicleJourney:40_A_86_10_4002_1_070100"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01036003",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:00035910",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01036003",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:00035910",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_A_86_10_4002_1_070100"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01036003 on ORLEANS:Line:40 d0 (stop 1 to stop 13 of a 25-stop ride): got ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01036003 on ORLEANS:Line:40 d0, trip ORLEANS:VehicleJourney:40_A_86_10_4002_1_070100"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 0,
+            "from_stop": 13,
+            "origin": "ORLEANS:StopArea:01036003",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:01036003",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_A_57_10_113_1_063501"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01036003 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0 (stop 13 to stop 25 of a 25-stop ride): got ORLEANS:StopArea:01036003 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0, trip ORLEANS:VehicleJourney:40_A_57_10_113_1_063501"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-40-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:40"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:00007923 .. ORLEANS:StopArea:01001712"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:00035910 .. ORLEANS:StopArea:01001712"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-40-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "route": "ORLEANS:Line:40"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00007923",
+            "direction": 0,
+            "from_stop": 15,
+            "origin": "ORLEANS:StopArea:01001712",
+            "ride_length": 15,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d0 (stop 15 to stop 1 of a 15-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00007923",
+            "direction": 0,
+            "from_stop": 8,
+            "origin": "ORLEANS:StopArea:00005500",
+            "ride_length": 15,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00005500 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d0 (stop 8 to stop 1 of a 15-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00005500",
+            "direction": 0,
+            "from_stop": 15,
+            "origin": "ORLEANS:StopArea:01001712",
+            "ride_length": 15,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 8
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00005500 on ORLEANS:Line:40 d0 (stop 15 to stop 8 of a 15-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00035910",
+            "direction": 0,
+            "from_stop": 25,
+            "origin": "ORLEANS:StopArea:01001712",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00035910",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00035910",
+            "direction": 0,
+            "from_stop": 13,
+            "origin": "ORLEANS:StopArea:01036003",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01036003 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d0 (stop 13 to stop 1 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01036003",
+            "direction": 0,
+            "from_stop": 25,
+            "origin": "ORLEANS:StopArea:01001712",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 13
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:01036003 on ORLEANS:Line:40 d0 (stop 25 to stop 13 of a 25-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-40-d0-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "ORLEANS:Line:40"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00007924",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00007924",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00007924 on ORLEANS:Line:40 d1 (stop 1 to stop 16 of a 16-stop ride): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00007924 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00005501",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00005501",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00005501 on ORLEANS:Line:40 d1 (stop 1 to stop 9 of a 16-stop ride): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00005501 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00007924",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "ORLEANS:StopArea:00005501",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00007924",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:00005501",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00005501 -> ORLEANS:StopArea:00007924 on ORLEANS:Line:40 d1 (stop 9 to stop 16 of a 16-stop ride): got ORLEANS:StopArea:00005501 -> ORLEANS:StopArea:00007924 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00035910",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 26
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00035910",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1 (stop 1 to stop 26 of a 26-stop ride): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01036004",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01036004",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:01036004 on ORLEANS:Line:40 d1 (stop 1 to stop 14 of a 26-stop ride): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:01036004 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00035910",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:01036004",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 26
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00035910",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01036004",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01036004 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1 (stop 14 to stop 26 of a 26-stop ride): got ORLEANS:StopArea:01036004 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00007923",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "ride_length": 17,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 17
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00007923",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d1 (stop 1 to stop 17 of a 17-stop ride): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00005501",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "ride_length": 17,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00005501",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01001712",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00005501 on ORLEANS:Line:40 d1 (stop 1 to stop 9 of a 17-stop ride): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00005501 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00007923",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "ORLEANS:StopArea:00005501",
+            "ride_length": 17,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 17
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00007923",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:00005501",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00005501 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d1 (stop 9 to stop 17 of a 17-stop ride): got ORLEANS:StopArea:00005501 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00035910",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01017071",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00035910",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01017071",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_100_21_4007_1_071301"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01017071 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1 (stop 1 to stop 25 of a 25-stop ride): got ORLEANS:StopArea:01017071 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_100_21_4007_1_071301"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01036004",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01017071",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01036004",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01017071",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01017071 -> ORLEANS:StopArea:01036004 on ORLEANS:Line:40 d1 (stop 1 to stop 13 of a 25-stop ride): got ORLEANS:StopArea:01017071 -> ORLEANS:StopArea:01036004 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00035910",
+            "direction": 1,
+            "from_stop": 13,
+            "origin": "ORLEANS:StopArea:01036004",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00035910",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01036004",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_100_21_4007_1_071301"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01036004 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1 (stop 13 to stop 25 of a 25-stop ride): got ORLEANS:StopArea:01036004 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_100_21_4007_1_071301"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00007923",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01017071",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00007923",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01017071",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01017071 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d1 (stop 1 to stop 16 of a 16-stop ride): got ORLEANS:StopArea:01017071 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00047360",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01017071",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00047360",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01017071",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01017071 -> ORLEANS:StopArea:00047360 on ORLEANS:Line:40 d1 (stop 1 to stop 9 of a 16-stop ride): got ORLEANS:StopArea:01017071 -> ORLEANS:StopArea:00047360 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00007923",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "ORLEANS:StopArea:00047360",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:40",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00007923",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:00047360",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00047360 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d1 (stop 9 to stop 16 of a 16-stop ride): got ORLEANS:StopArea:00047360 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-40-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:40"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:01017071 .. ORLEANS:StopArea:00035910"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:01001712 .. ORLEANS:StopArea:00007924"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:01001712 .. ORLEANS:StopArea:00035910"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:01017071 .. ORLEANS:StopArea:00007923"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:01001712 .. ORLEANS:StopArea:00007923"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-40-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "route": "ORLEANS:Line:40"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "ORLEANS:StopArea:00007924",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00007924 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d1 (stop 16 to stop 1 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "ORLEANS:StopArea:00005501",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00005501 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d1 (stop 9 to stop 1 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00005501",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "ORLEANS:StopArea:00007924",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00007924 -> ORLEANS:StopArea:00005501 on ORLEANS:Line:40 d1 (stop 16 to stop 9 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 1,
+            "from_stop": 26,
+            "origin": "ORLEANS:StopArea:00035910",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:00035910",
+            "route": "ORLEANS:Line:40",
+            "trip": "ORLEANS:VehicleJourney:40_A_86_10_4002_1_070100"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d1 (stop 26 to stop 1 of a 26-stop ride, this direction does not make it): got ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0, trip ORLEANS:VehicleJourney:40_A_86_10_4002_1_070100"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:01036004",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01036004 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d1 (stop 14 to stop 1 of a 26-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01036004",
+            "direction": 1,
+            "from_stop": 26,
+            "origin": "ORLEANS:StopArea:00035910",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01036004 on ORLEANS:Line:40 d1 (stop 26 to stop 14 of a 26-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 1,
+            "from_stop": 17,
+            "origin": "ORLEANS:StopArea:00007923",
+            "ride_length": 17,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00007923 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d1 (stop 17 to stop 1 of a 17-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001712",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "ORLEANS:StopArea:00005501",
+            "ride_length": 17,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00005501 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d1 (stop 9 to stop 1 of a 17-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00005501",
+            "direction": 1,
+            "from_stop": 17,
+            "origin": "ORLEANS:StopArea:00007923",
+            "ride_length": 17,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00007923 -> ORLEANS:StopArea:00005501 on ORLEANS:Line:40 d1 (stop 17 to stop 9 of a 17-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01017071",
+            "direction": 1,
+            "from_stop": 25,
+            "origin": "ORLEANS:StopArea:00035910",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01017071 on ORLEANS:Line:40 d1 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01017071",
+            "direction": 1,
+            "from_stop": 13,
+            "origin": "ORLEANS:StopArea:01036004",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01036004 -> ORLEANS:StopArea:01017071 on ORLEANS:Line:40 d1 (stop 13 to stop 1 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01036004",
+            "direction": 1,
+            "from_stop": 25,
+            "origin": "ORLEANS:StopArea:00035910",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 13
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01036004 on ORLEANS:Line:40 d1 (stop 25 to stop 13 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01017071",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "ORLEANS:StopArea:00007923",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00007923 -> ORLEANS:StopArea:01017071 on ORLEANS:Line:40 d1 (stop 16 to stop 1 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01017071",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "ORLEANS:StopArea:00047360",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00047360 -> ORLEANS:StopArea:01017071 on ORLEANS:Line:40 d1 (stop 9 to stop 1 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00047360",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "ORLEANS:StopArea:00007923",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:40",
+            "served": false,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00007923 -> ORLEANS:StopArea:00047360 on ORLEANS:Line:40 d1 (stop 16 to stop 9 of a 16-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-40-d1-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "ORLEANS:Line:40"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001710",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:00043200",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:41",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01001710",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:00043200",
+            "route": "ORLEANS:Line:41",
+            "trip": "ORLEANS:VehicleJourney:41_A_30_10_4101_1_070200"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00043200 -> ORLEANS:StopArea:01001710 on ORLEANS:Line:41 d0 (stop 1 to stop 16 of a 16-stop ride): got ORLEANS:StopArea:00043200 -> ORLEANS:StopArea:01001710 on ORLEANS:Line:41 d0, trip ORLEANS:VehicleJourney:41_A_30_10_4101_1_070200"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00005502",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:00043200",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:41",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00005502",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:00043200",
+            "route": "ORLEANS:Line:41",
+            "trip": "ORLEANS:VehicleJourney:41_A_30_10_4101_1_070200"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00043200 -> ORLEANS:StopArea:00005502 on ORLEANS:Line:41 d0 (stop 1 to stop 9 of a 16-stop ride): got ORLEANS:StopArea:00043200 -> ORLEANS:StopArea:00005502 on ORLEANS:Line:41 d0, trip ORLEANS:VehicleJourney:41_A_30_10_4101_1_070200"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001710",
+            "direction": 0,
+            "from_stop": 9,
+            "origin": "ORLEANS:StopArea:00005502",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:41",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01001710",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:00005502",
+            "route": "ORLEANS:Line:41",
+            "trip": "ORLEANS:VehicleJourney:41_A_30_10_4101_1_070200"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00005502 -> ORLEANS:StopArea:01001710 on ORLEANS:Line:41 d0 (stop 9 to stop 16 of a 16-stop ride): got ORLEANS:StopArea:00005502 -> ORLEANS:StopArea:01001710 on ORLEANS:Line:41 d0, trip ORLEANS:VehicleJourney:41_A_30_10_4101_1_070200"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-41-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:41"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:00043200 .. ORLEANS:StopArea:01001710"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-41-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:41"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00043200",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "ORLEANS:StopArea:01001710",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:41",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001710 -> ORLEANS:StopArea:00043200 on ORLEANS:Line:41 d0 (stop 16 to stop 1 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00043200",
+            "direction": 0,
+            "from_stop": 9,
+            "origin": "ORLEANS:StopArea:00005502",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:41",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00005502 -> ORLEANS:StopArea:00043200 on ORLEANS:Line:41 d0 (stop 9 to stop 1 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00005502",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "ORLEANS:StopArea:01001710",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:41",
+            "served": false,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001710 -> ORLEANS:StopArea:00005502 on ORLEANS:Line:41 d0 (stop 16 to stop 9 of a 16-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-41-d0-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:41"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01030202",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01001710",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:41",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01030202",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01001710",
+            "route": "ORLEANS:Line:41",
+            "trip": "ORLEANS:VehicleJourney:41_R_29_10_4101_1_063301"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001710 -> ORLEANS:StopArea:01030202 on ORLEANS:Line:41 d1 (stop 1 to stop 16 of a 16-stop ride): got ORLEANS:StopArea:01001710 -> ORLEANS:StopArea:01030202 on ORLEANS:Line:41 d1, trip ORLEANS:VehicleJourney:41_R_29_10_4101_1_063301"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00002201",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01001710",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:41",
+            "to_stop": 9
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00002201",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01001710",
+            "route": "ORLEANS:Line:41",
+            "trip": "ORLEANS:VehicleJourney:41_R_29_10_4101_1_063301"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01001710 -> ORLEANS:StopArea:00002201 on ORLEANS:Line:41 d1 (stop 1 to stop 9 of a 16-stop ride): got ORLEANS:StopArea:01001710 -> ORLEANS:StopArea:00002201 on ORLEANS:Line:41 d1, trip ORLEANS:VehicleJourney:41_R_29_10_4101_1_063301"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01030202",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "ORLEANS:StopArea:00002201",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:41",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01030202",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:00002201",
+            "route": "ORLEANS:Line:41",
+            "trip": "ORLEANS:VehicleJourney:41_R_29_10_4101_1_063301"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00002201 -> ORLEANS:StopArea:01030202 on ORLEANS:Line:41 d1 (stop 9 to stop 16 of a 16-stop ride): got ORLEANS:StopArea:00002201 -> ORLEANS:StopArea:01030202 on ORLEANS:Line:41 d1, trip ORLEANS:VehicleJourney:41_R_29_10_4101_1_063301"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-41-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:41"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:01001710 .. ORLEANS:StopArea:01030202"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-41-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:41"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001710",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "ORLEANS:StopArea:01030202",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:41",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01030202 -> ORLEANS:StopArea:01001710 on ORLEANS:Line:41 d1 (stop 16 to stop 1 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01001710",
+            "direction": 1,
+            "from_stop": 9,
+            "origin": "ORLEANS:StopArea:00002201",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:41",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00002201 -> ORLEANS:StopArea:01001710 on ORLEANS:Line:41 d1 (stop 9 to stop 1 of a 16-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00002201",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "ORLEANS:StopArea:01030202",
+            "ride_length": 16,
+            "route": "ORLEANS:Line:41",
+            "served": false,
+            "to_stop": 9
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01030202 -> ORLEANS:StopArea:00002201 on ORLEANS:Line:41 d1 (stop 16 to stop 9 of a 16-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-41-d1-swapped",
+      "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:41"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THOPAC1",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 26
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPAC1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_476_21_A08_1_055250"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPAC1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0 (stop 1 to stop 26 of a 26-stop ride): got ORLEANS:StopArea:THOPAC1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_476_21_A08_1_055250"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TCSMAR1",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THOPAC1",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TCSMAR1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPAC1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_476_21_A08_1_055250"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPAC1 -> ORLEANS:StopArea:TCSMAR1 on ORLEANS:Line:A d0 (stop 1 to stop 14 of a 26-stop ride): got ORLEANS:StopArea:THOPAC1 -> ORLEANS:StopArea:TCSMAR1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_476_21_A08_1_055250"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TCSMAR1",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 26
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TCSMAR1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_476_21_A08_1_055250"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TCSMAR1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0 (stop 14 to stop 26 of a 26-stop ride): got ORLEANS:StopArea:TCSMAR1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_476_21_A08_1_055250"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THOPAC1",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 26
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPAC1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_473_10_A01_1_040220"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPAC1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0 (stop 1 to stop 26 of a 26-stop ride): got ORLEANS:StopArea:THOPAC1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_473_10_A01_1_040220"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TCSMAR1",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THOPAC1",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TCSMAR1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPAC1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_473_10_A01_1_040220"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPAC1 -> ORLEANS:StopArea:TCSMAR1 on ORLEANS:Line:A d0 (stop 1 to stop 14 of a 26-stop ride): got ORLEANS:StopArea:THOPAC1 -> ORLEANS:StopArea:TCSMAR1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_473_10_A01_1_040220"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TCSMAR1",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 26
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TCSMAR1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_473_10_A01_1_040220"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TCSMAR1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0 (stop 14 to stop 26 of a 26-stop ride): got ORLEANS:StopArea:TCSMAR1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_473_10_A01_1_040220"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_477_21_A01_1_055950"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0 (stop 1 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_477_21_A01_1_055950"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL1",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TMOUIL1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_477_21_A01_1_055950"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TMOUIL1 on ORLEANS:Line:A d0 (stop 1 to stop 14 of a 27-stop ride): got ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TMOUIL1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_477_21_A01_1_055950"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TMOUIL1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_476_21_A08_1_055250"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0 (stop 14 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:TMOUIL1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_476_21_A08_1_055250"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_467_10_A01_1_060100"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0 (stop 1 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_467_10_A01_1_060100"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL1",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TMOUIL1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_467_10_A01_1_060100"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TMOUIL1 on ORLEANS:Line:A d0 (stop 1 to stop 14 of a 27-stop ride): got ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TMOUIL1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_467_10_A01_1_060100"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TMOUIL1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_473_10_A01_1_040220"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0 (stop 14 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:TMOUIL1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_473_10_A01_1_040220"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_471_21_A01_1_080005"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0 (stop 1 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_471_21_A01_1_080005"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL1",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TMOUIL1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_471_21_A01_1_080005"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TMOUIL1 on ORLEANS:Line:A d0 (stop 1 to stop 14 of a 27-stop ride): got ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TMOUIL1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_471_21_A01_1_080005"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TMOUIL1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_476_21_A08_1_055250"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0 (stop 14 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:TMOUIL1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_476_21_A08_1_055250"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_466_10_A01_1_155930"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0 (stop 1 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_466_10_A01_1_155930"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL1",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TMOUIL1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_466_10_A01_1_155930"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TMOUIL1 on ORLEANS:Line:A d0 (stop 1 to stop 14 of a 27-stop ride): got ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TMOUIL1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_466_10_A01_1_155930"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TMOUIL1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_473_10_A01_1_040220"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0 (stop 14 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:TMOUIL1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_473_10_A01_1_040220"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-A-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:A"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": false,
+          "text": "the list offers one station twice in a row [('ORLEANS:StopArea:THOPIT2', 'ORLEANS:StopArea:THOPIT1')]"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:THOPIT2 .. ORLEANS:StopArea:TVERNE2"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:THOPIT1 .. ORLEANS:StopArea:TVERNE2"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:THOPIT2 .. ORLEANS:StopArea:TVERNE1"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:THOPAC1 .. ORLEANS:StopArea:TVERNE2"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:THOPAC1 .. ORLEANS:StopArea:TVERNE1"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:THOPIT1 .. ORLEANS:StopArea:TVERNE1"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-A-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "route": "ORLEANS:Line:A"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPAC1",
+            "direction": 0,
+            "from_stop": 26,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPAC1 on ORLEANS:Line:A d0 (stop 26 to stop 1 of a 26-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPAC1",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TCSMAR1",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TCSMAR1 -> ORLEANS:StopArea:THOPAC1 on ORLEANS:Line:A d0 (stop 14 to stop 1 of a 26-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TCSMAR1",
+            "direction": 0,
+            "from_stop": 26,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:TCSMAR1 on ORLEANS:Line:A d0 (stop 26 to stop 14 of a 26-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPAC1",
+            "direction": 0,
+            "from_stop": 26,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPAC1 on ORLEANS:Line:A d0 (stop 26 to stop 1 of a 26-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPAC1",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TCSMAR1",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TCSMAR1 -> ORLEANS:StopArea:THOPAC1 on ORLEANS:Line:A d0 (stop 14 to stop 1 of a 26-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TCSMAR1",
+            "direction": 0,
+            "from_stop": 26,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "ride_length": 26,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:TCSMAR1 on ORLEANS:Line:A d0 (stop 26 to stop 14 of a 26-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 0,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_470_21_A01_1_085930"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_470_21_A01_1_085930"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL1 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d0 (stop 14 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL1",
+            "direction": 0,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:TMOUIL1 on ORLEANS:Line:A d0 (stop 27 to stop 14 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 0,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_469_10_A01_1_050000"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_469_10_A01_1_050000"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL1 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d0 (stop 14 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL1",
+            "direction": 0,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:TMOUIL1 on ORLEANS:Line:A d0 (stop 27 to stop 14 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 0,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d0 (stop 14 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL1",
+            "direction": 0,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:TMOUIL1 on ORLEANS:Line:A d0 (stop 27 to stop 14 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 0,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_468_10_A01_1_145630"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_468_10_A01_1_145630"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 0,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d0 (stop 14 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL1",
+            "direction": 0,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:TMOUIL1 on ORLEANS:Line:A d0 (stop 27 to stop 14 of a 27-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-A-d0-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "ORLEANS:Line:A"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_470_21_A01_1_085930"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1 (stop 1 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_470_21_A01_1_085930"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL2",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TMOUIL2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:TMOUIL2 on ORLEANS:Line:A d1 (stop 1 to stop 14 of a 27-stop ride): got ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:TMOUIL2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TMOUIL2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_470_21_A01_1_085930"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL2 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1 (stop 14 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:TMOUIL2 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_470_21_A01_1_085930"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1 (stop 1 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL2",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TMOUIL2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TVERNE1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:TMOUIL2 on ORLEANS:Line:A d1 (stop 1 to stop 14 of a 27-stop ride): got ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:TMOUIL2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TMOUIL2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1 (stop 14 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:TMOUIL2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_469_10_A01_1_050000"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1 (stop 1 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_469_10_A01_1_050000"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL2",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TMOUIL2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_469_10_A01_1_050000"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:TMOUIL2 on ORLEANS:Line:A d1 (stop 1 to stop 14 of a 27-stop ride): got ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:TMOUIL2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_469_10_A01_1_050000"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THOPIT1",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TMOUIL2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_469_10_A01_1_050000"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL2 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1 (stop 14 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:TMOUIL2 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_469_10_A01_1_050000"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_468_10_A01_1_145630"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1 (stop 1 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_468_10_A01_1_145630"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL2",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 14
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TMOUIL2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TVERNE2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_469_10_A01_1_050000"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:TMOUIL2 on ORLEANS:Line:A d1 (stop 1 to stop 14 of a 27-stop ride): got ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:TMOUIL2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_469_10_A01_1_050000"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "to_stop": 27
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THOPIT2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TMOUIL2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_R_468_10_A01_1_145630"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1 (stop 14 to stop 27 of a 27-stop ride): got ORLEANS:StopArea:TMOUIL2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_468_10_A01_1_145630"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-A-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:A"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": false,
+          "text": "the list offers one station twice in a row [('ORLEANS:StopArea:TVERNE2', 'ORLEANS:StopArea:TVERNE1')]"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:TVERNE2 .. ORLEANS:StopArea:THOPIT2"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:TVERNE2 .. ORLEANS:StopArea:THOPIT1"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:TVERNE1 .. ORLEANS:StopArea:THOPIT1"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:TVERNE1 .. ORLEANS:StopArea:THOPIT2"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-A-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "route": "ORLEANS:Line:A"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 1,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_477_21_A01_1_055950"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_477_21_A01_1_055950"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL2 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d1 (stop 14 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL2",
+            "direction": 1,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TMOUIL2 on ORLEANS:Line:A d1 (stop 27 to stop 14 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 1,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_471_21_A01_1_080005"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_471_21_A01_1_080005"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE1",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL2 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d1 (stop 14 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL2",
+            "direction": 1,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TMOUIL2 on ORLEANS:Line:A d1 (stop 27 to stop 14 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 1,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_467_10_A01_1_060100"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_467_10_A01_1_060100"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d1 (stop 14 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL2",
+            "direction": 1,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:THOPIT1",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TMOUIL2 on ORLEANS:Line:A d1 (stop 27 to stop 14 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 1,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "route": "ORLEANS:Line:A",
+            "trip": "ORLEANS:VehicleJourney:A_A_466_10_A01_1_155930"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_466_10_A01_1_155930"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TVERNE2",
+            "direction": 1,
+            "from_stop": 14,
+            "origin": "ORLEANS:StopArea:TMOUIL2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TMOUIL2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d1 (stop 14 to stop 1 of a 27-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TMOUIL2",
+            "direction": 1,
+            "from_stop": 27,
+            "origin": "ORLEANS:StopArea:THOPIT2",
+            "ride_length": 27,
+            "route": "ORLEANS:Line:A",
+            "served": false,
+            "to_stop": 14
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TMOUIL2 on ORLEANS:Line:A d1 (stop 27 to stop 14 of a 27-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-A-d1-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "ORLEANS:Line:A"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THAMEA1",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TGAUBR2",
+            "ride_length": 6,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THAMEA1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TGAUBR2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_226_10_B02_1_043825"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TGAUBR2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0 (stop 1 to stop 6 of a 6-stop ride): got ORLEANS:StopArea:TGAUBR2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_226_10_B02_1_043825"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TCLARC2",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TGAUBR2",
+            "ride_length": 6,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 4
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TCLARC2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TGAUBR2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_226_10_B02_1_043825"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TGAUBR2 -> ORLEANS:StopArea:TCLARC2 on ORLEANS:Line:B d0 (stop 1 to stop 4 of a 6-stop ride): got ORLEANS:StopArea:TGAUBR2 -> ORLEANS:StopArea:TCLARC2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_226_10_B02_1_043825"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THAMEA1",
+            "direction": 0,
+            "from_stop": 4,
+            "origin": "ORLEANS:StopArea:TCLARC2",
+            "ride_length": 6,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 6
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THAMEA1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TCLARC2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_226_10_B02_1_043825"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TCLARC2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0 (stop 4 to stop 6 of a 6-stop ride): got ORLEANS:StopArea:TCLARC2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_226_10_B02_1_043825"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TAMBER2",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "ride_length": 19,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 19
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TAMBER2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_207_10_B07_1_003600"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:TAMBER2 on ORLEANS:Line:B d0 (stop 1 to stop 19 of a 19-stop ride): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:TAMBER2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_207_10_B07_1_003600"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TGAULB2",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "ride_length": 19,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TGAULB2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_207_10_B07_1_003600"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:TGAULB2 on ORLEANS:Line:B d0 (stop 1 to stop 10 of a 19-stop ride): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:TGAULB2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_207_10_B07_1_003600"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TAMBER2",
+            "direction": 0,
+            "from_stop": 10,
+            "origin": "ORLEANS:StopArea:TGAULB2",
+            "ride_length": 19,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 19
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TAMBER2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TGAULB2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_207_10_B07_1_003600"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TGAULB2 -> ORLEANS:StopArea:TAMBER2 on ORLEANS:Line:B d0 (stop 10 to stop 19 of a 19-stop ride): got ORLEANS:StopArea:TGAULB2 -> ORLEANS:StopArea:TAMBER2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_207_10_B07_1_003600"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THAMEA1",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THAMEA1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_167_10_B01_1_050300"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0 (stop 1 to stop 25 of a 25-stop ride): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_167_10_B01_1_050300"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THALMA2",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THALMA2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_207_10_B07_1_003600"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THALMA2 on ORLEANS:Line:B d0 (stop 1 to stop 13 of a 25-stop ride): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THALMA2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_207_10_B07_1_003600"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THAMEA1",
+            "direction": 0,
+            "from_stop": 13,
+            "origin": "ORLEANS:StopArea:THALMA2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THAMEA1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THALMA2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_167_10_B01_1_050300"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THALMA2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0 (stop 13 to stop 25 of a 25-stop ride): got ORLEANS:StopArea:THALMA2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_167_10_B01_1_050300"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THAMEA2",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THAMEA2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_168_10_B06_1_195730"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d0 (stop 1 to stop 25 of a 25-stop ride): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_168_10_B06_1_195730"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THALMA2",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THALMA2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_207_10_B07_1_003600"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THALMA2 on ORLEANS:Line:B d0 (stop 1 to stop 13 of a 25-stop ride): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THALMA2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_207_10_B07_1_003600"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THAMEA2",
+            "direction": 0,
+            "from_stop": 13,
+            "origin": "ORLEANS:StopArea:THALMA2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THAMEA2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:THALMA2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_168_10_B06_1_195730"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THALMA2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d0 (stop 13 to stop 25 of a 25-stop ride): got ORLEANS:StopArea:THALMA2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_168_10_B06_1_195730"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-B-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:B"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": false,
+          "text": "the list offers one station twice in a row [('ORLEANS:StopArea:THAMEA1', 'ORLEANS:StopArea:THAMEA2')]"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:TPOMPI2 .. ORLEANS:StopArea:THAMEA1"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:TPOMPI2 .. ORLEANS:StopArea:THAMEA2"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:TPOMPI2 .. ORLEANS:StopArea:TAMBER2"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:TGAUBR2 .. ORLEANS:StopArea:THAMEA1"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-B-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "route": "ORLEANS:Line:B"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TGAUBR2",
+            "direction": 0,
+            "from_stop": 6,
+            "origin": "ORLEANS:StopArea:THAMEA1",
+            "ride_length": 6,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TGAUBR2 on ORLEANS:Line:B d0 (stop 6 to stop 1 of a 6-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TGAUBR2",
+            "direction": 0,
+            "from_stop": 4,
+            "origin": "ORLEANS:StopArea:TCLARC2",
+            "ride_length": 6,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TCLARC2 -> ORLEANS:StopArea:TGAUBR2 on ORLEANS:Line:B d0 (stop 4 to stop 1 of a 6-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TCLARC2",
+            "direction": 0,
+            "from_stop": 6,
+            "origin": "ORLEANS:StopArea:THAMEA1",
+            "ride_length": 6,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 4
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TCLARC2 on ORLEANS:Line:B d0 (stop 6 to stop 4 of a 6-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 0,
+            "from_stop": 19,
+            "origin": "ORLEANS:StopArea:TAMBER2",
+            "ride_length": 19,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TAMBER2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 19 to stop 1 of a 19-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 0,
+            "from_stop": 10,
+            "origin": "ORLEANS:StopArea:TGAULB2",
+            "ride_length": 19,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TGAULB2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 10 to stop 1 of a 19-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TGAULB2",
+            "direction": 0,
+            "from_stop": 19,
+            "origin": "ORLEANS:StopArea:TAMBER2",
+            "ride_length": 19,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 10
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TAMBER2 -> ORLEANS:StopArea:TGAULB2 on ORLEANS:Line:B d0 (stop 19 to stop 10 of a 19-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 0,
+            "from_stop": 25,
+            "origin": "ORLEANS:StopArea:THAMEA1",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:THAMEA1",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_R_173_10_B01_1_055030"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_173_10_B01_1_055030"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 0,
+            "from_stop": 13,
+            "origin": "ORLEANS:StopArea:THALMA2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THALMA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 13 to stop 1 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THALMA2",
+            "direction": 0,
+            "from_stop": 25,
+            "origin": "ORLEANS:StopArea:THAMEA1",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 13
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:THALMA2 on ORLEANS:Line:B d0 (stop 25 to stop 13 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 0,
+            "from_stop": 25,
+            "origin": "ORLEANS:StopArea:THAMEA2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:THAMEA2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_R_175_10_B09_1_201110"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_175_10_B09_1_201110"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 0,
+            "from_stop": 13,
+            "origin": "ORLEANS:StopArea:THALMA2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THALMA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 13 to stop 1 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THALMA2",
+            "direction": 0,
+            "from_stop": 25,
+            "origin": "ORLEANS:StopArea:THAMEA2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 13
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:THALMA2 on ORLEANS:Line:B d0 (stop 25 to stop 13 of a 25-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-B-d0-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "ORLEANS:Line:B"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TAMBER1",
+            "ride_length": 19,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 19
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TAMBER1",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_R_174_10_B01_1_043010"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TAMBER1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1 (stop 1 to stop 19 of a 19-stop ride): got ORLEANS:StopArea:TAMBER1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_174_10_B01_1_043010"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TGAULB1",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:TAMBER1",
+            "ride_length": 19,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 10
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TGAULB1",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TAMBER1",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_R_174_10_B01_1_043010"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TAMBER1 -> ORLEANS:StopArea:TGAULB1 on ORLEANS:Line:B d1 (stop 1 to stop 10 of a 19-stop ride): got ORLEANS:StopArea:TAMBER1 -> ORLEANS:StopArea:TGAULB1 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_174_10_B01_1_043010"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "from_stop": 10,
+            "origin": "ORLEANS:StopArea:TGAULB1",
+            "ride_length": 19,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 19
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:TGAULB1",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_R_174_10_B01_1_043010"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TGAULB1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1 (stop 10 to stop 19 of a 19-stop ride): got ORLEANS:StopArea:TGAULB1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_174_10_B01_1_043010"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THAMEA1",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:THAMEA1",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_R_173_10_B01_1_055030"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1 (stop 1 to stop 25 of a 25-stop ride): got ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_173_10_B01_1_055030"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THALMA1",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THAMEA1",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THALMA1",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:THAMEA1",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_R_173_10_B01_1_055030"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:THALMA1 on ORLEANS:Line:B d1 (stop 1 to stop 13 of a 25-stop ride): got ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:THALMA1 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_173_10_B01_1_055030"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "from_stop": 13,
+            "origin": "ORLEANS:StopArea:THALMA1",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:THALMA1",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_R_174_10_B01_1_043010"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THALMA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1 (stop 13 to stop 25 of a 25-stop ride): got ORLEANS:StopArea:THALMA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_174_10_B01_1_043010"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THAMEA2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:THAMEA2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_R_175_10_B09_1_201110"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1 (stop 1 to stop 25 of a 25-stop ride): got ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_175_10_B09_1_201110"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THALMA1",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:THAMEA2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 13
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THALMA1",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:THAMEA2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_R_175_10_B09_1_201110"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:THALMA1 on ORLEANS:Line:B d1 (stop 1 to stop 13 of a 25-stop ride): got ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:THALMA1 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_175_10_B09_1_201110"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "from_stop": 13,
+            "origin": "ORLEANS:StopArea:THALMA1",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "to_stop": 25
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:TPOMPI2",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:THALMA1",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_R_174_10_B01_1_043010"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THALMA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1 (stop 13 to stop 25 of a 25-stop ride): got ORLEANS:StopArea:THALMA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_174_10_B01_1_043010"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-B-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:B"
+    },
+    {
+      "checks": [
+        {
+          "ok": false,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:THAMEA1 .. ORLEANS:StopArea:TPOMPI2"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:TAMBER1 .. ORLEANS:StopArea:TPOMPI2"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:THAMEA2 .. ORLEANS:StopArea:TPOMPI2"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-B-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "xfailed",
+      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "route": "ORLEANS:Line:B"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TAMBER1",
+            "direction": 1,
+            "from_stop": 19,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "ride_length": 19,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:TAMBER1 on ORLEANS:Line:B d1 (stop 19 to stop 1 of a 19-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TAMBER1",
+            "direction": 1,
+            "from_stop": 10,
+            "origin": "ORLEANS:StopArea:TGAULB1",
+            "ride_length": 19,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TGAULB1 -> ORLEANS:StopArea:TAMBER1 on ORLEANS:Line:B d1 (stop 10 to stop 1 of a 19-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:TGAULB1",
+            "direction": 1,
+            "from_stop": 19,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "ride_length": 19,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 10
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:TGAULB1 on ORLEANS:Line:B d1 (stop 19 to stop 10 of a 19-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THAMEA1",
+            "direction": 1,
+            "from_stop": 25,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THAMEA1",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_167_10_B01_1_050300"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d1 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_167_10_B01_1_050300"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THAMEA1",
+            "direction": 1,
+            "from_stop": 13,
+            "origin": "ORLEANS:StopArea:THALMA1",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THALMA1 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d1 (stop 13 to stop 1 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THALMA1",
+            "direction": 1,
+            "from_stop": 25,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 13
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THALMA1 on ORLEANS:Line:B d1 (stop 25 to stop 13 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THAMEA2",
+            "direction": 1,
+            "from_stop": 25,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:THAMEA2",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "route": "ORLEANS:Line:B",
+            "trip": "ORLEANS:VehicleJourney:B_A_168_10_B06_1_195730"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d1 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_168_10_B06_1_195730"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THAMEA2",
+            "direction": 1,
+            "from_stop": 13,
+            "origin": "ORLEANS:StopArea:THALMA1",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:THALMA1 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d1 (stop 13 to stop 1 of a 25-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:THALMA1",
+            "direction": 1,
+            "from_stop": 25,
+            "origin": "ORLEANS:StopArea:TPOMPI2",
+            "ride_length": 25,
+            "route": "ORLEANS:Line:B",
+            "served": false,
+            "to_stop": 13
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THALMA1 on ORLEANS:Line:B d1 (stop 25 to stop 13 of a 25-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-B-d1-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "ORLEANS:Line:B"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01002003",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01086001",
+            "ride_length": 30,
+            "route": "ORLEANS:Line:N",
+            "to_stop": 30
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01002003",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:01086001",
+            "route": "ORLEANS:Line:N",
+            "trip": "ORLEANS:VehicleJourney:N_A_17_21_2184_4_003001"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01086001 -> ORLEANS:StopArea:01002003 on ORLEANS:Line:N d0 (stop 1 to stop 30 of a 30-stop ride): got ORLEANS:StopArea:01086001 -> ORLEANS:StopArea:01002003 on ORLEANS:Line:N d0, trip ORLEANS:VehicleJourney:N_A_17_21_2184_4_003001"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00041020",
+            "direction": 0,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01086001",
+            "ride_length": 30,
+            "route": "ORLEANS:Line:N",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:00041020",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:01086001",
+            "route": "ORLEANS:Line:N",
+            "trip": "ORLEANS:VehicleJourney:N_A_17_21_2184_4_003001"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01086001 -> ORLEANS:StopArea:00041020 on ORLEANS:Line:N d0 (stop 1 to stop 16 of a 30-stop ride): got ORLEANS:StopArea:01086001 -> ORLEANS:StopArea:00041020 on ORLEANS:Line:N d0, trip ORLEANS:VehicleJourney:N_A_17_21_2184_4_003001"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01002003",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "ORLEANS:StopArea:00041020",
+            "ride_length": 30,
+            "route": "ORLEANS:Line:N",
+            "to_stop": 30
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01002003",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:00041020",
+            "route": "ORLEANS:Line:N",
+            "trip": "ORLEANS:VehicleJourney:N_A_17_21_2184_4_003001"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00041020 -> ORLEANS:StopArea:01002003 on ORLEANS:Line:N d0 (stop 16 to stop 30 of a 30-stop ride): got ORLEANS:StopArea:00041020 -> ORLEANS:StopArea:01002003 on ORLEANS:Line:N d0, trip ORLEANS:VehicleJourney:N_A_17_21_2184_4_003001"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-N-d0-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:N"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:01086001 .. ORLEANS:StopArea:01002003"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-N-d0-stop_list",
+      "kind": "stop_list",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:N"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01086001",
+            "direction": 0,
+            "from_stop": 30,
+            "origin": "ORLEANS:StopArea:01002003",
+            "ride_length": 30,
+            "route": "ORLEANS:Line:N",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01086001",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01002003",
+            "route": "ORLEANS:Line:N",
+            "trip": "ORLEANS:VehicleJourney:N_R_16_21_2184_4_013000"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d0 (stop 30 to stop 1 of a 30-stop ride, this direction does not make it): got ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d1, trip ORLEANS:VehicleJourney:N_R_16_21_2184_4_013000"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01086001",
+            "direction": 0,
+            "from_stop": 16,
+            "origin": "ORLEANS:StopArea:00041020",
+            "ride_length": 30,
+            "route": "ORLEANS:Line:N",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:00041020 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d0 (stop 16 to stop 1 of a 30-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:00041020",
+            "direction": 0,
+            "from_stop": 30,
+            "origin": "ORLEANS:StopArea:01002003",
+            "ride_length": 30,
+            "route": "ORLEANS:Line:N",
+            "served": false,
+            "to_stop": 16
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:00041020 on ORLEANS:Line:N d0 (stop 30 to stop 16 of a 30-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-N-d0-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "ORLEANS:Line:N"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01086001",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01002003",
+            "ride_length": 30,
+            "route": "ORLEANS:Line:N",
+            "to_stop": 30
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01086001",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01002003",
+            "route": "ORLEANS:Line:N",
+            "trip": "ORLEANS:VehicleJourney:N_R_16_21_2184_4_013000"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d1 (stop 1 to stop 30 of a 30-stop ride): got ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d1, trip ORLEANS:VehicleJourney:N_R_16_21_2184_4_013000"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01078703",
+            "direction": 1,
+            "from_stop": 1,
+            "origin": "ORLEANS:StopArea:01002003",
+            "ride_length": 30,
+            "route": "ORLEANS:Line:N",
+            "to_stop": 16
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01078703",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01002003",
+            "route": "ORLEANS:Line:N",
+            "trip": "ORLEANS:VehicleJourney:N_R_16_21_2184_4_013000"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01078703 on ORLEANS:Line:N d1 (stop 1 to stop 16 of a 30-stop ride): got ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01078703 on ORLEANS:Line:N d1, trip ORLEANS:VehicleJourney:N_R_16_21_2184_4_013000"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01086001",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "ORLEANS:StopArea:01078703",
+            "ride_length": 30,
+            "route": "ORLEANS:Line:N",
+            "to_stop": 30
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01086001",
+            "direction": 1,
+            "origin": "ORLEANS:StopArea:01078703",
+            "route": "ORLEANS:Line:N",
+            "trip": "ORLEANS:VehicleJourney:N_R_16_21_2184_4_013000"
+          },
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01078703 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d1 (stop 16 to stop 30 of a 30-stop ride): got ORLEANS:StopArea:01078703 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d1, trip ORLEANS:VehicleJourney:N_R_16_21_2184_4_013000"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-N-d1-pairs",
+      "kind": "pairs",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:N"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "text": "the stop list repeats a stop_id"
+        },
+        {
+          "ok": true,
+          "text": "the list offers one station twice in a row []"
+        },
+        {
+          "ok": true,
+          "text": "a trip serves a stop the list does not offer"
+        },
+        {
+          "ok": true,
+          "text": "the list contradicts the riding order ORLEANS:StopArea:01002003 .. ORLEANS:StopArea:01086001"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-N-d1-stop_list",
+      "kind": "stop_list",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:N"
+    },
+    {
+      "checks": [
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01002003",
+            "direction": 1,
+            "from_stop": 30,
+            "origin": "ORLEANS:StopArea:01086001",
+            "ride_length": 30,
+            "route": "ORLEANS:Line:N",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": {
+            "destination": "ORLEANS:StopArea:01002003",
+            "direction": 0,
+            "origin": "ORLEANS:StopArea:01086001",
+            "route": "ORLEANS:Line:N",
+            "trip": "ORLEANS:VehicleJourney:N_A_17_21_2184_4_003001"
+          },
+          "ok": false,
+          "text": "asked ORLEANS:StopArea:01086001 -> ORLEANS:StopArea:01002003 on ORLEANS:Line:N d1 (stop 30 to stop 1 of a 30-stop ride, this direction does not make it): got ORLEANS:StopArea:01086001 -> ORLEANS:StopArea:01002003 on ORLEANS:Line:N d0, trip ORLEANS:VehicleJourney:N_A_17_21_2184_4_003001"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01002003",
+            "direction": 1,
+            "from_stop": 16,
+            "origin": "ORLEANS:StopArea:01078703",
+            "ride_length": 30,
+            "route": "ORLEANS:Line:N",
+            "served": false,
+            "to_stop": 1
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01078703 -> ORLEANS:StopArea:01002003 on ORLEANS:Line:N d1 (stop 16 to stop 1 of a 30-stop ride, this direction does not make it): no departure"
+        },
+        {
+          "asked": {
+            "destination": "ORLEANS:StopArea:01078703",
+            "direction": 1,
+            "from_stop": 30,
+            "origin": "ORLEANS:StopArea:01086001",
+            "ride_length": 30,
+            "route": "ORLEANS:Line:N",
+            "served": false,
+            "to_stop": 16
+          },
+          "got": null,
+          "ok": true,
+          "text": "asked ORLEANS:StopArea:01086001 -> ORLEANS:StopArea:01078703 on ORLEANS:Line:N d1 (stop 30 to stop 16 of a 30-stop ride, this direction does not make it): no departure"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-N-d1-swapped",
+      "kind": "swapped",
+      "outcome": "xfailed",
+      "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "ORLEANS:Line:N"
+    }
+  ]
+}

--- a/tests_provider/results.json
+++ b/tests_provider/results.json
@@ -315,15 +315,103 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "3979766": [
+              "5",
+              "8",
+              "20",
+              "23"
+            ],
+            "3979810": [
+              "12",
+              "15",
+              "27",
+              "30"
+            ],
+            "3979846": [
+              "3",
+              "6",
+              "18",
+              "21"
+            ],
+            "3979966": [
+              "1",
+              "13"
+            ],
+            "3980107": [
+              "10",
+              "13",
+              "25",
+              "28"
+            ],
+            "3980187": [
+              "2",
+              "5",
+              "17",
+              "20"
+            ],
+            "3980498": [
+              "6",
+              "9",
+              "21",
+              "24"
+            ],
+            "3980764": [
+              "11",
+              "14",
+              "26",
+              "29"
+            ],
+            "3980814": [
+              "7",
+              "10",
+              "22",
+              "25"
+            ],
+            "3980938": [
+              "2",
+              "14"
+            ],
+            "3981021": [
+              "8",
+              "11",
+              "23",
+              "26"
+            ],
+            "3981063": [
+              "3",
+              "15"
+            ],
+            "3981181": [
+              "4",
+              "7",
+              "19",
+              "22"
+            ],
+            "3981412": [
+              "9",
+              "12",
+              "24",
+              "27"
+            ],
+            "4138837": [
+              "1",
+              "4",
+              "16",
+              "19"
+            ]
+          },
+          "text": "the stop list offers a stop twice: 4138837 Amsterdam, Leidseplein at 1 and 4 and 16 and 19, 3979966 Amsterdam, Rhijnvis Feithstraat at 1 and 13, 3980187 Amsterdam, Rijksmuseum at 2 and 5 and 17 and 20, and 12 more"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -331,7 +419,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -339,7 +428,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -347,7 +437,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -355,7 +446,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -921,15 +1013,144 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "3979725": [
+              "1",
+              "16",
+              "19"
+            ],
+            "3979766": [
+              "8",
+              "9"
+            ],
+            "3979810": [
+              "15",
+              "16"
+            ],
+            "3979846": [
+              "6",
+              "7"
+            ],
+            "3979851": [
+              "8",
+              "23",
+              "26"
+            ],
+            "3979966": [
+              "1",
+              "2"
+            ],
+            "3980050": [
+              "4",
+              "19",
+              "22"
+            ],
+            "3980107": [
+              "13",
+              "14"
+            ],
+            "3980113": [
+              "9",
+              "24",
+              "27"
+            ],
+            "3980187": [
+              "5",
+              "6"
+            ],
+            "3980204": [
+              "7",
+              "22",
+              "25"
+            ],
+            "3980220": [
+              "2",
+              "17",
+              "20"
+            ],
+            "3980231": [
+              "5",
+              "20",
+              "23"
+            ],
+            "3980258": [
+              "6",
+              "21",
+              "24"
+            ],
+            "3980498": [
+              "9",
+              "10"
+            ],
+            "3980711": [
+              "11",
+              "26",
+              "29"
+            ],
+            "3980743": [
+              "12",
+              "27",
+              "30"
+            ],
+            "3980764": [
+              "14",
+              "15"
+            ],
+            "3980814": [
+              "10",
+              "11"
+            ],
+            "3980938": [
+              "2",
+              "3"
+            ],
+            "3981021": [
+              "11",
+              "12"
+            ],
+            "3981063": [
+              "3",
+              "4"
+            ],
+            "3981181": [
+              "7",
+              "8"
+            ],
+            "3981217": [
+              "10",
+              "25",
+              "28"
+            ],
+            "3981412": [
+              "12",
+              "13"
+            ],
+            "3981436": [
+              "3",
+              "18",
+              "21"
+            ],
+            "4138837": [
+              "4",
+              "5"
+            ]
+          },
+          "text": "the stop list offers a stop twice: 3979966 Amsterdam, Rhijnvis Feithstraat at 1 and 2, 3979725 Amsterdam, Surinameplein at 1 and 16 and 19, 3980938 Amsterdam, Jan Pieter Heijestraat at 2 and 3, and 24 more"
         },
         {
+          "folded": [
+            [
+              "3979766",
+              "3980631"
+            ]
+          ],
           "ok": false,
-          "text": "the list offers one station twice in a row [('3979766', '3980631')]"
+          "text": "the list offers one station twice in a row: 3979766 Amsterdam, Weesperplein then 3980631 Amsterdam, Weesperplein"
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -937,7 +1158,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -945,7 +1167,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -953,7 +1176,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -961,7 +1185,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -1407,15 +1632,76 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "3979794": [
+              "1",
+              "10"
+            ],
+            "3980128": [
+              "6",
+              "15"
+            ],
+            "3980268": [
+              "7",
+              "16"
+            ],
+            "3980349": [
+              "11",
+              "20"
+            ],
+            "3980464": [
+              "2",
+              "11"
+            ],
+            "3980544": [
+              "3",
+              "12"
+            ],
+            "3980579": [
+              "4",
+              "13"
+            ],
+            "3980590": [
+              "10",
+              "19"
+            ],
+            "3980701": [
+              "8",
+              "17"
+            ],
+            "3980882": [
+              "9",
+              "18"
+            ],
+            "3981052": [
+              "12",
+              "21"
+            ],
+            "3981133": [
+              "13",
+              "22"
+            ],
+            "3981334": [
+              "5",
+              "14"
+            ]
+          },
+          "text": "the stop list offers a stop twice: 3979794 Amsterdam, Mercatorplein at 1 and 10, 3980464 Amsterdam, Marco Polostraat at 2 and 11, 3980544 Amsterdam, Admiraal de Ruijterweg at 3 and 12, and 10 more"
         },
         {
+          "folded": [
+            [
+              "3980268",
+              "3980182"
+            ]
+          ],
           "ok": false,
-          "text": "the list offers one station twice in a row [('3980268', '3980182')]"
+          "text": "the list offers one station twice in a row: 3980268 Amsterdam, Elandsgracht then 3980182 Amsterdam, Elandsgracht"
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -1423,7 +1709,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -1431,7 +1718,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -1787,15 +2075,55 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "3979744": [
+              "8",
+              "21"
+            ],
+            "3979970": [
+              "7",
+              "20"
+            ],
+            "3980106": [
+              "9",
+              "22"
+            ],
+            "3980162": [
+              "3",
+              "16"
+            ],
+            "3980246": [
+              "6",
+              "19"
+            ],
+            "3980252": [
+              "5",
+              "18"
+            ],
+            "3980794": [
+              "1",
+              "14"
+            ],
+            "3980974": [
+              "2",
+              "15"
+            ],
+            "3981165": [
+              "4",
+              "17"
+            ]
+          },
+          "text": "the stop list offers a stop twice: 3980794 Amsterdam, Admiraal Helfrichstraat at 1 and 14, 3980974 Amsterdam, Jan Voermanstraat at 2 and 15, 3980162 Amsterdam, Jan Tooropstraat at 3 and 16, and 6 more"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -1803,7 +2131,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -1811,7 +2140,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -2407,15 +2737,104 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "3979727": [
+              "2",
+              "10"
+            ],
+            "3979768": [
+              "2",
+              "9"
+            ],
+            "3979798": [
+              "6",
+              "13"
+            ],
+            "3979805": [
+              "1",
+              "9"
+            ],
+            "3979826": [
+              "9",
+              "16"
+            ],
+            "3979886": [
+              "3",
+              "10"
+            ],
+            "3979931": [
+              "5",
+              "13"
+            ],
+            "3980213": [
+              "7",
+              "14"
+            ],
+            "3980234": [
+              "4",
+              "12"
+            ],
+            "3980239": [
+              "5",
+              "12"
+            ],
+            "3980489": [
+              "8",
+              "15"
+            ],
+            "3980549": [
+              "1",
+              "8"
+            ],
+            "3980629": [
+              "7",
+              "15"
+            ],
+            "3980771": [
+              "4",
+              "11"
+            ],
+            "3980804": [
+              "6",
+              "14"
+            ],
+            "3980826": [
+              "3",
+              "11"
+            ],
+            "3980992": [
+              "8",
+              "16"
+            ],
+            "3981274": [
+              "1",
+              "16"
+            ],
+            "4045456": [
+              "10",
+              "17"
+            ]
+          },
+          "text": "the stop list offers a stop twice: 3981274 Amsterdam, Centraal Station at 1 and 16, 3979805 Amsterdam, Mauritskade at 1 and 9, 3980549 Amsterdam, Mauritskade at 1 and 8, and 16 more"
         },
         {
+          "folded": [
+            [
+              "3980489",
+              "3980251"
+            ],
+            [
+              "3981274",
+              "4045456"
+            ]
+          ],
           "ok": false,
-          "text": "the list offers one station twice in a row [('3980489', '3980251')]"
+          "text": "the list offers one station twice in a row: 3980489 Amsterdam, Dam then 3980251 Amsterdam, Dam, 3981274 Amsterdam, Centraal Station then 4045456 Amsterdam, Centraal Station"
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -2423,7 +2842,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -2431,7 +2851,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -2439,7 +2860,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -2447,7 +2869,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -2455,7 +2878,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -2463,7 +2887,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -3185,15 +3610,111 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "3979727": [
+              "2",
+              "10"
+            ],
+            "3979768": [
+              "2",
+              "8",
+              "9"
+            ],
+            "3979798": [
+              "6",
+              "12",
+              "13"
+            ],
+            "3979805": [
+              "1",
+              "9"
+            ],
+            "3979886": [
+              "3",
+              "9",
+              "10"
+            ],
+            "3979931": [
+              "5",
+              "13"
+            ],
+            "3980213": [
+              "7",
+              "13",
+              "14"
+            ],
+            "3980234": [
+              "1",
+              "4",
+              "12"
+            ],
+            "3980239": [
+              "5",
+              "11",
+              "12"
+            ],
+            "3980251": [
+              "8",
+              "14",
+              "15"
+            ],
+            "3980549": [
+              "1",
+              "7",
+              "8"
+            ],
+            "3980629": [
+              "7",
+              "15"
+            ],
+            "3980771": [
+              "4",
+              "10",
+              "11"
+            ],
+            "3980804": [
+              "6",
+              "14"
+            ],
+            "3980826": [
+              "3",
+              "11"
+            ],
+            "3980992": [
+              "8",
+              "16"
+            ],
+            "3981274": [
+              "1",
+              "9",
+              "15",
+              "16"
+            ]
+          },
+          "text": "the stop list offers a stop twice: 3980549 Amsterdam, Mauritskade at 1 and 7 and 8, 3980234 Amsterdam, Javaplein at 1 and 4 and 12, 3981274 Amsterdam, Centraal Station at 1 and 9 and 15 and 16, and 14 more"
         },
         {
+          "folded": [
+            [
+              "4045456",
+              "3981274"
+            ],
+            [
+              "3980234",
+              "3981356"
+            ],
+            [
+              "3979768",
+              "3981148"
+            ]
+          ],
           "ok": false,
-          "text": "the list offers one station twice in a row [('4045456', '3981274')]"
+          "text": "the list offers one station twice in a row: 4045456 Amsterdam, Centraal Station then 3981274 Amsterdam, Centraal Station, 3980234 Amsterdam, Javaplein then 3981356 Amsterdam, Javaplein, 3979768 Amsterdam, Plantage Lepellaan then 3981148 Amsterdam, Plantage Lepellaan"
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -3201,7 +3722,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -3209,7 +3731,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": false,
@@ -3217,7 +3740,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -3225,7 +3749,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": false,
@@ -3233,7 +3758,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -3790,15 +4316,89 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "3979746": [
+              "5",
+              "15"
+            ],
+            "3979826": [
+              "7",
+              "13",
+              "23"
+            ],
+            "3979912": [
+              "2",
+              "8",
+              "18"
+            ],
+            "3980023": [
+              "5",
+              "11",
+              "21"
+            ],
+            "3980305": [
+              "1",
+              "11"
+            ],
+            "3980394": [
+              "6",
+              "16"
+            ],
+            "3980489": [
+              "6",
+              "12",
+              "22"
+            ],
+            "3980573": [
+              "4",
+              "10",
+              "20"
+            ],
+            "3980593": [
+              "2",
+              "12"
+            ],
+            "3980596": [
+              "4",
+              "14"
+            ],
+            "3980599": [
+              "1",
+              "7",
+              "17"
+            ],
+            "3980642": [
+              "3",
+              "9",
+              "19"
+            ],
+            "3980752": [
+              "3",
+              "13"
+            ],
+            "3981271": [
+              "1",
+              "8",
+              "14",
+              "24"
+            ]
+          },
+          "text": "the stop list offers a stop twice: 3980305 Amsterdam, Corantijnstraat at 1 and 11, 3981271 Amsterdam, Centraal Station at 1 and 8 and 14 and 24, 3980599 Amsterdam, Leidseplein at 1 and 7 and 17, and 11 more"
         },
         {
+          "folded": [
+            [
+              "3981140",
+              "3980752"
+            ]
+          ],
           "ok": false,
-          "text": "the list offers one station twice in a row [('3981140', '3980752')]"
+          "text": "the list offers one station twice in a row: 3981140 Amsterdam, Witte de Withstraat then 3980752 Amsterdam, Witte de Withstraat"
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -3806,7 +4406,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -3814,7 +4415,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": false,
@@ -3822,7 +4424,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -4283,15 +4886,97 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "3979725": [
+              "1",
+              "15"
+            ],
+            "3979826": [
+              "7",
+              "14"
+            ],
+            "3979912": [
+              "2",
+              "9"
+            ],
+            "3979971": [
+              "8",
+              "22"
+            ],
+            "3980023": [
+              "5",
+              "12"
+            ],
+            "3980050": [
+              "4",
+              "18"
+            ],
+            "3980220": [
+              "2",
+              "16"
+            ],
+            "3980231": [
+              "5",
+              "19"
+            ],
+            "3980240": [
+              "7",
+              "21"
+            ],
+            "3980351": [
+              "10",
+              "24"
+            ],
+            "3980489": [
+              "6",
+              "13"
+            ],
+            "3980573": [
+              "4",
+              "11"
+            ],
+            "3980599": [
+              "1",
+              "8"
+            ],
+            "3980642": [
+              "3",
+              "10"
+            ],
+            "3980728": [
+              "9",
+              "23"
+            ],
+            "3980933": [
+              "6",
+              "20"
+            ],
+            "3981271": [
+              "1",
+              "8",
+              "15"
+            ],
+            "3981436": [
+              "3",
+              "17"
+            ]
+          },
+          "text": "the stop list offers a stop twice: 3981271 Amsterdam, Centraal Station at 1 and 8 and 15, 3979725 Amsterdam, Surinameplein at 1 and 15, 3980599 Amsterdam, Leidseplein at 1 and 8, and 15 more"
         },
         {
+          "folded": [
+            [
+              "3980573",
+              "3980418"
+            ]
+          ],
           "ok": false,
-          "text": "the list offers one station twice in a row [('3980573', '3980418')]"
+          "text": "the list offers one station twice in a row: 3980573 Amsterdam, Koningsplein then 3980418 Amsterdam, Koningsplein"
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": false,
@@ -4299,7 +4984,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -4307,7 +4993,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -4315,7 +5002,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -4776,15 +5464,125 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "3979766": [
+              "2",
+              "20"
+            ],
+            "3979816": [
+              "11",
+              "21"
+            ],
+            "3979878": [
+              "5",
+              "23"
+            ],
+            "3979897": [
+              "2",
+              "12"
+            ],
+            "3979909": [
+              "17",
+              "27"
+            ],
+            "3979969": [
+              "18",
+              "28"
+            ],
+            "3980004": [
+              "1",
+              "11"
+            ],
+            "3980013": [
+              "5",
+              "15"
+            ],
+            "3980057": [
+              "4",
+              "22"
+            ],
+            "3980060": [
+              "10",
+              "20"
+            ],
+            "3980102": [
+              "1",
+              "20",
+              "30"
+            ],
+            "3980149": [
+              "12",
+              "22"
+            ],
+            "3980176": [
+              "13",
+              "23"
+            ],
+            "3980235": [
+              "7",
+              "17"
+            ],
+            "3980270": [
+              "9",
+              "19"
+            ],
+            "3980379": [
+              "4",
+              "14"
+            ],
+            "3980413": [
+              "14",
+              "24"
+            ],
+            "3980469": [
+              "3",
+              "13"
+            ],
+            "3980564": [
+              "16",
+              "26"
+            ],
+            "3980572": [
+              "15",
+              "25"
+            ],
+            "3980735": [
+              "3",
+              "21"
+            ],
+            "3980825": [
+              "19",
+              "29"
+            ],
+            "3980831": [
+              "6",
+              "16"
+            ],
+            "3981140": [
+              "8",
+              "18"
+            ],
+            "3981181": [
+              "1",
+              "19"
+            ]
+          },
+          "text": "the stop list offers a stop twice: 3980004 Amsterdam, Frederiksplein at 1 and 11, 3980102 Amsterdam, Sloterpark at 1 and 20 and 30, 3981181 Amsterdam, Frederiksplein at 1 and 19, and 22 more"
         },
         {
+          "folded": [
+            [
+              "3980060",
+              "3980854"
+            ]
+          ],
           "ok": false,
-          "text": "the list offers one station twice in a row [('3980060', '3980854')]"
+          "text": "the list offers one station twice in a row: 3980060 Amsterdam, Willem Schoutenstraat then 3980854 Amsterdam, Willem Schoutenstraat"
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -4792,7 +5590,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -4800,7 +5599,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": false,
@@ -4808,7 +5608,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -5275,15 +6076,149 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "3979766": [
+              "2",
+              "20"
+            ],
+            "3979816": [
+              "11",
+              "15"
+            ],
+            "3979897": [
+              "2",
+              "6"
+            ],
+            "3979909": [
+              "17",
+              "21"
+            ],
+            "3979969": [
+              "18",
+              "22"
+            ],
+            "3980004": [
+              "1",
+              "5"
+            ],
+            "3980013": [
+              "5",
+              "9"
+            ],
+            "3980060": [
+              "10",
+              "14"
+            ],
+            "3980102": [
+              "1",
+              "20",
+              "24"
+            ],
+            "3980149": [
+              "12",
+              "16"
+            ],
+            "3980176": [
+              "13",
+              "17"
+            ],
+            "3980235": [
+              "7",
+              "11"
+            ],
+            "3980270": [
+              "9",
+              "13"
+            ],
+            "3980379": [
+              "4",
+              "8"
+            ],
+            "3980413": [
+              "14",
+              "18"
+            ],
+            "3980469": [
+              "3",
+              "7"
+            ],
+            "3980480": [
+              "7",
+              "25"
+            ],
+            "3980498": [
+              "3",
+              "21"
+            ],
+            "3980564": [
+              "16",
+              "20"
+            ],
+            "3980572": [
+              "15",
+              "19"
+            ],
+            "3980605": [
+              "8",
+              "26"
+            ],
+            "3980629": [
+              "10",
+              "28"
+            ],
+            "3980804": [
+              "9",
+              "27"
+            ],
+            "3980825": [
+              "19",
+              "23"
+            ],
+            "3980831": [
+              "6",
+              "10"
+            ],
+            "3980992": [
+              "11",
+              "29"
+            ],
+            "3981110": [
+              "4",
+              "22"
+            ],
+            "3981140": [
+              "8",
+              "12"
+            ],
+            "3981181": [
+              "1",
+              "19"
+            ],
+            "4015596": [
+              "5",
+              "23"
+            ],
+            "4015723": [
+              "6",
+              "24"
+            ]
+          },
+          "text": "the stop list offers a stop twice: 3980102 Amsterdam, Sloterpark at 1 and 20 and 24, 3981181 Amsterdam, Frederiksplein at 1 and 19, 3980004 Amsterdam, Frederiksplein at 1 and 5, and 28 more"
         },
         {
+          "folded": [
+            [
+              "3980752",
+              "3981140"
+            ]
+          ],
           "ok": false,
-          "text": "the list offers one station twice in a row [('3980752', '3981140')]"
+          "text": "the list offers one station twice in a row: 3980752 Amsterdam, Witte de Withstraat then 3981140 Amsterdam, Witte de Withstraat"
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": false,
@@ -5291,7 +6226,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -5299,7 +6235,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -5307,7 +6244,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -5594,15 +6532,18 @@
       "checks": [
         {
           "ok": true,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -5808,15 +6749,127 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "BDMMBA": [
+              "10",
+              "22"
+            ],
+            "CMID0A": [
+              "12",
+              "24"
+            ],
+            "EROMAN": [
+              "11",
+              "23"
+            ],
+            "GMA0AR": [
+              "25",
+              "37"
+            ],
+            "GSNF0R": [
+              "27",
+              "39"
+            ],
+            "HDV08A": [
+              "24",
+              "36"
+            ],
+            "ISL22R": [
+              "2",
+              "14"
+            ],
+            "JHIB0A": [
+              "22",
+              "34"
+            ],
+            "KI290A": [
+              "15",
+              "27"
+            ],
+            "KI310A": [
+              "14",
+              "26"
+            ],
+            "LMOR0A": [
+              "13",
+              "25"
+            ],
+            "MCOL0A": [
+              "20",
+              "32"
+            ],
+            "MIN22R": [
+              "5",
+              "17"
+            ],
+            "MLEA0A": [
+              "19",
+              "31"
+            ],
+            "MMER0A": [
+              "18",
+              "30"
+            ],
+            "MNAD0A": [
+              "21",
+              "33"
+            ],
+            "PLRO0R": [
+              "9",
+              "21"
+            ],
+            "PMID0A": [
+              "23",
+              "35"
+            ],
+            "PNA16A": [
+              "7",
+              "19"
+            ],
+            "PRA16A": [
+              "6",
+              "18"
+            ],
+            "PROC0A": [
+              "17",
+              "29"
+            ],
+            "RAG22R": [
+              "4",
+              "16"
+            ],
+            "RPO16A": [
+              "8",
+              "20"
+            ],
+            "RSE0AA": [
+              "26",
+              "38"
+            ],
+            "THEC0A": [
+              "1",
+              "13"
+            ],
+            "THEG0A": [
+              "3",
+              "15"
+            ],
+            "VERR0A": [
+              "16",
+              "28"
+            ]
+          },
+          "text": "the stop list offers a stop twice: THEC0A Théoule Plages at 1 and 13, ISL22R Le Princes des Iles at 2 and 14, THEG0A Théoule Gare at 3 and 15, and 24 more"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -5824,7 +6877,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -6075,15 +7129,18 @@
       "checks": [
         {
           "ok": true,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -6091,7 +7148,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -6282,15 +7340,18 @@
       "checks": [
         {
           "ok": true,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -6442,15 +7503,18 @@
       "checks": [
         {
           "ok": true,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -6722,15 +7786,18 @@
       "checks": [
         {
           "ok": true,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -6738,7 +7805,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -6746,7 +7814,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -7168,15 +8237,141 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "BLAN0C": [
+              "1",
+              "7",
+              "11"
+            ],
+            "CABR0A": [
+              "6",
+              "10"
+            ],
+            "CJA01A": [
+              "3",
+              "9",
+              "13"
+            ],
+            "CMOU0A": [
+              "2",
+              "6"
+            ],
+            "GSNF0R": [
+              "13",
+              "17",
+              "23",
+              "27"
+            ],
+            "JUYE0A": [
+              "3",
+              "7"
+            ],
+            "LCA0AA": [
+              "9",
+              "13",
+              "19",
+              "23"
+            ],
+            "LIC01A": [
+              "2",
+              "6",
+              "12",
+              "16"
+            ],
+            "LRO01A": [
+              "4",
+              "10",
+              "14"
+            ],
+            "MADR6A": [
+              "6",
+              "10",
+              "16",
+              "20"
+            ],
+            "MEU0AA": [
+              "11",
+              "15",
+              "21",
+              "25"
+            ],
+            "MIL0AA": [
+              "10",
+              "14",
+              "20",
+              "24"
+            ],
+            "MRO35A": [
+              "4",
+              "8",
+              "14",
+              "18"
+            ],
+            "NDAN6A": [
+              "5",
+              "9",
+              "15",
+              "19"
+            ],
+            "OLI01A": [
+              "1",
+              "5",
+              "11",
+              "15"
+            ],
+            "PDO0AA": [
+              "8",
+              "12",
+              "18",
+              "22"
+            ],
+            "PRO11R": [
+              "3",
+              "7",
+              "13",
+              "17"
+            ],
+            "PVA0AA": [
+              "12",
+              "16",
+              "22",
+              "26"
+            ],
+            "SEV06A": [
+              "7",
+              "11",
+              "17",
+              "21"
+            ],
+            "TOUR0A": [
+              "1",
+              "5"
+            ],
+            "VALM0A": [
+              "4",
+              "8"
+            ],
+            "VAUM0A": [
+              "5",
+              "9"
+            ],
+            "VFE01A": [
+              "2",
+              "8",
+              "12"
+            ]
+          },
+          "text": "the stop list offers a stop twice: TOUR0A Tournamy at 1 and 5, BLAN0C Blanchisserie at 1 and 7 and 11, OLI01A L'Olivet at 1 and 5 and 11 and 15, and 20 more"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -7184,7 +8379,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -7192,7 +8388,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -7200,7 +8397,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -10335,15 +11533,18 @@
       "checks": [
         {
           "ok": true,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -10489,15 +11690,18 @@
       "checks": [
         {
           "ok": true,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -10703,15 +11907,79 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "ORLEANS:StopArea:00001220": [
+              "11",
+              "21"
+            ],
+            "ORLEANS:StopArea:00004730": [
+              "3",
+              "13"
+            ],
+            "ORLEANS:StopArea:00005402": [
+              "12",
+              "22"
+            ],
+            "ORLEANS:StopArea:00005500": [
+              "7",
+              "17"
+            ],
+            "ORLEANS:StopArea:00007923": [
+              "0",
+              "10"
+            ],
+            "ORLEANS:StopArea:00019301": [
+              "13",
+              "23"
+            ],
+            "ORLEANS:StopArea:00026500": [
+              "8",
+              "18"
+            ],
+            "ORLEANS:StopArea:00034303": [
+              "1",
+              "11"
+            ],
+            "ORLEANS:StopArea:00038310": [
+              "9",
+              "19"
+            ],
+            "ORLEANS:StopArea:00039751": [
+              "4",
+              "14"
+            ],
+            "ORLEANS:StopArea:00045620": [
+              "10",
+              "20"
+            ],
+            "ORLEANS:StopArea:00047321": [
+              "5",
+              "15"
+            ],
+            "ORLEANS:StopArea:00047361": [
+              "6",
+              "16"
+            ],
+            "ORLEANS:StopArea:01001712": [
+              "14",
+              "24"
+            ],
+            "ORLEANS:StopArea:01036003": [
+              "2",
+              "12"
+            ]
+          },
+          "text": "the stop list offers a stop twice: ORLEANS:StopArea:00007923 Chèques Postaux - M. Ricoud - Quai C at 0 and 10, ORLEANS:StopArea:00034303 Montesquieu at 1 and 11, ORLEANS:StopArea:01036003 Théâtre Philipe at 2 and 12, and 12 more"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -10719,7 +11987,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -11156,15 +12425,123 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "ORLEANS:StopArea:00001223": [
+              "3",
+              "4"
+            ],
+            "ORLEANS:StopArea:00001600": [
+              "22",
+              "23"
+            ],
+            "ORLEANS:StopArea:00003726": [
+              "15",
+              "16"
+            ],
+            "ORLEANS:StopArea:00004732": [
+              "11",
+              "12"
+            ],
+            "ORLEANS:StopArea:00005401": [
+              "2",
+              "3"
+            ],
+            "ORLEANS:StopArea:00005501": [
+              "7",
+              "8"
+            ],
+            "ORLEANS:StopArea:00007601": [
+              "19",
+              "20"
+            ],
+            "ORLEANS:StopArea:00007923": [
+              "15",
+              "16"
+            ],
+            "ORLEANS:StopArea:00007924": [
+              "14",
+              "15"
+            ],
+            "ORLEANS:StopArea:00010100": [
+              "17",
+              "18"
+            ],
+            "ORLEANS:StopArea:00016101": [
+              "21",
+              "22"
+            ],
+            "ORLEANS:StopArea:00019303": [
+              "1",
+              "2"
+            ],
+            "ORLEANS:StopArea:00026501": [
+              "6",
+              "7"
+            ],
+            "ORLEANS:StopArea:00034302": [
+              "13",
+              "14"
+            ],
+            "ORLEANS:StopArea:00035910": [
+              "24",
+              "25"
+            ],
+            "ORLEANS:StopArea:00038311": [
+              "5",
+              "6"
+            ],
+            "ORLEANS:StopArea:00039750": [
+              "10",
+              "11"
+            ],
+            "ORLEANS:StopArea:00043320": [
+              "20",
+              "21"
+            ],
+            "ORLEANS:StopArea:00045621": [
+              "4",
+              "5"
+            ],
+            "ORLEANS:StopArea:00047320": [
+              "9",
+              "10"
+            ],
+            "ORLEANS:StopArea:00047360": [
+              "8",
+              "9"
+            ],
+            "ORLEANS:StopArea:00049101": [
+              "16",
+              "17"
+            ],
+            "ORLEANS:StopArea:01017071": [
+              "0",
+              "1"
+            ],
+            "ORLEANS:StopArea:01036004": [
+              "12",
+              "13"
+            ],
+            "ORLEANS:StopArea:01077502": [
+              "18",
+              "19"
+            ],
+            "ORLEANS:StopArea:01088001": [
+              "23",
+              "24"
+            ]
+          },
+          "text": "the stop list offers a stop twice: ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis at 0 and 1, ORLEANS:StopArea:00019303 Halmagrand at 1 and 2, ORLEANS:StopArea:00005401 Carré St-Vincent at 2 and 3, and 23 more"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -11172,7 +12549,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -11180,7 +12558,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -11188,7 +12567,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -11196,7 +12576,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -11528,15 +12909,18 @@
       "checks": [
         {
           "ok": true,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -11682,15 +13066,18 @@
       "checks": [
         {
           "ok": true,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -12136,15 +13523,148 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "ORLEANS:StopArea:TAUBRA1": [
+              "22",
+              "23"
+            ],
+            "ORLEANS:StopArea:TAULNA1": [
+              "7",
+              "8"
+            ],
+            "ORLEANS:StopArea:TBOLIE1": [
+              "1",
+              "2"
+            ],
+            "ORLEANS:StopArea:TBUSTI1": [
+              "23",
+              "24"
+            ],
+            "ORLEANS:StopArea:TCAMPU1": [
+              "5",
+              "6"
+            ],
+            "ORLEANS:StopArea:TCOLIG1": [
+              "20",
+              "21"
+            ],
+            "ORLEANS:StopArea:TCOMET1": [
+              "11",
+              "12"
+            ],
+            "ORLEANS:StopArea:TCSMAR1": [
+              "13",
+              "14"
+            ],
+            "ORLEANS:StopArea:TFLORA1": [
+              "4",
+              "5"
+            ],
+            "ORLEANS:StopArea:TGARDO1": [
+              "18",
+              "19"
+            ],
+            "ORLEANS:StopArea:TGAULA1": [
+              "16",
+              "17"
+            ],
+            "ORLEANS:StopArea:THOPAC1": [
+              "0",
+              "1"
+            ],
+            "ORLEANS:StopArea:TINDIE1": [
+              "3",
+              "4"
+            ],
+            "ORLEANS:StopArea:TLAMBA1": [
+              "24",
+              "25"
+            ],
+            "ORLEANS:StopArea:TLARRY1": [
+              "8",
+              "9"
+            ],
+            "ORLEANS:StopArea:TLBRAL1": [
+              "19",
+              "20"
+            ],
+            "ORLEANS:StopArea:TLIBER1": [
+              "21",
+              "22"
+            ],
+            "ORLEANS:StopArea:TLORET1": [
+              "6",
+              "7"
+            ],
+            "ORLEANS:StopArea:TMOUIL1": [
+              "12",
+              "13"
+            ],
+            "ORLEANS:StopArea:TPOSTA1": [
+              "2",
+              "3"
+            ],
+            "ORLEANS:StopArea:TREPUB1": [
+              "17",
+              "18"
+            ],
+            "ORLEANS:StopArea:TROYAL1": [
+              "15",
+              "16"
+            ],
+            "ORLEANS:StopArea:TTOURE1": [
+              "14",
+              "15"
+            ],
+            "ORLEANS:StopArea:TVERNE1": [
+              "25",
+              "26"
+            ],
+            "ORLEANS:StopArea:TVERNE2": [
+              "25",
+              "26"
+            ],
+            "ORLEANS:StopArea:TVHUGO1": [
+              "9",
+              "10"
+            ],
+            "ORLEANS:StopArea:TZENIT1": [
+              "10",
+              "11"
+            ]
+          },
+          "text": "the stop list offers a stop twice: ORLEANS:StopArea:THOPAC1 Hôpital-Accueil at 0 and 1, ORLEANS:StopArea:TBOLIE1 Bolière at 1 and 2, ORLEANS:StopArea:TPOSTA1 Chèques Postaux - Michel Ricoud at 2 and 3, and 24 more"
         },
         {
+          "folded": [
+            [
+              "ORLEANS:StopArea:THOPIT2",
+              "ORLEANS:StopArea:THOPIT1"
+            ],
+            [
+              "ORLEANS:StopArea:TZENIT1",
+              "ORLEANS:StopArea:TZENIT1"
+            ],
+            [
+              "ORLEANS:StopArea:TVERNE2",
+              "ORLEANS:StopArea:TVERNE1"
+            ],
+            [
+              "ORLEANS:StopArea:TVERNE1",
+              "ORLEANS:StopArea:TVERNE2"
+            ],
+            [
+              "ORLEANS:StopArea:TVERNE2",
+              "ORLEANS:StopArea:TVERNE1"
+            ]
+          ],
           "ok": false,
-          "text": "the list offers one station twice in a row [('ORLEANS:StopArea:THOPIT2', 'ORLEANS:StopArea:THOPIT1')]"
+          "text": "the list offers one station twice in a row: ORLEANS:StopArea:THOPIT2 Hôpital de La Source then ORLEANS:StopArea:THOPIT1 Hôpital de La Source, ORLEANS:StopArea:TZENIT1 Zénith then ORLEANS:StopArea:TZENIT1 Zénith, ORLEANS:StopArea:TVERNE2 Jules Verne then ORLEANS:StopArea:TVERNE1 Jules Verne, and 2 more"
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -12152,7 +13672,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -12160,7 +13681,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -12168,7 +13690,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -12176,7 +13699,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -12184,7 +13708,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -12759,15 +14284,27 @@
       "checks": [
         {
           "ok": true,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
+          "folded": [
+            [
+              "ORLEANS:StopArea:TVERNE2",
+              "ORLEANS:StopArea:TVERNE1"
+            ],
+            [
+              "ORLEANS:StopArea:THOPIT2",
+              "ORLEANS:StopArea:THOPIT1"
+            ]
+          ],
           "ok": false,
-          "text": "the list offers one station twice in a row [('ORLEANS:StopArea:TVERNE2', 'ORLEANS:StopArea:TVERNE1')]"
+          "text": "the list offers one station twice in a row: ORLEANS:StopArea:TVERNE2 Jules Verne then ORLEANS:StopArea:TVERNE1 Jules Verne, ORLEANS:StopArea:THOPIT2 Hôpital de La Source then ORLEANS:StopArea:THOPIT1 Hôpital de La Source"
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -12775,7 +14312,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -12783,7 +14321,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -12791,7 +14330,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -13276,15 +14816,48 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "ORLEANS:StopArea:TCLARC2": [
+              "3",
+              "22"
+            ],
+            "ORLEANS:StopArea:TGAUBR2": [
+              "0",
+              "19"
+            ],
+            "ORLEANS:StopArea:THAMEA1": [
+              "5",
+              "24"
+            ],
+            "ORLEANS:StopArea:TLBLUM2": [
+              "4",
+              "23"
+            ],
+            "ORLEANS:StopArea:TPTBOR2": [
+              "1",
+              "20"
+            ],
+            "ORLEANS:StopArea:TVERVI2": [
+              "2",
+              "21"
+            ]
+          },
+          "text": "the stop list offers a stop twice: ORLEANS:StopArea:TGAUBR2 Gaudier-Brzeska at 0 and 19, ORLEANS:StopArea:TPTBOR2 Pont Bordeau at 1 and 20, ORLEANS:StopArea:TVERVI2 Verville at 2 and 21, and 3 more"
         },
         {
+          "folded": [
+            [
+              "ORLEANS:StopArea:THAMEA1",
+              "ORLEANS:StopArea:THAMEA2"
+            ]
+          ],
           "ok": false,
-          "text": "the list offers one station twice in a row [('ORLEANS:StopArea:THAMEA1', 'ORLEANS:StopArea:THAMEA2')]"
+          "text": "the list offers one station twice in a row: ORLEANS:StopArea:THAMEA1 Clos du Hameau then ORLEANS:StopArea:THAMEA2 Clos du Hameau"
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -13292,7 +14865,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -13300,7 +14874,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -13308,7 +14883,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -13721,15 +15297,95 @@
       "checks": [
         {
           "ok": false,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {
+            "ORLEANS:StopArea:TAMBER1": [
+              "0",
+              "6"
+            ],
+            "ORLEANS:StopArea:TBEAUM1": [
+              "12",
+              "18"
+            ],
+            "ORLEANS:StopArea:TCAHDV1": [
+              "7",
+              "13"
+            ],
+            "ORLEANS:StopArea:TCXMOR1": [
+              "10",
+              "16"
+            ],
+            "ORLEANS:StopArea:TDRHOM1": [
+              "3",
+              "9"
+            ],
+            "ORLEANS:StopArea:TGAULB1": [
+              "9",
+              "15"
+            ],
+            "ORLEANS:StopArea:TGVILL1": [
+              "1",
+              "7"
+            ],
+            "ORLEANS:StopArea:THALMA1": [
+              "6",
+              "12"
+            ],
+            "ORLEANS:StopArea:TJDARC1": [
+              "8",
+              "14"
+            ],
+            "ORLEANS:StopArea:TMADEL1": [
+              "11",
+              "17"
+            ],
+            "ORLEANS:StopArea:TMLKIN1": [
+              "16",
+              "22"
+            ],
+            "ORLEANS:StopArea:TMOZAR1": [
+              "2",
+              "8"
+            ],
+            "ORLEANS:StopArea:TPEURO1": [
+              "14",
+              "20"
+            ],
+            "ORLEANS:StopArea:TPOMPI2": [
+              "18",
+              "24"
+            ],
+            "ORLEANS:StopArea:TPTDUN1": [
+              "13",
+              "19"
+            ],
+            "ORLEANS:StopArea:TRIOBE1": [
+              "4",
+              "10"
+            ],
+            "ORLEANS:StopArea:TTANGU1": [
+              "15",
+              "21"
+            ],
+            "ORLEANS:StopArea:TTFONT1": [
+              "17",
+              "23"
+            ],
+            "ORLEANS:StopArea:TVIGNA1": [
+              "5",
+              "11"
+            ]
+          },
+          "text": "the stop list offers a stop twice: ORLEANS:StopArea:TAMBER1 Ambert at 0 and 6, ORLEANS:StopArea:TGVILL1 Grand Villiers at 1 and 7, ORLEANS:StopArea:TMOZAR1 Mozart at 2 and 8, and 16 more"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -13737,7 +15393,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -13745,7 +15402,8 @@
         },
         {
           "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -13993,15 +15651,18 @@
       "checks": [
         {
           "ok": true,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,
@@ -14153,15 +15814,18 @@
       "checks": [
         {
           "ok": true,
-          "text": "the stop list repeats a stop_id"
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
+        },
+        {
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
-          "text": "the list offers one station twice in a row []"
-        },
-        {
-          "ok": true,
-          "text": "a trip serves a stop the list does not offer"
+          "text": "a trip serves a stop the list does not offer",
+          "unoffered": []
         },
         {
           "ok": true,

--- a/tests_provider/results.txt
+++ b/tests_provider/results.txt
@@ -7,7 +7,7 @@ case: gvb-1-d0-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list repeats a stop_id
+    the stop list offers a stop twice: 4138837 Amsterdam, Leidseplein at 1 and 4 and 16 and 19, 3979966 Amsterdam, Rhijnvis Feithstraat at 1 and 13, 3980187 Amsterdam, Rijksmuseum at 2 and 5 and 17 and 20, and 12 more
 
 case: gvb-1-d0-swapped
   result: PASSED
@@ -19,8 +19,8 @@ case: gvb-1-d1-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list repeats a stop_id
-    the list offers one station twice in a row [('3979766', '3980631')]
+    the stop list offers a stop twice: 3979966 Amsterdam, Rhijnvis Feithstraat at 1 and 2, 3979725 Amsterdam, Surinameplein at 1 and 16 and 19, 3980938 Amsterdam, Jan Pieter Heijestraat at 2 and 3, and 24 more
+    the list offers one station twice in a row: 3979766 Amsterdam, Weesperplein then 3980631 Amsterdam, Weesperplein
 
 case: gvb-1-d1-swapped
   result: PASSED
@@ -32,8 +32,8 @@ case: gvb-13-d0-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list repeats a stop_id
-    the list offers one station twice in a row [('3980268', '3980182')]
+    the stop list offers a stop twice: 3979794 Amsterdam, Mercatorplein at 1 and 10, 3980464 Amsterdam, Marco Polostraat at 2 and 11, 3980544 Amsterdam, Admiraal de Ruijterweg at 3 and 12, and 10 more
+    the list offers one station twice in a row: 3980268 Amsterdam, Elandsgracht then 3980182 Amsterdam, Elandsgracht
 
 case: gvb-13-d0-swapped
   result: PASSED
@@ -45,7 +45,7 @@ case: gvb-13-d1-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list repeats a stop_id
+    the stop list offers a stop twice: 3980794 Amsterdam, Admiraal Helfrichstraat at 1 and 14, 3980974 Amsterdam, Jan Voermanstraat at 2 and 15, 3980162 Amsterdam, Jan Tooropstraat at 3 and 16, and 6 more
 
 case: gvb-13-d1-swapped
   result: PASSED
@@ -57,8 +57,8 @@ case: gvb-14-d0-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list repeats a stop_id
-    the list offers one station twice in a row [('3980489', '3980251')]
+    the stop list offers a stop twice: 3981274 Amsterdam, Centraal Station at 1 and 16, 3979805 Amsterdam, Mauritskade at 1 and 9, 3980549 Amsterdam, Mauritskade at 1 and 8, and 16 more
+    the list offers one station twice in a row: 3980489 Amsterdam, Dam then 3980251 Amsterdam, Dam, 3981274 Amsterdam, Centraal Station then 4045456 Amsterdam, Centraal Station
 
 case: gvb-14-d0-swapped
   result: PASSED
@@ -70,8 +70,8 @@ case: gvb-14-d1-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list repeats a stop_id
-    the list offers one station twice in a row [('4045456', '3981274')]
+    the stop list offers a stop twice: 3980549 Amsterdam, Mauritskade at 1 and 7 and 8, 3980234 Amsterdam, Javaplein at 1 and 4 and 12, 3981274 Amsterdam, Centraal Station at 1 and 9 and 15 and 16, and 14 more
+    the list offers one station twice in a row: 4045456 Amsterdam, Centraal Station then 3981274 Amsterdam, Centraal Station, 3980234 Amsterdam, Javaplein then 3981356 Amsterdam, Javaplein, 3979768 Amsterdam, Plantage Lepellaan then 3981148 Amsterdam, Plantage Lepellaan
     the list contradicts the riding order 3980234 .. 3981274
     the list contradicts the riding order 3981274 .. 3980992
 
@@ -85,8 +85,8 @@ case: gvb-17-d0-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list repeats a stop_id
-    the list offers one station twice in a row [('3981140', '3980752')]
+    the stop list offers a stop twice: 3980305 Amsterdam, Corantijnstraat at 1 and 11, 3981271 Amsterdam, Centraal Station at 1 and 8 and 14 and 24, 3980599 Amsterdam, Leidseplein at 1 and 7 and 17, and 11 more
+    the list offers one station twice in a row: 3981140 Amsterdam, Witte de Withstraat then 3980752 Amsterdam, Witte de Withstraat
     the list contradicts the riding order 3981271 .. 4132580
 
 case: gvb-17-d0-swapped
@@ -99,8 +99,8 @@ case: gvb-17-d1-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list repeats a stop_id
-    the list offers one station twice in a row [('3980573', '3980418')]
+    the stop list offers a stop twice: 3981271 Amsterdam, Centraal Station at 1 and 8 and 15, 3979725 Amsterdam, Surinameplein at 1 and 15, 3980599 Amsterdam, Leidseplein at 1 and 8, and 15 more
+    the list offers one station twice in a row: 3980573 Amsterdam, Koningsplein then 3980418 Amsterdam, Koningsplein
     the list contradicts the riding order 3981271 .. 3980351
 
 case: gvb-17-d1-swapped
@@ -113,8 +113,8 @@ case: gvb-7-d0-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list repeats a stop_id
-    the list offers one station twice in a row [('3980060', '3980854')]
+    the stop list offers a stop twice: 3980004 Amsterdam, Frederiksplein at 1 and 11, 3980102 Amsterdam, Sloterpark at 1 and 20 and 30, 3981181 Amsterdam, Frederiksplein at 1 and 19, and 22 more
+    the list offers one station twice in a row: 3980060 Amsterdam, Willem Schoutenstraat then 3980854 Amsterdam, Willem Schoutenstraat
     the list contradicts the riding order 3980102 .. 3979878
 
 case: gvb-7-d0-swapped
@@ -130,8 +130,8 @@ case: gvb-7-d1-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list repeats a stop_id
-    the list offers one station twice in a row [('3980752', '3981140')]
+    the stop list offers a stop twice: 3980102 Amsterdam, Sloterpark at 1 and 20 and 24, 3981181 Amsterdam, Frederiksplein at 1 and 19, 3980004 Amsterdam, Frederiksplein at 1 and 5, and 28 more
+    the list offers one station twice in a row: 3980752 Amsterdam, Witte de Withstraat then 3981140 Amsterdam, Witte de Withstraat
     the list contradicts the riding order 3980102 .. 3980992
 
 case: gvb-7-d1-swapped
@@ -156,7 +156,7 @@ case: palmbus-22-d0-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198)
   detail:
-    the stop list repeats a stop_id
+    the stop list offers a stop twice: THEC0A Théoule Plages at 1 and 13, ISL22R Le Princes des Iles at 2 and 14, THEG0A Théoule Gare at 3 and 15, and 24 more
 
 case: palmbus-22-d0-swapped
   result: PASSED
@@ -213,7 +213,7 @@ case: palmbus-B-d1-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198)
   detail:
-    the stop list repeats a stop_id
+    the stop list offers a stop twice: TOUR0A Tournamy at 1 and 5, BLAN0C Blanchisserie at 1 and 7 and 11, OLI01A L'Olivet at 1 and 5 and 11 and 15, and 20 more
 
 case: palmbus-B-d1-swapped
   result: XFAILED
@@ -291,7 +291,7 @@ case: tao-journeys-40-d0-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198)
   detail:
-    the stop list repeats a stop_id
+    the stop list offers a stop twice: ORLEANS:StopArea:00007923 Chèques Postaux - M. Ricoud - Quai C at 0 and 10, ORLEANS:StopArea:00034303 Montesquieu at 1 and 11, ORLEANS:StopArea:01036003 Théâtre Philipe at 2 and 12, and 12 more
 
 case: tao-journeys-40-d0-swapped
   result: XFAILED
@@ -306,7 +306,7 @@ case: tao-journeys-40-d1-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198)
   detail:
-    the stop list repeats a stop_id
+    the stop list offers a stop twice: ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis at 0 and 1, ORLEANS:StopArea:00019303 Halmagrand at 1 and 2, ORLEANS:StopArea:00005401 Carré St-Vincent at 2 and 3, and 23 more
 
 case: tao-journeys-40-d1-swapped
   result: XFAILED
@@ -339,8 +339,8 @@ case: tao-journeys-A-d0-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198)
   detail:
-    the stop list repeats a stop_id
-    the list offers one station twice in a row [('ORLEANS:StopArea:THOPIT2', 'ORLEANS:StopArea:THOPIT1')]
+    the stop list offers a stop twice: ORLEANS:StopArea:THOPAC1 Hôpital-Accueil at 0 and 1, ORLEANS:StopArea:TBOLIE1 Bolière at 1 and 2, ORLEANS:StopArea:TPOSTA1 Chèques Postaux - Michel Ricoud at 2 and 3, and 24 more
+    the list offers one station twice in a row: ORLEANS:StopArea:THOPIT2 Hôpital de La Source then ORLEANS:StopArea:THOPIT1 Hôpital de La Source, ORLEANS:StopArea:TZENIT1 Zénith then ORLEANS:StopArea:TZENIT1 Zénith, ORLEANS:StopArea:TVERNE2 Jules Verne then ORLEANS:StopArea:TVERNE1 Jules Verne, and 2 more
 
 case: tao-journeys-A-d0-swapped
   result: XFAILED
@@ -358,7 +358,7 @@ case: tao-journeys-A-d1-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198)
   detail:
-    the list offers one station twice in a row [('ORLEANS:StopArea:TVERNE2', 'ORLEANS:StopArea:TVERNE1')]
+    the list offers one station twice in a row: ORLEANS:StopArea:TVERNE2 Jules Verne then ORLEANS:StopArea:TVERNE1 Jules Verne, ORLEANS:StopArea:THOPIT2 Hôpital de La Source then ORLEANS:StopArea:THOPIT1 Hôpital de La Source
 
 case: tao-journeys-A-d1-swapped
   result: XFAILED
@@ -376,8 +376,8 @@ case: tao-journeys-B-d0-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198)
   detail:
-    the stop list repeats a stop_id
-    the list offers one station twice in a row [('ORLEANS:StopArea:THAMEA1', 'ORLEANS:StopArea:THAMEA2')]
+    the stop list offers a stop twice: ORLEANS:StopArea:TGAUBR2 Gaudier-Brzeska at 0 and 19, ORLEANS:StopArea:TPTBOR2 Pont Bordeau at 1 and 20, ORLEANS:StopArea:TVERVI2 Verville at 2 and 21, and 3 more
+    the list offers one station twice in a row: ORLEANS:StopArea:THAMEA1 Clos du Hameau then ORLEANS:StopArea:THAMEA2 Clos du Hameau
 
 case: tao-journeys-B-d0-swapped
   result: XFAILED
@@ -393,7 +393,7 @@ case: tao-journeys-B-d1-stop_list
   result: XFAILED
   reason: the stop selector offers a stop twice or out of riding order (discussion #198)
   detail:
-    the stop list repeats a stop_id
+    the stop list offers a stop twice: ORLEANS:StopArea:TAMBER1 Ambert at 0 and 6, ORLEANS:StopArea:TGVILL1 Grand Villiers at 1 and 7, ORLEANS:StopArea:TMOZAR1 Mozart at 2 and 8, and 16 more
 
 case: tao-journeys-B-d1-swapped
   result: XFAILED

--- a/tests_provider/results.txt
+++ b/tests_provider/results.txt
@@ -1,0 +1,427 @@
+test_journeys.py case results -- 95 case(s)
+
+case: gvb-1-d0-pairs
+  result: PASSED
+
+case: gvb-1-d0-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  detail:
+    the stop list repeats a stop_id
+
+case: gvb-1-d0-swapped
+  result: PASSED
+
+case: gvb-1-d1-pairs
+  result: PASSED
+
+case: gvb-1-d1-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  detail:
+    the stop list repeats a stop_id
+    the list offers one station twice in a row [('3979766', '3980631')]
+
+case: gvb-1-d1-swapped
+  result: PASSED
+
+case: gvb-13-d0-pairs
+  result: PASSED
+
+case: gvb-13-d0-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  detail:
+    the stop list repeats a stop_id
+    the list offers one station twice in a row [('3980268', '3980182')]
+
+case: gvb-13-d0-swapped
+  result: PASSED
+
+case: gvb-13-d1-pairs
+  result: PASSED
+
+case: gvb-13-d1-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  detail:
+    the stop list repeats a stop_id
+
+case: gvb-13-d1-swapped
+  result: PASSED
+
+case: gvb-14-d0-pairs
+  result: PASSED
+
+case: gvb-14-d0-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  detail:
+    the stop list repeats a stop_id
+    the list offers one station twice in a row [('3980489', '3980251')]
+
+case: gvb-14-d0-swapped
+  result: PASSED
+
+case: gvb-14-d1-pairs
+  result: PASSED
+
+case: gvb-14-d1-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  detail:
+    the stop list repeats a stop_id
+    the list offers one station twice in a row [('4045456', '3981274')]
+    the list contradicts the riding order 3980234 .. 3981274
+    the list contradicts the riding order 3981274 .. 3980992
+
+case: gvb-14-d1-swapped
+  result: PASSED
+
+case: gvb-17-d0-pairs
+  result: PASSED
+
+case: gvb-17-d0-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  detail:
+    the stop list repeats a stop_id
+    the list offers one station twice in a row [('3981140', '3980752')]
+    the list contradicts the riding order 3981271 .. 4132580
+
+case: gvb-17-d0-swapped
+  result: PASSED
+
+case: gvb-17-d1-pairs
+  result: PASSED
+
+case: gvb-17-d1-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  detail:
+    the stop list repeats a stop_id
+    the list offers one station twice in a row [('3980573', '3980418')]
+    the list contradicts the riding order 3981271 .. 3980351
+
+case: gvb-17-d1-swapped
+  result: PASSED
+
+case: gvb-7-d0-pairs
+  result: PASSED
+
+case: gvb-7-d0-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  detail:
+    the stop list repeats a stop_id
+    the list offers one station twice in a row [('3980060', '3980854')]
+    the list contradicts the riding order 3980102 .. 3979878
+
+case: gvb-7-d0-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked 3979878 -> 3980102 on 152328 d0 (stop 23 to stop 1 of a 23-stop ride, this direction does not make it): got 3979878 -> 3980102 on 152328 d1, trip 380799628
+
+case: gvb-7-d1-pairs
+  result: PASSED
+
+case: gvb-7-d1-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  detail:
+    the stop list repeats a stop_id
+    the list offers one station twice in a row [('3980752', '3981140')]
+    the list contradicts the riding order 3980102 .. 3980992
+
+case: gvb-7-d1-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked 3980102 -> 3979878 on 152328 d1 (stop 24 to stop 1 of a 24-stop ride, this direction does not make it): got 3980102 -> 3979878 on 152328 d0, trip 380799711
+
+case: palmbus-21-d0-pairs
+  result: PASSED
+
+case: palmbus-21-d0-stop_list
+  result: PASSED
+
+case: palmbus-21-d0-swapped
+  result: PASSED
+
+case: palmbus-22-d0-pairs
+  result: PASSED
+
+case: palmbus-22-d0-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  detail:
+    the stop list repeats a stop_id
+
+case: palmbus-22-d0-swapped
+  result: PASSED
+
+case: palmbus-22-d1-pairs
+  result: PASSED
+
+case: palmbus-22-d1-stop_list
+  result: PASSED
+
+case: palmbus-22-d1-swapped
+  result: PASSED
+
+case: palmbus-A-d0-pairs
+  result: PASSED
+
+case: palmbus-A-d0-stop_list
+  result: PASSED
+
+case: palmbus-A-d0-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked GSNF0A -> CCO15A on A d0 (stop 35 to stop 1 of a 35-stop ride, this direction does not make it): got GSNF0A -> CCO15A on A d1, trip 1418363764878
+
+case: palmbus-A-d1-pairs
+  result: PASSED
+
+case: palmbus-A-d1-stop_list
+  result: PASSED
+
+case: palmbus-A-d1-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked CCO15A -> GSNF0A on A d1 (stop 36 to stop 1 of a 36-stop ride, this direction does not make it): got CCO15A -> GSNF0A on A d0, trip 1418363764404
+
+case: palmbus-B-d0-pairs
+  result: PASSED
+
+case: palmbus-B-d0-stop_list
+  result: PASSED
+
+case: palmbus-B-d0-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked MSCE0A -> GSNF0R on B d0 (stop 29 to stop 1 of a 29-stop ride, this direction does not make it): got MSCE0A -> GSNF0R on B d1, trip 1418363764159
+
+case: palmbus-B-d1-pairs
+  result: PASSED
+
+case: palmbus-B-d1-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  detail:
+    the stop list repeats a stop_id
+
+case: palmbus-B-d1-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked GSNF0R -> MSCE0A on B d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got GSNF0R -> MSCE0A on B d0, trip 1418363764271
+
+case: sncf-journeys-K8+-d0-pairs
+  result: XFAILED
+  reason: a train journey is matched by stop name prefix on any line, not the asked one
+  detail:
+    asked Paris Austerlitz -> Les Aubrais on K8+ (stop 1 to stop 2 of a 2-stop ride): got Paris Austerlitz -> Les Aubrais on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106
+    asked Paris Austerlitz -> Orléans on K8+ (stop 1 to stop 3 of a 3-stop ride): got Paris Austerlitz -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106
+    asked Paris Austerlitz -> Les Aubrais on K8+ (stop 1 to stop 2 of a 3-stop ride): got Paris Austerlitz -> Les Aubrais on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106
+    asked Les Aubrais -> Orléans on K8+ (stop 2 to stop 3 of a 3-stop ride): got Les Aubrais -> Orléans on P8 d0, trip OCESN860581F1187_F:TER:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87547000:87543009:13:720:20261106
+
+case: sncf-journeys-K8+-d1-pairs
+  result: XFAILED
+  reason: a train journey is matched by stop name prefix on any line, not the asked one
+  detail:
+    asked Orléans -> Les Aubrais Gare Routière on K8+ (stop 1 to stop 2 of a 3-stop ride): got Orléans -> Les Aubrais Gare Routière on P8 d1, trip OCESN424586R1187_R:CTE:FR:Line::89BD9468-3499-4B6B-B3CB-50073CDD3F95::87543009:87543090:8:1350:20261211
+
+case: sncf-journeys-P8(924A148:)-d0-pairs
+  result: PASSED
+
+case: sncf-journeys-P8(924A148:)-d1-pairs
+  result: PASSED
+
+case: sncf-journeys-P8(A594575:)-d0-pairs
+  result: PASSED
+
+case: sncf-journeys-P8(A594575:)-d1-pairs
+  result: XFAILED
+  reason: a train journey is matched by stop name prefix on any line, not the asked one
+  detail:
+    asked La Chaumusse - Fort-du-Plasne -> Champagnole on P8 (stop 5 to stop 8 of a 8-stop ride): got La Chaumusse - Fort-du-Plasne -> Champagnole Paul-Émile Victor on P8 d1, trip OCESN895512F1187_F:TER:FR:Line::79F02D11-43E5-467F-ACFC-6DDA1A594575::87743633:87713412:13:841:20261212
+
+case: sncf-journeys-P8(CDD3F95:)-d0-pairs
+  result: PASSED
+
+case: sncf-journeys-P8(CDD3F95:)-d1-pairs
+  result: XFAILED
+  reason: a train journey is matched by stop name prefix on any line, not the asked one
+  detail:
+    asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 11 of a 11-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
+    asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 12 of a 12-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
+    asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 10 of a 10-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
+    asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 9 of a 9-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
+    asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 11 of a 11-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
+    asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 8 of a 8-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
+    asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 5 of a 5-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
+
+case: tao-journeys-22-d0-pairs
+  result: PASSED
+
+case: tao-journeys-22-d0-stop_list
+  result: PASSED
+
+case: tao-journeys-22-d0-swapped
+  result: PASSED
+
+case: tao-journeys-22-d1-pairs
+  result: PASSED
+
+case: tao-journeys-22-d1-stop_list
+  result: PASSED
+
+case: tao-journeys-22-d1-swapped
+  result: PASSED
+
+case: tao-journeys-40-d0-pairs
+  result: PASSED
+
+case: tao-journeys-40-d0-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  detail:
+    the stop list repeats a stop_id
+
+case: tao-journeys-40-d0-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401
+
+case: tao-journeys-40-d1-pairs
+  result: PASSED
+
+case: tao-journeys-40-d1-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  detail:
+    the stop list repeats a stop_id
+
+case: tao-journeys-40-d1-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d1 (stop 26 to stop 1 of a 26-stop ride, this direction does not make it): got ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0, trip ORLEANS:VehicleJourney:40_A_86_10_4002_1_070100
+
+case: tao-journeys-41-d0-pairs
+  result: PASSED
+
+case: tao-journeys-41-d0-stop_list
+  result: PASSED
+
+case: tao-journeys-41-d0-swapped
+  result: PASSED
+
+case: tao-journeys-41-d1-pairs
+  result: PASSED
+
+case: tao-journeys-41-d1-stop_list
+  result: PASSED
+
+case: tao-journeys-41-d1-swapped
+  result: PASSED
+
+case: tao-journeys-A-d0-pairs
+  result: PASSED
+
+case: tao-journeys-A-d0-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  detail:
+    the stop list repeats a stop_id
+    the list offers one station twice in a row [('ORLEANS:StopArea:THOPIT2', 'ORLEANS:StopArea:THOPIT1')]
+
+case: tao-journeys-A-d0-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_470_21_A01_1_085930
+    asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_469_10_A01_1_050000
+    asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900
+    asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_468_10_A01_1_145630
+
+case: tao-journeys-A-d1-pairs
+  result: PASSED
+
+case: tao-journeys-A-d1-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  detail:
+    the list offers one station twice in a row [('ORLEANS:StopArea:TVERNE2', 'ORLEANS:StopArea:TVERNE1')]
+
+case: tao-journeys-A-d1-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_477_21_A01_1_055950
+    asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_471_21_A01_1_080005
+    asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_467_10_A01_1_060100
+    asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_466_10_A01_1_155930
+
+case: tao-journeys-B-d0-pairs
+  result: PASSED
+
+case: tao-journeys-B-d0-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  detail:
+    the stop list repeats a stop_id
+    the list offers one station twice in a row [('ORLEANS:StopArea:THAMEA1', 'ORLEANS:StopArea:THAMEA2')]
+
+case: tao-journeys-B-d0-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_173_10_B01_1_055030
+    asked ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_175_10_B09_1_201110
+
+case: tao-journeys-B-d1-pairs
+  result: PASSED
+
+case: tao-journeys-B-d1-stop_list
+  result: XFAILED
+  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  detail:
+    the stop list repeats a stop_id
+
+case: tao-journeys-B-d1-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d1 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_167_10_B01_1_050300
+    asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d1 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_168_10_B06_1_195730
+
+case: tao-journeys-N-d0-pairs
+  result: PASSED
+
+case: tao-journeys-N-d0-stop_list
+  result: PASSED
+
+case: tao-journeys-N-d0-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d0 (stop 30 to stop 1 of a 30-stop ride, this direction does not make it): got ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d1, trip ORLEANS:VehicleJourney:N_R_16_21_2184_4_013000
+
+case: tao-journeys-N-d1-pairs
+  result: PASSED
+
+case: tao-journeys-N-d1-stop_list
+  result: PASSED
+
+case: tao-journeys-N-d1-swapped
+  result: XFAILED
+  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
+  detail:
+    asked ORLEANS:StopArea:01086001 -> ORLEANS:StopArea:01002003 on ORLEANS:Line:N d1 (stop 30 to stop 1 of a 30-stop ride, this direction does not make it): got ORLEANS:StopArea:01086001 -> ORLEANS:StopArea:01002003 on ORLEANS:Line:N d0, trip ORLEANS:VehicleJourney:N_A_17_21_2184_4_003001

--- a/tests_provider/test_journeys.py
+++ b/tests_provider/test_journeys.py
@@ -232,14 +232,19 @@ def sample_pairs(pattern):
 
 
 class Check:
-    def __init__(self):
-        self.failures = []
-        self.checked = 0
+    """Every verification made for one case, as records: the verdict, the
+    line a reader sees, and for a pair the asked and answered sides as
+    fields. conftest.py writes them to results.txt and results.json."""
 
-    def note(self, ok, message):
-        self.checked += 1
-        if not ok:
-            self.failures.append(message)
+    def __init__(self):
+        self.records = []
+
+    def note(self, ok, text, **fields):
+        self.records.append({"ok": bool(ok), "text": text, **fields})
+
+    @property
+    def failures(self):
+        return [r["text"] for r in self.records if not r["ok"]]
 
 
 # Cases known to fail on main today, each with what breaks the promise.
@@ -248,8 +253,10 @@ class Check:
 SELECTOR = ("the stop selector offers a stop twice or out of riding order "
             "(discussion #198)")
 SELECTOR_GVB = SELECTOR + "; trams 1, 7 and 17 also carry wrong direction_ids"
-SWAPPED = "the swapped pair answers a departure the line does not ride"
-TRAIN = "a train journey is matched by stop name on any line, not the asked one"
+SWAPPED = ("the swapped pair is answered although the asked direction does "
+           "not ride it: the query filters neither route nor direction")
+TRAIN = ("a train journey is matched by stop name prefix on any line, not "
+         "the asked one")
 KNOWN = {
     **{f"gvb-{r}-d{d}-stop_list": SELECTOR_GVB
        for r in ("1", "7", "13", "14", "17") for d in (0, 1)},
@@ -301,7 +308,7 @@ CASES = _cases()
 
 
 @pytest.mark.parametrize("fixture,route_id,direction,kind", CASES)
-def test_journeys(fixture, route_id, direction, kind):
+def test_journeys(record_property, fixture, route_id, direction, kind):
     fx = fixture_of(fixture)
     # HA sets its default zone once at startup from the configured one, which
     # on an install reading a French network is the French one; left in UTC
@@ -313,6 +320,9 @@ def test_journeys(fixture, route_id, direction, kind):
         check_train_route(check, fx, route_id, direction)
     else:
         check_route(check, fx, route_id, direction, kind)
+    record_property("case", {"fixture": fixture, "route": route_id,
+                             "direction": direction, "kind": kind})
+    record_property("checks", check.records)
     assert not check.failures, "\n".join(check.failures)
 
 
@@ -406,7 +416,9 @@ def check_route(check, fx, route_id, direction, kind):
                           and result["origin_stop_sequence"]
                           < result["destination_stop_time"]["Sequence"]
                           and result["arrival_time"] >= result["departure_time"])
-                    check.note(ok, stop_pair(result, pattern, o, d))
+                    asked = asked_of(pattern, o, d, route_id, query_direction)
+                    got = got_of(result)
+                    check.note(ok, answered(asked, got), asked=asked, got=got)
                 else:
                     swapped = dict(data, origin=data["destination"],
                                    destination=data["origin"])
@@ -420,23 +432,65 @@ def check_route(check, fx, route_id, direction, kind):
                     # when there is one, matches a ride the line actually
                     # makes. Answering nothing stays acceptable, the pattern
                     # that rides it may not run on the frozen day.
+                    served = served_between(grouped, fx.siblings_of(pattern[d]),
+                                            fx.siblings_of(pattern[o]))
                     honest = not result or (
-                        served_between(grouped, fx.siblings_of(pattern[d]),
-                                       fx.siblings_of(pattern[o]))
+                        served
                         and result["origin_stop_sequence"]
                         < result["destination_stop_time"]["Sequence"]
                         and result["arrival_time"] >= result["departure_time"])
-                    check.note(honest,
-                               f"the swapped pair {pattern[d]} -> {pattern[o]} "
-                               "answered a departure the line does not ride")
+                    asked = asked_of(pattern, d, o, route_id, query_direction,
+                                     served=served)
+                    got = got_of(result)
+                    check.note(honest, answered(asked, got), asked=asked, got=got)
 
 
-def stop_pair(result, pattern, o, d):
+def asked_of(pattern, a, b, route, direction, served=None):
+    """The asked side of a pair, with where the two stops sit in the
+    sequence being checked, so the line can be read without opening the
+    zip: stop 35 to stop 1 of a 35-stop ride is a journey against the
+    direction. `served` says whether this direction rides it at all."""
+    asked = {"origin": pattern[a], "destination": pattern[b], "route": route,
+             "direction": direction, "from_stop": a + 1, "to_stop": b + 1,
+             "ride_length": len(pattern)}
+    if served is not None:
+        asked["served"] = served
+    return asked
+
+
+def got_of(result, by_name=False):
+    """What get_next_departure gave back: the stops, the line and direction
+    of the trip it took them from, and that trip. None when it gave nothing."""
     if not result:
-        return f"no departure for {pattern[o]} -> {pattern[d]}"
-    return (f"wrong answer for {pattern[o]} -> {pattern[d]}: got "
-            f"{result.get('origin_stop_id')} -> "
-            f"{result.get('destination_stop_id')}")
+        return None
+    if by_name:
+        return {"origin": result.get("origin_stop_name"),
+                "destination": result.get("destination_stop_name"),
+                "route": result.get("route_short_name"),
+                "direction": result.get("trip_direction_id"),
+                "trip": result.get("trip_id")}
+    return {"origin": result.get("origin_stop_id"),
+            "destination": result.get("destination_stop_id"),
+            "route": result.get("route_id"),
+            "direction": result.get("trip_direction_id"),
+            "trip": result.get("trip_id")}
+
+
+def answered(asked, got):
+    """The one line a reader sees for a pair: the asked side, then the
+    answered side, both rendered from the same records results.json holds."""
+    where = (f"stop {asked['from_stop']} to stop {asked['to_stop']} of a "
+             f"{asked['ride_length']}-stop ride")
+    if asked.get("served") is False:
+        where += ", this direction does not make it"
+    on = f" on {asked['route']}"
+    if asked["direction"] is not None:
+        on += f" d{asked['direction']}"
+    head = f"asked {asked['origin']} -> {asked['destination']}{on} ({where})"
+    if not got:
+        return f"{head}: no departure"
+    return (f"{head}: got {got['origin']} -> {got['destination']} on "
+            f"{got['route']} d{got['direction']}, trip {got['trip']}")
 
 
 def _data_for(schedule, route_id, route_type, entries, position,
@@ -488,8 +542,7 @@ def check_train_route(check, fx, route_id, direction):
                       and result["origin_stop_sequence"]
                       < result["destination_stop_time"]["Sequence"]
                       and result["arrival_time"] >= result["departure_time"])
-                check.note(ok, f"{name_o} -> {name_d}: "
-                               + ("no departure" if not result else
-                                  f"got {result.get('origin_stop_name')} -> "
-                                  f"{result.get('destination_stop_name')} on "
-                                  f"{result.get('route_short_name')}"))
+                asked = asked_of([fx.stop_names[s] for s in pattern], o, d,
+                                 short_name, None)
+                got = got_of(result, by_name=True)
+                check.note(ok, answered(asked, got), asked=asked, got=got)

--- a/tests_provider/test_journeys.py
+++ b/tests_provider/test_journeys.py
@@ -357,22 +357,47 @@ def check_route(check, fx, route_id, direction, kind):
         return min(offered, key=lambda n: (n < previous, abs(n - previous)))
 
     if kind == "stop_list":
-        check.note(len(ids) == len(set(ids)), "the stop list repeats a stop_id")
+        # The entries read "STOP: Name (12)", the number being the
+        # stop_sequence the selector showed; a stop offered twice is one
+        # stop_id under two of those numbers, which is what a reader has to
+        # be told to find it again in the feed.
+        offered_at = {}
+        for entry, stop_id in zip(entries, ids):
+            place = entry.rsplit(" (", 1)[-1].rstrip(")") if " (" in entry else "?"
+            offered_at.setdefault(stop_id, []).append(place)
+        repeated = {stop_id: places for stop_id, places in offered_at.items()
+                    if len(places) > 1}
+        text = "the stop list offers a stop twice"
+        if repeated:
+            text += ": " + listed([f"{named(fx, stop_id)} at "
+                                   + " and ".join(places)
+                                   for stop_id, places in repeated.items()])
+        check.note(not repeated, text,
+                   repeated={stop_id: places
+                             for stop_id, places in repeated.items()})
         # Two platforms of one place, called one after the other, are one
         # entry: TAO line A offered Jules Verne twice and each choice hid
         # half the trams. Two records of a station the line calls at twice,
         # far apart in the ride, are not that case and stay offered.
         folded = [(a, b) for a, b in zip(ids, ids[1:])
                   if fx.station_of(a) and fx.station_of(a) == fx.station_of(b)]
-        check.note(not folded,
-                   f"the list offers one station twice in a row {folded[:1]}")
+        text = "the list offers one station twice in a row"
+        if folded:
+            text += ": " + listed([f"{named(fx, a)} then {named(fx, b)}"
+                                   for a, b in folded])
+        check.note(not folded, text, folded=[list(pair) for pair in folded])
         for pattern in grouped:
             places = []
             for stop in pattern:
                 previous = next((p for p in reversed(places) if p is not None), None)
                 places.append(place_of(stop, previous))
-            check.note(None not in places,
-                       "a trip serves a stop the list does not offer")
+            unoffered = [stop for stop, place in zip(pattern, places)
+                         if place is None]
+            text = "a trip serves a stop the list does not offer"
+            if unoffered:
+                text += (": " + listed([named(fx, stop) for stop in unoffered])
+                         + f" (on the ride {pattern[0]} .. {pattern[-1]})")
+            check.note(not unoffered, text, unoffered=list(unoffered))
             known = [place for place in places if place is not None]
             descents = sum(1 for a, b in zip(known, known[1:]) if a >= b)
             # a rotation of a circular line reads k..n then 0..k-1: one
@@ -474,6 +499,19 @@ def got_of(result, by_name=False):
             "route": result.get("route_id"),
             "direction": result.get("trip_direction_id"),
             "trip": result.get("trip_id")}
+
+
+def named(fx, stop_id):
+    """A stop as a reader can look it up: its id and the name it carries."""
+    name = fx.stop_names.get(stop_id)
+    return f"{stop_id} {name}" if name else stop_id
+
+
+def listed(items, limit=3):
+    """The first few of a list, then how many were left out."""
+    shown = ", ".join(items[:limit])
+    rest = len(items) - limit
+    return f"{shown}, and {rest} more" if rest > 0 else shown
 
 
 def answered(asked, got):


### PR DESCRIPTION
Follows #206 and answers the results file request. The commit message says what changes; nothing in the assertions does. Both results files committed here are the run on your main, as examples of the output.

On your question of 08:23: the tests already go through the code as it is, get_stop_list and get_next_departure, nothing of gtfs_helper.py is copied into the test. The SQL the test carries reads the feed (which directions a route has, the stop sequences of its trips, a day they run), not the code; that is the expected side. So no change to gtfs_helper.py is needed for this tree.
