### PR TITLE
Offer each stop once, in riding order, then the destinations a trip really reaches

### DIFF
--- a/custom_components/gtfs2/config_flow.py
+++ b/custom_components/gtfs2/config_flow.py
@@ -56,6 +56,7 @@ from .gtfs_helper import (
     get_next_departure,
     get_route_list,
     get_stop_list,
+    get_destination_stop_list,
     get_datasources,
     remove_datasource,
     check_datasource_index,
@@ -75,6 +76,16 @@ TRANSLATION_DESCRIPTION_PLACEHOLDERS = {
     "docu_configuring_options": "https://github.com/vingerha/gtfs2/wiki/04:-Configuring-a-route's-options-(inc.-adding-real%E2%80%90time)",
     "model": "Example model",
 }
+
+
+def _stop_name_of(entry):
+    """The stop name inside a picker entry "stop_id: Name #2 (12)": the
+    number given to a repeated name and the sequence are display only."""
+    name = entry.split(": ", 1)[1].rsplit(" (", 1)[0]
+    if " #" in name and name.rsplit(" #", 1)[1].isdigit():
+        name = name.rsplit(" #", 1)[0]
+    return name
+
 
 @config_entries.HANDLERS.register(DOMAIN)
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -327,83 +338,87 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_stops()
 
     async def async_step_stops(self, user_input: dict | None = None) -> FlowResult:
-        """Handle the route step."""
+        """Pick the origin: every stop the route rides in this direction."""
         errors: dict[str, str] = {}
         if user_input is None:
             try:
-                stops = get_stop_list(
+                stops = await self.hass.async_add_executor_job(
+                    get_stop_list,
                     self._pygtfs,
                     self._user_inputs[CONF_ROUTE],
                     self._user_inputs[CONF_DIRECTION],
                 )
-                last_stop = stops[-1:][0]
+                if not stops:
+                    raise ValueError("no stops")
                 return self.async_show_form(
                     step_id="stops",
                     data_schema=vol.Schema(
                         {
                             vol.Required(CONF_ORIGIN): vol.In(stops),
-                            vol.Required(CONF_DESTINATION, default=last_stop): vol.In(stops),
-                            vol.Required(CONF_NAME): str,
                         },
                     ),
                     description_placeholders=TRANSLATION_DESCRIPTION_PLACEHOLDERS,
                     errors=errors,
                 )
-            except:
+            except Exception:  # pylint: disable=broad-except
                 _LOGGER.debug(f"Likely no stops for this route: {[CONF_ROUTE]}")
                 return self.async_abort(reason="no_stops")
-                
-        # when train route-type, use the names of the selected stops       
-        if self._user_inputs[CONF_ROUTE_TYPE] == '2':
-            user_input[CONF_ORIGIN] = user_input.get(CONF_ORIGIN).split(': ')[1].split(" (")[0] 
-            user_input[CONF_DESTINATION] = user_input.get(CONF_DESTINATION).split(': ')[1].split(" (")[0]  
-            
+
         self._user_inputs.update(user_input)
-        _LOGGER.debug(f"UserInputs Stops: {self._user_inputs}")
-        check_config = await self._check_config(self._user_inputs)
-        if check_config:
-            return await self.async_step_stops_retry()
-        else:
-            return self.async_create_entry(
-                title=user_input[CONF_NAME], data=self._user_inputs
-            )
-            
-    async def async_step_stops_retry(self, user_input: dict | None = None) -> FlowResult:
-        """Handle the route step."""
+        _LOGGER.debug(f"UserInputs Origin: {self._user_inputs}")
+        return await self.async_step_destination()
+
+    async def async_step_destination(self, user_input: dict | None = None) -> FlowResult:
+        """Pick the destination among the stops a trip really rides to from
+        the chosen origin, so the pair can always be matched to a trip.
+
+        A pair no trip rides cannot be picked any more, so the only check
+        left is whether a trip is still to come. When none is, the screen
+        comes back with that said, the picks kept, and the user can choose
+        another destination.
+        """
         errors: dict[str, str] = {}
-        if user_input is None:
-            try:
-                stops = get_stop_list(
-                    self._pygtfs,
-                    self._user_inputs[CONF_ROUTE],
-                    self._user_inputs[CONF_DIRECTION],
-                )
-                last_stop = stops[-1:][0]
-                return self.async_show_form(
-                    step_id="stops_retry",
-                    data_schema=vol.Schema(
-                        {
-                            vol.Required(CONF_ORIGIN, default = self._user_inputs[CONF_ORIGIN]): vol.In(stops),
-                            vol.Required(CONF_DESTINATION, default = self._user_inputs[CONF_DESTINATION]): vol.In(stops),
-                            vol.Required(CONF_NAME): str,
-                        },
-                    ),
-                    description_placeholders=TRANSLATION_DESCRIPTION_PLACEHOLDERS,
-                    errors=errors,
-                )
-            except:
-                _LOGGER.debug(f"Likely no stops for this route: {[CONF_ROUTE]}")
-                return self.async_abort(reason="no_stops")
-        self._user_inputs.update(user_input)
-        _LOGGER.debug(f"UserInputs Stops: {self._user_inputs}")
-        check_config = await self._check_config(self._user_inputs)
-        if check_config:
-            return await self.async_step_stops_retry()
-        else:
-            return self.async_create_entry(
-                title=user_input[CONF_NAME], data=self._user_inputs
-            )            
-            
+        if user_input is not None:
+            data = {**self._user_inputs, **user_input}
+            # when train route-type, use the names of the selected stops: a
+            # platform id is not something the rider picks, the station is.
+            # The picker entries stay untouched in _user_inputs, the screen
+            # may have to be shown again
+            if data[CONF_ROUTE_TYPE] == '2':
+                data[CONF_ORIGIN] = _stop_name_of(data[CONF_ORIGIN])
+                data[CONF_DESTINATION] = _stop_name_of(data[CONF_DESTINATION])
+            _LOGGER.debug(f"UserInputs Destination: {data}")
+            check_config = await self._check_config(data)
+            if check_config == "stop_incorrect":
+                errors["base"] = "stop_incorrect"
+            elif check_config:
+                return self.async_abort(reason=check_config)
+            else:
+                return self.async_create_entry(title=data[CONF_NAME], data=data)
+
+        destinations = await self.hass.async_add_executor_job(
+            get_destination_stop_list,
+            self._pygtfs,
+            self._user_inputs[CONF_ROUTE],
+            self._user_inputs[CONF_DIRECTION],
+            self._user_inputs[CONF_ORIGIN].split(": ")[0],
+        )
+        if not destinations:
+            # the origin is the last stop of every trip that calls at it
+            return self.async_abort(reason="no_destination")
+        picked = user_input or {}
+        return self.async_show_form(
+            step_id="destination",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_DESTINATION, default=picked.get(CONF_DESTINATION, destinations[-1])): vol.In(destinations),
+                    vol.Required(CONF_NAME, default=picked.get(CONF_NAME, vol.UNDEFINED)): str,
+                },
+            ),
+            description_placeholders=TRANSLATION_DESCRIPTION_PLACEHOLDERS,
+            errors=errors,
+        )
+
     async def async_step_stops_train(self, user_input: dict | None = None) -> FlowResult:
         """Handle the stops when train, as often impossible to select ID"""
         errors: dict[str, str] = {}

--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -589,30 +589,140 @@ def get_route_list(schedule, data):
     _LOGGER.debug(f"routes: {routes}")
     return routes
 
-def get_stop_list(schedule, route_id, direction):
-    _LOGGER.debug("Getting stops list for route: %s", route_id)
-    sql_stops = f"""
-    SELECT distinct(s.stop_id), s.stop_name, st.stop_sequence
+def _walk_stops(rows):
+    """Order (trip_id, stop_id, stop_name, stop_sequence) rows, given by trip
+    and sequence, into one stop each, in riding order.
+
+    Trips of one direction do not all run the full length, and a partial
+    trip renumbers stop_sequence from 0, so sorting the union of all trips
+    by stop_sequence interleaves the start of the route with its middle
+    (TAO tram B: 110 short runs from mid-route) and offers a stop once per
+    number it was seen under (Palm Bus 22: 52 entries for 26 stops). Walk
+    the fullest trip first instead, it is the route as the rider rides it,
+    then slot each stop it skips right after the stop preceding it on a
+    trip that does serve it.
+
+    Returns the ordered stop_ids, their names, and the sequence each was
+    first seen under.
+    """
+    trips = {}
+    names = {}
+    for trip_id, stop_id, stop_name, stop_sequence in rows:
+        trips.setdefault(trip_id, []).append((stop_id, stop_sequence))
+        names[stop_id] = stop_name
+    order = []
+    kept_seq = {}
+    for _trip_id, trip_stops in sorted(
+        trips.items(), key=lambda kv: (-len(kv[1]), kv[0])
+    ):
+        prev = -1
+        for stop_id, stop_sequence in trip_stops:
+            if stop_id in kept_seq:
+                prev = order.index(stop_id)
+                continue
+            prev += 1
+            order.insert(prev, stop_id)
+            kept_seq[stop_id] = stop_sequence
+    return order, names, kept_seq
+
+
+def _homonym_ranks(order, names):
+    """{stop_id: n} for the stops whose name the line meets more than once.
+
+    A circular line calls at its terminus twice under ids of its own (TAO 22
+    runs Zenith to Zenith and offers three stops all reading "Zenith"), a
+    square carries four stops of one name (GVB's Surinameplein). Two entries
+    reading the same thing leave the choice to chance, so the repeats are
+    numbered in the order the line calls at them. Same-name stops stay
+    distinct entries: the two sides of a street are two stops, and folding
+    them by name would show a rider departures they cannot take.
+    """
+    by_name = {}
+    for stop_id in order:
+        by_name.setdefault(names[stop_id], []).append(stop_id)
+    rank = {}
+    for group in by_name.values():
+        if len(group) > 1:
+            for n, stop_id in enumerate(group, 1):
+                rank[stop_id] = n
+    return rank
+
+
+def _stop_entries(order, names, kept_seq, rank):
+    """The picker's entries, "stop_id: Name (sequence)". The value keeps the
+    id untouched, the sensor queries on it; only the readable part changes."""
+    stops = []
+    for stop_id in order:
+        shown = names[stop_id]
+        if stop_id in rank:
+            shown = f"{shown} #{rank[stop_id]}"
+        stops.append(f"{stop_id}: {shown} ({kept_seq[stop_id]})")
+    return stops
+
+
+def _route_stop_rows(schedule, route_id, direction):
+    sql_stops = """
+    SELECT st.trip_id, s.stop_id, s.stop_name, st.stop_sequence
     from trips t
     inner join stop_times st on st.trip_id = t.trip_id
     inner join stops s on s.stop_id = st.stop_id
-    where  t.route_id = '{route_id}'
-    and (t.direction_id = {direction} or t.direction_id is null)
-    order by st.stop_sequence
-    """  # noqa: S608
-    stops_list = []
-    stops = []
+    where t.route_id = :route_id
+    and (t.direction_id = :direction or t.direction_id is null)
+    order by st.trip_id, st.stop_sequence
+    """
     with schedule.engine.connect() as conn:
-        rows = conn.execute(text(sql_stops), {"q": "q"}).fetchall()
-    for row_cursor in rows:
-        row = row_cursor._asdict()
-        stops_list.append(list(row_cursor))
-    for x in stops_list:
-        val = x[0] + ": " + x[1] + ' (' + str(x[2]) + ')'
-        stops.append(val)
+        return conn.execute(text(sql_stops), {
+            "route_id": route_id, "direction": int(direction)}).fetchall()
+
+
+def get_stop_list(schedule, route_id, direction):
+    """Every stop a route rides in one direction, once each, in riding order."""
+    _LOGGER.debug("Getting stops list for route: %s", route_id)
+    order, names, kept_seq = _walk_stops(_route_stop_rows(schedule, route_id, direction))
+    stops = _stop_entries(order, names, kept_seq, _homonym_ranks(order, names))
     _LOGGER.debug(f"Route stops: {stops}")
-    return stops 
-    
+    return stops
+
+
+def get_destination_stop_list(schedule, route_id, direction, origin_stop_id):
+    """The stops reachable from origin_stop_id on this route and direction.
+
+    Only the trips that call at the origin are read, and of each only the
+    part after it, so every entry offered can be paired with the origin on
+    at least one trip: a pair that no trip rides never reaches the sensor.
+    Whether that trip runs today is another question, answered by
+    get_next_service_date. Same walk as get_stop_list, so the list reads as
+    the rest of the ride, and the same numbering of repeated names, so a
+    stop reads the same on both screens. A loop that calls at the origin
+    twice is read from its first call, which keeps the way back on offer.
+    """
+    _LOGGER.debug("Getting destinations for route: %s direction: %s from: %s",
+                  route_id, direction, origin_stop_id)
+    sql_stops = """
+    SELECT st.trip_id, s.stop_id, s.stop_name, st.stop_sequence
+    from trips t
+    inner join (
+        select trip_id, min(stop_sequence) as origin_sequence
+        from stop_times where stop_id = :origin group by trip_id
+    ) o on o.trip_id = t.trip_id
+    inner join stop_times st on st.trip_id = t.trip_id
+        and st.stop_sequence > o.origin_sequence
+    inner join stops s on s.stop_id = st.stop_id
+    where t.route_id = :route_id
+    and (t.direction_id = :direction or t.direction_id is null)
+    order by st.trip_id, st.stop_sequence
+    """
+    with schedule.engine.connect() as conn:
+        rows = conn.execute(text(sql_stops), {
+            "route_id": route_id, "direction": int(direction),
+            "origin": origin_stop_id}).fetchall()
+    whole, whole_names, _ = _walk_stops(_route_stop_rows(schedule, route_id, direction))
+    order, names, kept_seq = _walk_stops(rows)
+    stops = _stop_entries(order, names, kept_seq, _homonym_ranks(whole, whole_names))
+    _LOGGER.debug(f"Destinations from {origin_stop_id}: {stops}")
+    return stops
+
+
 def get_agency_list(schedule, data):
     _LOGGER.debug("Getting agencies with data: %s", data)
     sql_agencies = f"""

--- a/custom_components/gtfs2/strings.json
+++ b/custom_components/gtfs2/strings.json
@@ -56,22 +56,17 @@
       },
       "stops": {
         "data": {
-          "origin": "Origin Stop",
-          "destination": "Destination Stop",
-          "name": "Name of the route",
-          "include_tomorrow": "Include tomorrow"
+          "origin": "Origin Stop"
         },
-		"description": "Select from the options below [(docu)]({docu_new_route})"
+        "description": "Select the origin stop, listed in riding order [(docu)]({docu_new_route})"
       },
-      "stops_retry": {
+      "destination": {
         "data": {
-          "origin": "Origin Stop",
           "destination": "Destination Stop",
-          "name": "Name of the route",
-          "include_tomorrow": "Include tomorrow"
+          "name": "Name of the route"
         },
-		"description": "No trip found between selected stops, try again [(docu)]({docu_new_route})"
-      },	  
+        "description": "Select the destination among the stops a trip really rides to from the chosen origin [(docu)]({docu_new_route})"
+      },
 	  "stops_train": {
         "data": {
           "origin": "Enter the city of departure",
@@ -104,6 +99,8 @@
       "stop_incorrect": "Start and/or End destination incorrect, \n possibly no transport 'today' or not in same direction, \n please check logs",
 	  "no_data_file": "Data collection issue: URL incorrect or filename not in the correct folder",
 	  "no_stops": "Data collection issue: probably no stops for the selected route",
+	  "no_destination": "No stop can be reached from the selected origin in this direction",
+	  "generic_failure": "Overall failure, check logs",
 	  "no_zip_file": "Data collection issue: ZIP file not existing in the correct folder, note that it is capital-sensitive",
 	  "stop_limit_reached": "Detected a high number of stops for this radius, \npossibly impacting system performance. \n You can change the limit at your own risk before changing the radius.",
 	  "extracting": "(Still) extracting data, this will take time [(docu)]({docu_extracting})"

--- a/custom_components/gtfs2/translations/de.json
+++ b/custom_components/gtfs2/translations/de.json
@@ -56,20 +56,17 @@
       },
       "stops": {
         "data": {
-          "origin": "Origin Stop",
-          "destination": "Zielhaltestelle",
-          "name": "Name der Route"
+          "origin": "Starthaltestelle"
         },
-        "description": "Wählen Sie aus den Optionen unten [(docu)]({docu_new_route})"
+        "description": "Wählen Sie die Starthaltestelle, in Fahrtreihenfolge [(docu)]({docu_new_route})"
       },
-      "stops_retry": {
+      "destination": {
         "data": {
-          "origin": "Origin Stop",
           "destination": "Zielhaltestelle",
           "name": "Name der Route"
         },
-        "description": "Kein Trip gefunden, bitte Haltestelle(n) ändern [(docu)]({docu_new_route})"
-      },	  
+        "description": "Wählen Sie das Ziel unter den Haltestellen, die eine Fahrt ab der gewählten Starthaltestelle tatsächlich anfährt [(docu)]({docu_new_route})"
+      },
       "stops_train": {
         "data": {
           "origin": "Wählen sie die Stadt ihrer Abfahrt",
@@ -100,6 +97,8 @@
       "files_deleted": "Datenquelle gelöscht, dies kann sich auf bestehende Routen auswirken",
       "stop_incorrect": "Start- und/oder Endziel falsch, möglicherweise kein Transport ‚heute‘ oder nicht in die gleiche Richtung, Protokolle prüfen",
 	  "no_stops": "Problem bei der Datenerfassung: wahrscheinlich keine Stops für die gewählte Route",
+	  "no_destination": "Von der gewählten Starthaltestelle ist in dieser Richtung keine Haltestelle erreichbar",
+	  "generic_failure": "Gesamtfehler, Protokolle prüfen",
       "no_data_file": "Problem bei der Datenerfassung: URL falsch oder Dateiname nicht im richtigen Ordner",
       "no_zip_file": "Problem bei der Datenerfassung: ZIP-Datei ist nicht im richtigen Ordner vorhanden. Beachten Sie, dass Groß- und Kleinschreibung berücksichtigt werden muss",
 	  "stop_limit_reached": "Es wurde eine hohe Anzahl von Stopps für diesen Umkreis festgestellt. \n Es besteht die Gefahr einer Beeinträchtigung der Systemleistung. \n Sie können die Limite auf eigenes Risiko ändern, bevor Sie den Umkreis ändern",

--- a/custom_components/gtfs2/translations/en.json
+++ b/custom_components/gtfs2/translations/en.json
@@ -56,20 +56,17 @@
       },
       "stops": {
         "data": {
-          "origin": "Origin Stop",
-          "destination": "Destination Stop",
-          "name": "Name of the route"
+          "origin": "Origin Stop"
         },
-		"description": "Select from the options below [(docu)]({docu_new_route})"
+        "description": "Select the origin stop, listed in riding order [(docu)]({docu_new_route})"
       },
-      "stops_retry": {
+      "destination": {
         "data": {
-          "origin": "Origin Stop",
           "destination": "Destination Stop",
           "name": "Name of the route"
         },
-		"description": "No trip found between selected stops, try again [(docu)]({docu_new_route})"
-      },	  
+        "description": "Select the destination among the stops a trip really rides to from the chosen origin [(docu)]({docu_new_route})"
+      },
 	  "stops_train": {
         "data": {
           "origin": "Enter the city of departure",
@@ -101,6 +98,8 @@
       "stop_incorrect": "Start and/or End destination incorrect, \n possibly no transport 'today' or not in same direction, \n please check logs",
 	  "no_data_file": "Data collection issue: URL incorrect or filename not in the correct folder",
 	  "no_stops": "Data collection issue: probably no stops for the selected route",
+	  "no_destination": "No stop can be reached from the selected origin in this direction",
+	  "generic_failure": "Overall failure, check logs",
 	  "no_zip_file": "Data collection issue: ZIP file not existing in the correct folder, note that it is capital-sensitive",
 	  "stop_limit_reached": "Detected a high number of stops for this radius, \npossibly impacting system performance. \n You can change the limit at your own risk before changing the radius.",
 	  "extracting": "(Still) extracting data, this will take time [(docu)]({docu_extracting})"

--- a/custom_components/gtfs2/translations/es.json
+++ b/custom_components/gtfs2/translations/es.json
@@ -56,20 +56,17 @@
       },
       "stops": {
         "data": {
-          "origin": "Parada de origen",
-          "destination": "Parada de destino",
-          "name": "Nombre de la ruta"
+          "origin": "Parada de origen"
         },
-		"description": "Seleccione una de las siguientes opciones [(docu)]({docu_new_route})"
+        "description": "Seleccione la parada de origen, en orden de recorrido [(docu)]({docu_new_route})"
       },
-      "stops_retry": {
+      "destination": {
         "data": {
-          "origin": "Parada de origen",
           "destination": "Parada de destino",
           "name": "Nombre de la ruta"
         },
-		"description": "Viaje no encontrado, Inténtalo de nuevo con otra parada(s). [(docu)]({docu_new_route})"
-      },	  
+        "description": "Seleccione el destino entre las paradas a las que un viaje llega realmente desde el origen elegido [(docu)]({docu_new_route})"
+      },
 	  "stops_train": {
         "data": {
           "origin": "Introduzca la ciudad de salida",
@@ -101,6 +98,8 @@
       "stop_incorrect": "Destino inicial y/o final incorrecto, posiblemente no hay transporte 'hoy' o no en la misma dirección, compruebe los registros",
 	  "no_data_file": "Problema de recopilación de datos: URL incorrecta o nombre de archivo que no está en la carpeta correcta",
 	  "no_stops": "Problema de recogida de datos: probablemente no hay paradas en la ruta seleccionada",
+	  "no_destination": "Ninguna parada es alcanzable desde el origen seleccionado en esta dirección",
+	  "generic_failure": "Fallo general, compruebe los registros",
 	  "no_zip_file": "Problema con la recogida de datos: El archivo ZIP no existe en la carpeta correcta, tenga en cuenta que es sensible a las mayúsculas",
 	  "stop_limit_reached": "Se detectó una gran cantidad de paradas para este radio, \nlo que posiblemente afecte el rendimiento del sistema. \nPuedes cambiar el límite bajo tu propia responsabilidad antes de cambiar el radio",
 	  "extracting": "(Todavía) extrayendo datos, esto llevará tiempo [(docu)]({docu_extracting})"

--- a/custom_components/gtfs2/translations/fr.json
+++ b/custom_components/gtfs2/translations/fr.json
@@ -56,20 +56,17 @@
       },
       "stops": {
         "data": {
-          "origin": "Arrêt d'origine",
-          "destination": "Arrêt de destination",
-          "name": "Nom de la ligne"
+          "origin": "Arrêt d'origine"
         },
-		"description": "Sélectionnez parmi les options [(docu)]({docu_new_route})"
+        "description": "Sélectionnez l'arrêt d'origine, dans l'ordre de passage [(docu)]({docu_new_route})"
       },
-      "stops_retry": {
+      "destination": {
         "data": {
-          "origin": "Arrêt d'origine",
           "destination": "Arrêt de destination",
           "name": "Nom de la ligne"
         },
-		"description": "Échoué, svp re-essayer avec d'autre arrêt(s) [(docu)]({docu_new_route})"
-      },	  
+        "description": "Sélectionnez la destination parmi les arrêts qu'un trajet dessert réellement depuis l'origine choisie [(docu)]({docu_new_route})"
+      },
 	  "stops_train": {
         "data": {
           "origin": "Ville de départ",
@@ -101,6 +98,8 @@
       "stop_incorrect": "Arrêt de départ et/ou de fin incorrecte, éventuellement pas de transport « aujourd'hui » ou pas dans la même direction, vérifiez logs d'érreur",
 	  "no_data_file": "Problème de collecte de données : URL incorrecte ou nom de fichier ne se trouve pas dans le bon dossier",
 	  "no_stops": "Problème de collecte de données : probablement pas des stops pour la route sélectionné",
+	  "no_destination": "Aucun arrêt n'est atteignable depuis l'origine choisie dans cette direction",
+	  "generic_failure": "Échec global, vérifiez les logs d'erreur",
 	  "no_zip_file": "Problème de collecte de données : fichier ZIP ne se trouve pas dans le bon dossier, note: sensible à la casse",
 	  "stop_limit_reached": "Un nombre élevé d'arrêts a été détecté pour ce rayon, \nrisque d'impact sur les performances du système. \n Vous pouvez modifier la limite à votre propre risque avant de modifier le rayon",
 	  "extracting": "Extraction des données en cours, cela prend du temps [(docu)]({docu_extracting})"

--- a/custom_components/gtfs2/translations/pt.json
+++ b/custom_components/gtfs2/translations/pt.json
@@ -56,20 +56,17 @@
       },
       "stops": {
         "data": {
-          "origin": "Paragem de origem",
-          "destination": "Paragem de destino",
-          "name": "Nome da rota"
+          "origin": "Paragem de origem"
         },
-		"description": "Selecione uma das opções abaixo [(docu)]({docu_new_route})"
+        "description": "Selecione a paragem de origem, por ordem de passagem [(docu)]({docu_new_route})"
       },
-      "stops_retry": {
+      "destination": {
         "data": {
-          "origin": "Paragem de origem",
           "destination": "Paragem de destino",
           "name": "Nome da rota"
         },
-		"description": "Viagem não encontrada, tente novamente com outra paragem(s) [(docu)]({docu_new_route})"
-      },	  
+        "description": "Selecione o destino entre as paragens que uma viagem alcança realmente a partir da origem escolhida [(docu)]({docu_new_route})"
+      },
 	  "stops_train": {
         "data": {
           "origin": "Introduza a cidade de partida",
@@ -101,6 +98,8 @@
       "stop_incorrect": "Paragem de início e/ou de fim incorreta, \n possivelmente sem transporte 'hoje' ou não na mesma direção, \n por favor, verifique os logs",
 	  "no_data_file": "Problema de recolha de dados: URL incorreta ou nome do ficheiro não está na pasta correta",
 	  "no_stops": "Problema de recolha de dados: provavelmente sem paragens para a rota selecionada",
+	  "no_destination": "Nenhuma paragem é alcançável a partir da origem selecionada nesta direção",
+	  "generic_failure": "Falha geral, verifique os logs",
 	  "no_zip_file": "Problema de recolha de dados: Ficheiro ZIP não existe na pasta correta, note que é sensível a maiúsculas",
 	  "stop_limit_reached": "Foi detectado um grande número de paragens neste raio, \nrisco de impacto no desempenho do sistema. \n Pode alterar o limite por sua conta e risco antes de alterar o raio",
 	  "extracting": "(Ainda) a extrair dados, isso vai demorar [(docu)]({docu_extracting})"

--- a/tests_provider/instructions.txt
+++ b/tests_provider/instructions.txt
@@ -5,7 +5,7 @@ What it is:
 - manifest.json in each says where the bytes came from, what was kept and why; sncf also carries scenarios.json, the journeys its entities make testable
 - fixtures/build_fixture.py cuts any static zip down to named routes, a few trips per stop pattern
 - fixtures/capture_rt.py freezes a static + trip updates + alerts capture, SNCF by default, any feed with --static/--trip-updates/--alerts
-- test_journeys.py reads them: one test per fixture, route, direction and promise (stop list, a valid pair, the swapped pair), through the real query on a db fixture_db.py builds from the zip, no pygtfs import
+- test_journeys.py reads them: one test per fixture, route, direction and promise (stop list, destinations from an origin, a valid pair, the swapped pair), through the real query on a db fixture_db.py builds from the zip, no pygtfs import
 - the clock is pinned with freezegun to a day the trips run, in the agency's zone, so the data never has to be shifted to today
 - the cases known to fail on main are marked xfail with the reason, strict, so a fix has to lift its mark
 
@@ -20,6 +20,10 @@ How a case is built:
   file, the feed itself says what the line rides
 - stop_list asks get_stop_list for the route and direction and checks the list
   against every sequence: each stop once, in an order every trip agrees with
+- destinations asks get_destination_stop_list from three stops of each
+  sequence (the first, one in the middle, the one before last) and checks the
+  list against the trips through that stop: every stop they ride to after it,
+  once, in riding order, and nothing no trip through it reaches
 - pairs and swapped take three pairs per sequence (the two ends, first stop to
   middle, middle to last), pin the clock with freezegun at 00:05 in the agency's
   zone on the first day one of those trips runs, and hand get_next_departure

--- a/tests_provider/results.json
+++ b/tests_provider/results.json
@@ -3,6 +3,362 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "3980295",
+          "text": "a destination is offered twice from 3980295 Amsterdam, Azartplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980295",
+          "text": "a stop this ride reaches from 3980295 Amsterdam, Azartplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980295",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980295 Amsterdam, Azartplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980295",
+          "text": "the destinations from 3980295 Amsterdam, Azartplein contradict the riding order 3980295 .. 4015830"
+        },
+        {
+          "ok": true,
+          "origin": "3980004",
+          "text": "a destination is offered twice from 3980004 Amsterdam, Frederiksplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980004",
+          "text": "a stop this ride reaches from 3980004 Amsterdam, Frederiksplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980004",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980004 Amsterdam, Frederiksplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980004",
+          "text": "the destinations from 3980004 Amsterdam, Frederiksplein contradict the riding order 3980295 .. 4015830"
+        },
+        {
+          "ok": true,
+          "origin": "3980919",
+          "text": "a destination is offered twice from 3980919 Amsterdam, Rhijnvis Feithstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980919",
+          "text": "a stop this ride reaches from 3980919 Amsterdam, Rhijnvis Feithstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980919",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980919 Amsterdam, Rhijnvis Feithstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980919",
+          "text": "the destinations from 3980919 Amsterdam, Rhijnvis Feithstraat contradict the riding order 3980295 .. 4015830"
+        },
+        {
+          "ok": true,
+          "origin": "3981002",
+          "text": "a destination is offered twice from 3981002 Amsterdam, Matterhorn",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981002",
+          "text": "a stop this ride reaches from 3981002 Amsterdam, Matterhorn is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981002",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981002 Amsterdam, Matterhorn is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981002",
+          "text": "the destinations from 3981002 Amsterdam, Matterhorn contradict the riding order 3981002 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3980596",
+          "text": "a destination is offered twice from 3980596 Amsterdam, Nicolaas Beetsstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980596",
+          "text": "a stop this ride reaches from 3980596 Amsterdam, Nicolaas Beetsstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980596",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980596 Amsterdam, Nicolaas Beetsstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980596",
+          "text": "the destinations from 3980596 Amsterdam, Nicolaas Beetsstraat contradict the riding order 3981002 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "text": "a destination is offered twice from 3980764 Amsterdam, C. van Eesterenlaan",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980764",
+          "text": "a stop this ride reaches from 3980764 Amsterdam, C. van Eesterenlaan is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980764 Amsterdam, C. van Eesterenlaan is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "text": "the destinations from 3980764 Amsterdam, C. van Eesterenlaan contradict the riding order 3981002 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "4138837",
+          "text": "a destination is offered twice from 4138837 Amsterdam, Leidseplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "4138837",
+          "text": "a stop this ride reaches from 4138837 Amsterdam, Leidseplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "4138837",
+          "stray": [],
+          "text": "a destination no trip reaches from 4138837 Amsterdam, Leidseplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "4138837",
+          "text": "the destinations from 4138837 Amsterdam, Leidseplein contradict the riding order 4138837 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3980814",
+          "text": "a destination is offered twice from 3980814 Amsterdam, Alexanderplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980814",
+          "text": "a stop this ride reaches from 3980814 Amsterdam, Alexanderplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980814",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980814 Amsterdam, Alexanderplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980814",
+          "text": "the destinations from 3980814 Amsterdam, Alexanderplein contradict the riding order 4138837 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "text": "a destination is offered twice from 3980764 Amsterdam, C. van Eesterenlaan",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980764",
+          "text": "a stop this ride reaches from 3980764 Amsterdam, C. van Eesterenlaan is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980764 Amsterdam, C. van Eesterenlaan is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "text": "the destinations from 3980764 Amsterdam, C. van Eesterenlaan contradict the riding order 4138837 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3981002",
+          "text": "a destination is offered twice from 3981002 Amsterdam, Matterhorn",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981002",
+          "text": "a stop this ride reaches from 3981002 Amsterdam, Matterhorn is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981002",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981002 Amsterdam, Matterhorn is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981002",
+          "text": "the destinations from 3981002 Amsterdam, Matterhorn contradict the riding order 3981002 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3980938",
+          "text": "a destination is offered twice from 3980938 Amsterdam, Jan Pieter Heijestraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980938",
+          "text": "a stop this ride reaches from 3980938 Amsterdam, Jan Pieter Heijestraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980938",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980938 Amsterdam, Jan Pieter Heijestraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980938",
+          "text": "the destinations from 3980938 Amsterdam, Jan Pieter Heijestraat contradict the riding order 3981002 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "text": "a destination is offered twice from 3980764 Amsterdam, C. van Eesterenlaan",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980764",
+          "text": "a stop this ride reaches from 3980764 Amsterdam, C. van Eesterenlaan is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980764 Amsterdam, C. van Eesterenlaan is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "text": "the destinations from 3980764 Amsterdam, C. van Eesterenlaan contradict the riding order 3981002 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3979966",
+          "text": "a destination is offered twice from 3979966 Amsterdam, Rhijnvis Feithstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979966",
+          "text": "a stop this ride reaches from 3979966 Amsterdam, Rhijnvis Feithstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979966",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979966 Amsterdam, Rhijnvis Feithstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979966",
+          "text": "the destinations from 3979966 Amsterdam, Rhijnvis Feithstraat contradict the riding order 3979966 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3979766",
+          "text": "a destination is offered twice from 3979766 Amsterdam, Weesperplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979766",
+          "text": "a stop this ride reaches from 3979766 Amsterdam, Weesperplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979766",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979766 Amsterdam, Weesperplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979766",
+          "text": "the destinations from 3979766 Amsterdam, Weesperplein contradict the riding order 3979966 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "text": "a destination is offered twice from 3980764 Amsterdam, C. van Eesterenlaan",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980764",
+          "text": "a stop this ride reaches from 3980764 Amsterdam, C. van Eesterenlaan is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980764 Amsterdam, C. van Eesterenlaan is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "text": "the destinations from 3980764 Amsterdam, C. van Eesterenlaan contradict the riding order 3979966 .. 3979810"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-1-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152323"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "3979810",
             "direction": 0,
@@ -314,94 +670,9 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "3979766": [
-              "5",
-              "8",
-              "20",
-              "23"
-            ],
-            "3979810": [
-              "12",
-              "15",
-              "27",
-              "30"
-            ],
-            "3979846": [
-              "3",
-              "6",
-              "18",
-              "21"
-            ],
-            "3979966": [
-              "1",
-              "13"
-            ],
-            "3980107": [
-              "10",
-              "13",
-              "25",
-              "28"
-            ],
-            "3980187": [
-              "2",
-              "5",
-              "17",
-              "20"
-            ],
-            "3980498": [
-              "6",
-              "9",
-              "21",
-              "24"
-            ],
-            "3980764": [
-              "11",
-              "14",
-              "26",
-              "29"
-            ],
-            "3980814": [
-              "7",
-              "10",
-              "22",
-              "25"
-            ],
-            "3980938": [
-              "2",
-              "14"
-            ],
-            "3981021": [
-              "8",
-              "11",
-              "23",
-              "26"
-            ],
-            "3981063": [
-              "3",
-              "15"
-            ],
-            "3981181": [
-              "4",
-              "7",
-              "19",
-              "22"
-            ],
-            "3981412": [
-              "9",
-              "12",
-              "24",
-              "27"
-            ],
-            "4138837": [
-              "1",
-              "4",
-              "16",
-              "19"
-            ]
-          },
-          "text": "the stop list offers a stop twice: 4138837 Amsterdam, Leidseplein at 1 and 4 and 16 and 19, 3979966 Amsterdam, Rhijnvis Feithstraat at 1 and 13, 3980187 Amsterdam, Rijksmuseum at 2 and 5 and 17 and 20, and 12 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
           "folded": [],
@@ -458,8 +729,8 @@
       "fixture": "gvb",
       "id": "gvb-1-d0-stop_list",
       "kind": "stop_list",
-      "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "outcome": "passed",
+      "reason": null,
       "route": "152323"
     },
     {
@@ -694,6 +965,362 @@
       "fixture": "gvb",
       "id": "gvb-1-d0-swapped",
       "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152323"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "4132580",
+          "text": "a destination is offered twice from 4132580 Amsterdam, Surinameplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "4132580",
+          "text": "a stop this ride reaches from 4132580 Amsterdam, Surinameplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "4132580",
+          "stray": [],
+          "text": "a destination no trip reaches from 4132580 Amsterdam, Surinameplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "4132580",
+          "text": "the destinations from 4132580 Amsterdam, Surinameplein contradict the riding order 4132580 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3979766",
+          "text": "a destination is offered twice from 3979766 Amsterdam, Weesperplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979766",
+          "text": "a stop this ride reaches from 3979766 Amsterdam, Weesperplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979766",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979766 Amsterdam, Weesperplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979766",
+          "text": "the destinations from 3979766 Amsterdam, Weesperplein contradict the riding order 4132580 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "text": "a destination is offered twice from 3980764 Amsterdam, C. van Eesterenlaan",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980764",
+          "text": "a stop this ride reaches from 3980764 Amsterdam, C. van Eesterenlaan is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980764 Amsterdam, C. van Eesterenlaan is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "text": "the destinations from 3980764 Amsterdam, C. van Eesterenlaan contradict the riding order 4132580 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3979966",
+          "text": "a destination is offered twice from 3979966 Amsterdam, Rhijnvis Feithstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979966",
+          "text": "a stop this ride reaches from 3979966 Amsterdam, Rhijnvis Feithstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979966",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979966 Amsterdam, Rhijnvis Feithstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979966",
+          "text": "the destinations from 3979966 Amsterdam, Rhijnvis Feithstraat contradict the riding order 3979966 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3979766",
+          "text": "a destination is offered twice from 3979766 Amsterdam, Weesperplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979766",
+          "text": "a stop this ride reaches from 3979766 Amsterdam, Weesperplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979766",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979766 Amsterdam, Weesperplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979766",
+          "text": "the destinations from 3979766 Amsterdam, Weesperplein contradict the riding order 3979966 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "text": "a destination is offered twice from 3980764 Amsterdam, C. van Eesterenlaan",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980764",
+          "text": "a stop this ride reaches from 3980764 Amsterdam, C. van Eesterenlaan is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980764 Amsterdam, C. van Eesterenlaan is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980764",
+          "text": "the destinations from 3980764 Amsterdam, C. van Eesterenlaan contradict the riding order 3979966 .. 3979810"
+        },
+        {
+          "ok": true,
+          "origin": "3980295",
+          "text": "a destination is offered twice from 3980295 Amsterdam, Azartplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980295",
+          "text": "a stop this ride reaches from 3980295 Amsterdam, Azartplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980295",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980295 Amsterdam, Azartplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980295",
+          "text": "the destinations from 3980295 Amsterdam, Azartplein contradict the riding order 3980295 .. 3980743"
+        },
+        {
+          "ok": true,
+          "origin": "3981140",
+          "text": "a destination is offered twice from 3981140 Amsterdam, Witte de Withstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981140",
+          "text": "a stop this ride reaches from 3981140 Amsterdam, Witte de Withstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981140",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981140 Amsterdam, Witte de Withstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981140",
+          "text": "the destinations from 3981140 Amsterdam, Witte de Withstraat contradict the riding order 3980295 .. 3980743"
+        },
+        {
+          "ok": true,
+          "origin": "3980711",
+          "text": "a destination is offered twice from 3980711 Amsterdam, Pilatus",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980711",
+          "text": "a stop this ride reaches from 3980711 Amsterdam, Pilatus is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980711",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980711 Amsterdam, Pilatus is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980711",
+          "text": "the destinations from 3980711 Amsterdam, Pilatus contradict the riding order 3980295 .. 3980743"
+        },
+        {
+          "ok": true,
+          "origin": "3979725",
+          "text": "a destination is offered twice from 3979725 Amsterdam, Surinameplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979725",
+          "text": "a stop this ride reaches from 3979725 Amsterdam, Surinameplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979725",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979725 Amsterdam, Surinameplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979725",
+          "text": "the destinations from 3979725 Amsterdam, Surinameplein contradict the riding order 3979725 .. 3980743"
+        },
+        {
+          "ok": true,
+          "origin": "3980204",
+          "text": "a destination is offered twice from 3980204 Amsterdam, Hoekenes",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980204",
+          "text": "a stop this ride reaches from 3980204 Amsterdam, Hoekenes is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980204",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980204 Amsterdam, Hoekenes is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980204",
+          "text": "the destinations from 3980204 Amsterdam, Hoekenes contradict the riding order 3979725 .. 3980743"
+        },
+        {
+          "ok": true,
+          "origin": "3980711",
+          "text": "a destination is offered twice from 3980711 Amsterdam, Pilatus",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980711",
+          "text": "a stop this ride reaches from 3980711 Amsterdam, Pilatus is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980711",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980711 Amsterdam, Pilatus is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980711",
+          "text": "the destinations from 3980711 Amsterdam, Pilatus contradict the riding order 3979725 .. 3980743"
+        },
+        {
+          "ok": true,
+          "origin": "3980295",
+          "text": "a destination is offered twice from 3980295 Amsterdam, Azartplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980295",
+          "text": "a stop this ride reaches from 3980295 Amsterdam, Azartplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980295",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980295 Amsterdam, Azartplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980295",
+          "text": "the destinations from 3980295 Amsterdam, Azartplein contradict the riding order 3980295 .. 3980743"
+        },
+        {
+          "ok": true,
+          "origin": "3981186",
+          "text": "a destination is offered twice from 3981186 Amsterdam, Jan Pieter Heijestraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981186",
+          "text": "a stop this ride reaches from 3981186 Amsterdam, Jan Pieter Heijestraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981186",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981186 Amsterdam, Jan Pieter Heijestraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981186",
+          "text": "the destinations from 3981186 Amsterdam, Jan Pieter Heijestraat contradict the riding order 3980295 .. 3980743"
+        },
+        {
+          "ok": true,
+          "origin": "3980711",
+          "text": "a destination is offered twice from 3980711 Amsterdam, Pilatus",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980711",
+          "text": "a stop this ride reaches from 3980711 Amsterdam, Pilatus is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980711",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980711 Amsterdam, Pilatus is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980711",
+          "text": "the destinations from 3980711 Amsterdam, Pilatus contradict the riding order 3980295 .. 3980743"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-1-d1-destinations",
+      "kind": "destinations",
       "outcome": "passed",
       "reason": null,
       "route": "152323"
@@ -1012,140 +1639,19 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "3979725": [
-              "1",
-              "16",
-              "19"
-            ],
-            "3979766": [
-              "8",
-              "9"
-            ],
-            "3979810": [
-              "15",
-              "16"
-            ],
-            "3979846": [
-              "6",
-              "7"
-            ],
-            "3979851": [
-              "8",
-              "23",
-              "26"
-            ],
-            "3979966": [
-              "1",
-              "2"
-            ],
-            "3980050": [
-              "4",
-              "19",
-              "22"
-            ],
-            "3980107": [
-              "13",
-              "14"
-            ],
-            "3980113": [
-              "9",
-              "24",
-              "27"
-            ],
-            "3980187": [
-              "5",
-              "6"
-            ],
-            "3980204": [
-              "7",
-              "22",
-              "25"
-            ],
-            "3980220": [
-              "2",
-              "17",
-              "20"
-            ],
-            "3980231": [
-              "5",
-              "20",
-              "23"
-            ],
-            "3980258": [
-              "6",
-              "21",
-              "24"
-            ],
-            "3980498": [
-              "9",
-              "10"
-            ],
-            "3980711": [
-              "11",
-              "26",
-              "29"
-            ],
-            "3980743": [
-              "12",
-              "27",
-              "30"
-            ],
-            "3980764": [
-              "14",
-              "15"
-            ],
-            "3980814": [
-              "10",
-              "11"
-            ],
-            "3980938": [
-              "2",
-              "3"
-            ],
-            "3981021": [
-              "11",
-              "12"
-            ],
-            "3981063": [
-              "3",
-              "4"
-            ],
-            "3981181": [
-              "7",
-              "8"
-            ],
-            "3981217": [
-              "10",
-              "25",
-              "28"
-            ],
-            "3981412": [
-              "12",
-              "13"
-            ],
-            "3981436": [
-              "3",
-              "18",
-              "21"
-            ],
-            "4138837": [
-              "4",
-              "5"
-            ]
-          },
-          "text": "the stop list offers a stop twice: 3979966 Amsterdam, Rhijnvis Feithstraat at 1 and 2, 3979725 Amsterdam, Surinameplein at 1 and 16 and 19, 3980938 Amsterdam, Jan Pieter Heijestraat at 2 and 3, and 24 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
           "folded": [
             [
-              "3979766",
-              "3980631"
+              "3979810",
+              "3980295"
             ]
           ],
           "ok": false,
-          "text": "the list offers one station twice in a row: 3979766 Amsterdam, Weesperplein then 3980631 Amsterdam, Weesperplein"
+          "text": "the list offers one station twice in a row: 3979810 Amsterdam, Azartplein then 3980295 Amsterdam, Azartplein"
         },
         {
           "ok": true,
@@ -1198,7 +1704,7 @@
       "id": "gvb-1-d1-stop_list",
       "kind": "stop_list",
       "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "reason": "two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups); trams 1, 7 and 17 also carry wrong direction_ids",
       "route": "152323"
     },
     {
@@ -1440,6 +1946,224 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "3981287",
+          "text": "a destination is offered twice from 3981287 Amsterdam, Lambertus Zijlplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981287",
+          "text": "a stop this ride reaches from 3981287 Amsterdam, Lambertus Zijlplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981287",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981287 Amsterdam, Lambertus Zijlplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981287",
+          "text": "the destinations from 3981287 Amsterdam, Lambertus Zijlplein contradict the riding order 3981287 .. 3981133"
+        },
+        {
+          "ok": true,
+          "origin": "3980544",
+          "text": "a destination is offered twice from 3980544 Amsterdam, Admiraal de Ruijterweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980544",
+          "text": "a stop this ride reaches from 3980544 Amsterdam, Admiraal de Ruijterweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980544",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980544 Amsterdam, Admiraal de Ruijterweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980544",
+          "text": "the destinations from 3980544 Amsterdam, Admiraal de Ruijterweg contradict the riding order 3981287 .. 3981133"
+        },
+        {
+          "ok": true,
+          "origin": "3981052",
+          "text": "a destination is offered twice from 3981052 Amsterdam, Haarlemmerplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981052",
+          "text": "a stop this ride reaches from 3981052 Amsterdam, Haarlemmerplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981052",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981052 Amsterdam, Haarlemmerplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981052",
+          "text": "the destinations from 3981052 Amsterdam, Haarlemmerplein contradict the riding order 3981287 .. 3981133"
+        },
+        {
+          "ok": true,
+          "origin": "3979794",
+          "text": "a destination is offered twice from 3979794 Amsterdam, Mercatorplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979794",
+          "text": "a stop this ride reaches from 3979794 Amsterdam, Mercatorplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979794",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979794 Amsterdam, Mercatorplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979794",
+          "text": "the destinations from 3979794 Amsterdam, Mercatorplein contradict the riding order 3979794 .. 3981133"
+        },
+        {
+          "ok": true,
+          "origin": "3980268",
+          "text": "a destination is offered twice from 3980268 Amsterdam, Elandsgracht",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980268",
+          "text": "a stop this ride reaches from 3980268 Amsterdam, Elandsgracht is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980268",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980268 Amsterdam, Elandsgracht is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980268",
+          "text": "the destinations from 3980268 Amsterdam, Elandsgracht contradict the riding order 3979794 .. 3981133"
+        },
+        {
+          "ok": true,
+          "origin": "3981052",
+          "text": "a destination is offered twice from 3981052 Amsterdam, Haarlemmerplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981052",
+          "text": "a stop this ride reaches from 3981052 Amsterdam, Haarlemmerplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981052",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981052 Amsterdam, Haarlemmerplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981052",
+          "text": "the destinations from 3981052 Amsterdam, Haarlemmerplein contradict the riding order 3979794 .. 3981133"
+        },
+        {
+          "ok": true,
+          "origin": "3981287",
+          "text": "a destination is offered twice from 3981287 Amsterdam, Lambertus Zijlplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981287",
+          "text": "a stop this ride reaches from 3981287 Amsterdam, Lambertus Zijlplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981287",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981287 Amsterdam, Lambertus Zijlplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981287",
+          "text": "the destinations from 3981287 Amsterdam, Lambertus Zijlplein contradict the riding order 3981287 .. 4149790"
+        },
+        {
+          "ok": true,
+          "origin": "3980544",
+          "text": "a destination is offered twice from 3980544 Amsterdam, Admiraal de Ruijterweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980544",
+          "text": "a stop this ride reaches from 3980544 Amsterdam, Admiraal de Ruijterweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980544",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980544 Amsterdam, Admiraal de Ruijterweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980544",
+          "text": "the destinations from 3980544 Amsterdam, Admiraal de Ruijterweg contradict the riding order 3981287 .. 4149790"
+        },
+        {
+          "ok": true,
+          "origin": "4149767",
+          "text": "a destination is offered twice from 4149767 Amsterdam, Oranje Nassaulaan",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "4149767",
+          "text": "a stop this ride reaches from 4149767 Amsterdam, Oranje Nassaulaan is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "4149767",
+          "stray": [],
+          "text": "a destination no trip reaches from 4149767 Amsterdam, Oranje Nassaulaan is offered"
+        },
+        {
+          "ok": true,
+          "origin": "4149767",
+          "text": "the destinations from 4149767 Amsterdam, Oranje Nassaulaan contradict the riding order 3981287 .. 4149790"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-13-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152330"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "3981133",
             "direction": 0,
@@ -1631,72 +2355,14 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "3979794": [
-              "1",
-              "10"
-            ],
-            "3980128": [
-              "6",
-              "15"
-            ],
-            "3980268": [
-              "7",
-              "16"
-            ],
-            "3980349": [
-              "11",
-              "20"
-            ],
-            "3980464": [
-              "2",
-              "11"
-            ],
-            "3980544": [
-              "3",
-              "12"
-            ],
-            "3980579": [
-              "4",
-              "13"
-            ],
-            "3980590": [
-              "10",
-              "19"
-            ],
-            "3980701": [
-              "8",
-              "17"
-            ],
-            "3980882": [
-              "9",
-              "18"
-            ],
-            "3981052": [
-              "12",
-              "21"
-            ],
-            "3981133": [
-              "13",
-              "22"
-            ],
-            "3981334": [
-              "5",
-              "14"
-            ]
-          },
-          "text": "the stop list offers a stop twice: 3979794 Amsterdam, Mercatorplein at 1 and 10, 3980464 Amsterdam, Marco Polostraat at 2 and 11, 3980544 Amsterdam, Admiraal de Ruijterweg at 3 and 12, and 10 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
-          "folded": [
-            [
-              "3980268",
-              "3980182"
-            ]
-          ],
-          "ok": false,
-          "text": "the list offers one station twice in a row: 3980268 Amsterdam, Elandsgracht then 3980182 Amsterdam, Elandsgracht"
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
@@ -1730,8 +2396,8 @@
       "fixture": "gvb",
       "id": "gvb-13-d0-stop_list",
       "kind": "stop_list",
-      "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "outcome": "passed",
+      "reason": null,
       "route": "152330"
     },
     {
@@ -1876,6 +2542,224 @@
       "fixture": "gvb",
       "id": "gvb-13-d0-swapped",
       "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152330"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "3981133",
+          "text": "a destination is offered twice from 3981133 Amsterdam, Zoutkeetsgracht",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981133",
+          "text": "a stop this ride reaches from 3981133 Amsterdam, Zoutkeetsgracht is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981133",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981133 Amsterdam, Zoutkeetsgracht is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981133",
+          "text": "the destinations from 3981133 Amsterdam, Zoutkeetsgracht contradict the riding order 3981133 .. 3980106"
+        },
+        {
+          "ok": true,
+          "origin": "3979733",
+          "text": "a destination is offered twice from 3979733 Amsterdam, Marco Polostraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979733",
+          "text": "a stop this ride reaches from 3979733 Amsterdam, Marco Polostraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979733",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979733 Amsterdam, Marco Polostraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979733",
+          "text": "the destinations from 3979733 Amsterdam, Marco Polostraat contradict the riding order 3981133 .. 3980106"
+        },
+        {
+          "ok": true,
+          "origin": "3979744",
+          "text": "a destination is offered twice from 3979744 Amsterdam, Dr. H. Colijnstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979744",
+          "text": "a stop this ride reaches from 3979744 Amsterdam, Dr. H. Colijnstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979744",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979744 Amsterdam, Dr. H. Colijnstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979744",
+          "text": "the destinations from 3979744 Amsterdam, Dr. H. Colijnstraat contradict the riding order 3981133 .. 3980106"
+        },
+        {
+          "ok": true,
+          "origin": "3980794",
+          "text": "a destination is offered twice from 3980794 Amsterdam, Admiraal Helfrichstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980794",
+          "text": "a stop this ride reaches from 3980794 Amsterdam, Admiraal Helfrichstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980794",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980794 Amsterdam, Admiraal Helfrichstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980794",
+          "text": "the destinations from 3980794 Amsterdam, Admiraal Helfrichstraat contradict the riding order 3980794 .. 3980106"
+        },
+        {
+          "ok": true,
+          "origin": "3980252",
+          "text": "a destination is offered twice from 3980252 Amsterdam, Burg. Rendorpstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980252",
+          "text": "a stop this ride reaches from 3980252 Amsterdam, Burg. Rendorpstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980252",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980252 Amsterdam, Burg. Rendorpstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980252",
+          "text": "the destinations from 3980252 Amsterdam, Burg. Rendorpstraat contradict the riding order 3980794 .. 3980106"
+        },
+        {
+          "ok": true,
+          "origin": "3979744",
+          "text": "a destination is offered twice from 3979744 Amsterdam, Dr. H. Colijnstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979744",
+          "text": "a stop this ride reaches from 3979744 Amsterdam, Dr. H. Colijnstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979744",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979744 Amsterdam, Dr. H. Colijnstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979744",
+          "text": "the destinations from 3979744 Amsterdam, Dr. H. Colijnstraat contradict the riding order 3980794 .. 3980106"
+        },
+        {
+          "ok": true,
+          "origin": "3979948",
+          "text": "a destination is offered twice from 3979948 Amsterdam, Zeilstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979948",
+          "text": "a stop this ride reaches from 3979948 Amsterdam, Zeilstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979948",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979948 Amsterdam, Zeilstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979948",
+          "text": "the destinations from 3979948 Amsterdam, Zeilstraat contradict the riding order 3979948 .. 3980106"
+        },
+        {
+          "ok": true,
+          "origin": "3979733",
+          "text": "a destination is offered twice from 3979733 Amsterdam, Marco Polostraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979733",
+          "text": "a stop this ride reaches from 3979733 Amsterdam, Marco Polostraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979733",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979733 Amsterdam, Marco Polostraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979733",
+          "text": "the destinations from 3979733 Amsterdam, Marco Polostraat contradict the riding order 3979948 .. 3980106"
+        },
+        {
+          "ok": true,
+          "origin": "3979744",
+          "text": "a destination is offered twice from 3979744 Amsterdam, Dr. H. Colijnstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979744",
+          "text": "a stop this ride reaches from 3979744 Amsterdam, Dr. H. Colijnstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979744",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979744 Amsterdam, Dr. H. Colijnstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979744",
+          "text": "the destinations from 3979744 Amsterdam, Dr. H. Colijnstraat contradict the riding order 3979948 .. 3980106"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-13-d1-destinations",
+      "kind": "destinations",
       "outcome": "passed",
       "reason": null,
       "route": "152330"
@@ -2074,46 +2958,9 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "3979744": [
-              "8",
-              "21"
-            ],
-            "3979970": [
-              "7",
-              "20"
-            ],
-            "3980106": [
-              "9",
-              "22"
-            ],
-            "3980162": [
-              "3",
-              "16"
-            ],
-            "3980246": [
-              "6",
-              "19"
-            ],
-            "3980252": [
-              "5",
-              "18"
-            ],
-            "3980794": [
-              "1",
-              "14"
-            ],
-            "3980974": [
-              "2",
-              "15"
-            ],
-            "3981165": [
-              "4",
-              "17"
-            ]
-          },
-          "text": "the stop list offers a stop twice: 3980794 Amsterdam, Admiraal Helfrichstraat at 1 and 14, 3980974 Amsterdam, Jan Voermanstraat at 2 and 15, 3980162 Amsterdam, Jan Tooropstraat at 3 and 16, and 6 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
           "folded": [],
@@ -2152,8 +2999,8 @@
       "fixture": "gvb",
       "id": "gvb-13-d1-stop_list",
       "kind": "stop_list",
-      "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "outcome": "passed",
+      "reason": null,
       "route": "152330"
     },
     {
@@ -2301,6 +3148,477 @@
       "outcome": "passed",
       "reason": null,
       "route": "152330"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "3981274",
+          "text": "a destination is offered twice from 3981274 Amsterdam, Centraal Station",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981274",
+          "text": "a stop this ride reaches from 3981274 Amsterdam, Centraal Station is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981274",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981274 Amsterdam, Centraal Station is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981274",
+          "text": "the destinations from 3981274 Amsterdam, Centraal Station contradict the riding order 3981274 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "text": "a destination is offered twice from 3979805 Amsterdam, Mauritskade",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979805",
+          "text": "a stop this ride reaches from 3979805 Amsterdam, Mauritskade is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979805 Amsterdam, Mauritskade is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "text": "the destinations from 3979805 Amsterdam, Mauritskade contradict the riding order 3981274 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "a destination is offered twice from 3980629 Amsterdam, Insulindeweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980629",
+          "text": "a stop this ride reaches from 3980629 Amsterdam, Insulindeweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980629 Amsterdam, Insulindeweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "the destinations from 3980629 Amsterdam, Insulindeweg contradict the riding order 3981274 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "text": "a destination is offered twice from 3979805 Amsterdam, Mauritskade",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979805",
+          "text": "a stop this ride reaches from 3979805 Amsterdam, Mauritskade is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979805 Amsterdam, Mauritskade is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "text": "the destinations from 3979805 Amsterdam, Mauritskade contradict the riding order 3979805 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3979931",
+          "text": "a destination is offered twice from 3979931 Amsterdam, Molukkenstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979931",
+          "text": "a stop this ride reaches from 3979931 Amsterdam, Molukkenstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979931",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979931 Amsterdam, Molukkenstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979931",
+          "text": "the destinations from 3979931 Amsterdam, Molukkenstraat contradict the riding order 3979805 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "a destination is offered twice from 3980629 Amsterdam, Insulindeweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980629",
+          "text": "a stop this ride reaches from 3980629 Amsterdam, Insulindeweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980629 Amsterdam, Insulindeweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "the destinations from 3980629 Amsterdam, Insulindeweg contradict the riding order 3979805 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "text": "a destination is offered twice from 3979805 Amsterdam, Mauritskade",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979805",
+          "text": "a stop this ride reaches from 3979805 Amsterdam, Mauritskade is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979805 Amsterdam, Mauritskade is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "text": "the destinations from 3979805 Amsterdam, Mauritskade contradict the riding order 3979805 .. 3980234"
+        },
+        {
+          "ok": true,
+          "origin": "3980826",
+          "text": "a destination is offered twice from 3980826 Amsterdam, Zeeburgerdijk",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980826",
+          "text": "a stop this ride reaches from 3980826 Amsterdam, Zeeburgerdijk is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980826",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980826 Amsterdam, Zeeburgerdijk is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980826",
+          "text": "the destinations from 3980826 Amsterdam, Zeeburgerdijk contradict the riding order 3979805 .. 3980234"
+        },
+        {
+          "ok": true,
+          "origin": "3981274",
+          "text": "a destination is offered twice from 3981274 Amsterdam, Centraal Station",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981274",
+          "text": "a stop this ride reaches from 3981274 Amsterdam, Centraal Station is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981274",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981274 Amsterdam, Centraal Station is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981274",
+          "text": "the destinations from 3981274 Amsterdam, Centraal Station contradict the riding order 3981274 .. 3980234"
+        },
+        {
+          "ok": true,
+          "origin": "3980195",
+          "text": "a destination is offered twice from 3980195 Amsterdam, Artis/Holocaustmuseum",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980195",
+          "text": "a stop this ride reaches from 3980195 Amsterdam, Artis/Holocaustmuseum is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980195",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980195 Amsterdam, Artis/Holocaustmuseum is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980195",
+          "text": "the destinations from 3980195 Amsterdam, Artis/Holocaustmuseum contradict the riding order 3981274 .. 3980234"
+        },
+        {
+          "ok": true,
+          "origin": "3980826",
+          "text": "a destination is offered twice from 3980826 Amsterdam, Zeeburgerdijk",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980826",
+          "text": "a stop this ride reaches from 3980826 Amsterdam, Zeeburgerdijk is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980826",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980826 Amsterdam, Zeeburgerdijk is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980826",
+          "text": "the destinations from 3980826 Amsterdam, Zeeburgerdijk contradict the riding order 3981274 .. 3980234"
+        },
+        {
+          "ok": true,
+          "origin": "3980163",
+          "text": "a destination is offered twice from 3980163 Amsterdam, Flevopark",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980163",
+          "text": "a stop this ride reaches from 3980163 Amsterdam, Flevopark is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980163",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980163 Amsterdam, Flevopark is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980163",
+          "text": "the destinations from 3980163 Amsterdam, Flevopark contradict the riding order 3980163 .. 4045456"
+        },
+        {
+          "ok": true,
+          "origin": "3979768",
+          "text": "a destination is offered twice from 3979768 Amsterdam, Plantage Lepellaan",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979768",
+          "text": "a stop this ride reaches from 3979768 Amsterdam, Plantage Lepellaan is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979768",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979768 Amsterdam, Plantage Lepellaan is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979768",
+          "text": "the destinations from 3979768 Amsterdam, Plantage Lepellaan contradict the riding order 3980163 .. 4045456"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "a destination is offered twice from 3979826 Amsterdam, Nieuwezijds Kolk",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979826",
+          "text": "a stop this ride reaches from 3979826 Amsterdam, Nieuwezijds Kolk is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979826 Amsterdam, Nieuwezijds Kolk is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "the destinations from 3979826 Amsterdam, Nieuwezijds Kolk contradict the riding order 3980163 .. 4045456"
+        },
+        {
+          "ok": true,
+          "origin": "3980163",
+          "text": "a destination is offered twice from 3980163 Amsterdam, Flevopark",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980163",
+          "text": "a stop this ride reaches from 3980163 Amsterdam, Flevopark is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980163",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980163 Amsterdam, Flevopark is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980163",
+          "text": "the destinations from 3980163 Amsterdam, Flevopark contradict the riding order 3980163 .. 3981274"
+        },
+        {
+          "ok": true,
+          "origin": "3979768",
+          "text": "a destination is offered twice from 3979768 Amsterdam, Plantage Lepellaan",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979768",
+          "text": "a stop this ride reaches from 3979768 Amsterdam, Plantage Lepellaan is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979768",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979768 Amsterdam, Plantage Lepellaan is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979768",
+          "text": "the destinations from 3979768 Amsterdam, Plantage Lepellaan contradict the riding order 3980163 .. 3981274"
+        },
+        {
+          "ok": true,
+          "origin": "3980251",
+          "text": "a destination is offered twice from 3980251 Amsterdam, Dam",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980251",
+          "text": "a stop this ride reaches from 3980251 Amsterdam, Dam is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980251",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980251 Amsterdam, Dam is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980251",
+          "text": "the destinations from 3980251 Amsterdam, Dam contradict the riding order 3980163 .. 3981274"
+        },
+        {
+          "ok": true,
+          "origin": "3980549",
+          "text": "a destination is offered twice from 3980549 Amsterdam, Mauritskade",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980549",
+          "text": "a stop this ride reaches from 3980549 Amsterdam, Mauritskade is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980549",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980549 Amsterdam, Mauritskade is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980549",
+          "text": "the destinations from 3980549 Amsterdam, Mauritskade contradict the riding order 3980549 .. 4045456"
+        },
+        {
+          "ok": true,
+          "origin": "3979798",
+          "text": "a destination is offered twice from 3979798 Amsterdam, Rembrandtplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979798",
+          "text": "a stop this ride reaches from 3979798 Amsterdam, Rembrandtplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979798",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979798 Amsterdam, Rembrandtplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979798",
+          "text": "the destinations from 3979798 Amsterdam, Rembrandtplein contradict the riding order 3980549 .. 4045456"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "a destination is offered twice from 3979826 Amsterdam, Nieuwezijds Kolk",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979826",
+          "text": "a stop this ride reaches from 3979826 Amsterdam, Nieuwezijds Kolk is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979826 Amsterdam, Nieuwezijds Kolk is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "the destinations from 3979826 Amsterdam, Nieuwezijds Kolk contradict the riding order 3980549 .. 4045456"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-14-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152331"
     },
     {
       "checks": [
@@ -2736,100 +4054,23 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "3979727": [
-              "2",
-              "10"
-            ],
-            "3979768": [
-              "2",
-              "9"
-            ],
-            "3979798": [
-              "6",
-              "13"
-            ],
-            "3979805": [
-              "1",
-              "9"
-            ],
-            "3979826": [
-              "9",
-              "16"
-            ],
-            "3979886": [
-              "3",
-              "10"
-            ],
-            "3979931": [
-              "5",
-              "13"
-            ],
-            "3980213": [
-              "7",
-              "14"
-            ],
-            "3980234": [
-              "4",
-              "12"
-            ],
-            "3980239": [
-              "5",
-              "12"
-            ],
-            "3980489": [
-              "8",
-              "15"
-            ],
-            "3980549": [
-              "1",
-              "8"
-            ],
-            "3980629": [
-              "7",
-              "15"
-            ],
-            "3980771": [
-              "4",
-              "11"
-            ],
-            "3980804": [
-              "6",
-              "14"
-            ],
-            "3980826": [
-              "3",
-              "11"
-            ],
-            "3980992": [
-              "8",
-              "16"
-            ],
-            "3981274": [
-              "1",
-              "16"
-            ],
-            "4045456": [
-              "10",
-              "17"
-            ]
-          },
-          "text": "the stop list offers a stop twice: 3981274 Amsterdam, Centraal Station at 1 and 16, 3979805 Amsterdam, Mauritskade at 1 and 9, 3980549 Amsterdam, Mauritskade at 1 and 8, and 16 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
           "folded": [
             [
-              "3980489",
-              "3980251"
+              "3980992",
+              "3980163"
             ],
             [
-              "3981274",
-              "4045456"
+              "3980251",
+              "3980489"
             ]
           ],
           "ok": false,
-          "text": "the list offers one station twice in a row: 3980489 Amsterdam, Dam then 3980251 Amsterdam, Dam, 3981274 Amsterdam, Centraal Station then 4045456 Amsterdam, Centraal Station"
+          "text": "the list offers one station twice in a row: 3980992 Amsterdam, Flevopark then 3980163 Amsterdam, Flevopark, 3980251 Amsterdam, Dam then 3980489 Amsterdam, Dam"
         },
         {
           "ok": true,
@@ -2900,7 +4141,7 @@
       "id": "gvb-14-d0-stop_list",
       "kind": "stop_list",
       "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "reason": "two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups); trams 1, 7 and 17 also carry wrong direction_ids",
       "route": "152331"
     },
     {
@@ -3231,6 +4472,431 @@
       "fixture": "gvb",
       "id": "gvb-14-d0-swapped",
       "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152331"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "3980163",
+          "text": "a destination is offered twice from 3980163 Amsterdam, Flevopark",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980163",
+          "text": "a stop this ride reaches from 3980163 Amsterdam, Flevopark is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980163",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980163 Amsterdam, Flevopark is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980163",
+          "text": "the destinations from 3980163 Amsterdam, Flevopark contradict the riding order 3980163 .. 3981274"
+        },
+        {
+          "ok": true,
+          "origin": "3979768",
+          "text": "a destination is offered twice from 3979768 Amsterdam, Plantage Lepellaan",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979768",
+          "text": "a stop this ride reaches from 3979768 Amsterdam, Plantage Lepellaan is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979768",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979768 Amsterdam, Plantage Lepellaan is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979768",
+          "text": "the destinations from 3979768 Amsterdam, Plantage Lepellaan contradict the riding order 3980163 .. 3981274"
+        },
+        {
+          "ok": true,
+          "origin": "3980251",
+          "text": "a destination is offered twice from 3980251 Amsterdam, Dam",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980251",
+          "text": "a stop this ride reaches from 3980251 Amsterdam, Dam is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980251",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980251 Amsterdam, Dam is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980251",
+          "text": "the destinations from 3980251 Amsterdam, Dam contradict the riding order 3980163 .. 3981274"
+        },
+        {
+          "ok": true,
+          "origin": "3980549",
+          "text": "a destination is offered twice from 3980549 Amsterdam, Mauritskade",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980549",
+          "text": "a stop this ride reaches from 3980549 Amsterdam, Mauritskade is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980549",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980549 Amsterdam, Mauritskade is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980549",
+          "text": "the destinations from 3980549 Amsterdam, Mauritskade contradict the riding order 3980549 .. 3981274"
+        },
+        {
+          "ok": true,
+          "origin": "3980239",
+          "text": "a destination is offered twice from 3980239 Amsterdam, Waterlooplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980239",
+          "text": "a stop this ride reaches from 3980239 Amsterdam, Waterlooplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980239",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980239 Amsterdam, Waterlooplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980239",
+          "text": "the destinations from 3980239 Amsterdam, Waterlooplein contradict the riding order 3980549 .. 3981274"
+        },
+        {
+          "ok": true,
+          "origin": "3980251",
+          "text": "a destination is offered twice from 3980251 Amsterdam, Dam",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980251",
+          "text": "a stop this ride reaches from 3980251 Amsterdam, Dam is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980251",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980251 Amsterdam, Dam is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980251",
+          "text": "the destinations from 3980251 Amsterdam, Dam contradict the riding order 3980549 .. 3981274"
+        },
+        {
+          "ok": true,
+          "origin": "3980234",
+          "text": "a destination is offered twice from 3980234 Amsterdam, Javaplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980234",
+          "text": "a stop this ride reaches from 3980234 Amsterdam, Javaplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980234",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980234 Amsterdam, Javaplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980234",
+          "text": "the destinations from 3980234 Amsterdam, Javaplein contradict the riding order 3980234 .. 3981274"
+        },
+        {
+          "ok": true,
+          "origin": "3979768",
+          "text": "a destination is offered twice from 3979768 Amsterdam, Plantage Lepellaan",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979768",
+          "text": "a stop this ride reaches from 3979768 Amsterdam, Plantage Lepellaan is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979768",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979768 Amsterdam, Plantage Lepellaan is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979768",
+          "text": "the destinations from 3979768 Amsterdam, Plantage Lepellaan contradict the riding order 3980234 .. 3981274"
+        },
+        {
+          "ok": true,
+          "origin": "3980251",
+          "text": "a destination is offered twice from 3980251 Amsterdam, Dam",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980251",
+          "text": "a stop this ride reaches from 3980251 Amsterdam, Dam is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980251",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980251 Amsterdam, Dam is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980251",
+          "text": "the destinations from 3980251 Amsterdam, Dam contradict the riding order 3980234 .. 3981274"
+        },
+        {
+          "ok": true,
+          "origin": "4045456",
+          "text": "a destination is offered twice from 4045456 Amsterdam, Centraal Station",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "4045456",
+          "text": "a stop this ride reaches from 4045456 Amsterdam, Centraal Station is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "4045456",
+          "stray": [],
+          "text": "a destination no trip reaches from 4045456 Amsterdam, Centraal Station is offered"
+        },
+        {
+          "ok": true,
+          "origin": "4045456",
+          "text": "the destinations from 4045456 Amsterdam, Centraal Station contradict the riding order 4045456 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "text": "a destination is offered twice from 3979805 Amsterdam, Mauritskade",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979805",
+          "text": "a stop this ride reaches from 3979805 Amsterdam, Mauritskade is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979805 Amsterdam, Mauritskade is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "text": "the destinations from 3979805 Amsterdam, Mauritskade contradict the riding order 4045456 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "a destination is offered twice from 3980629 Amsterdam, Insulindeweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980629",
+          "text": "a stop this ride reaches from 3980629 Amsterdam, Insulindeweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980629 Amsterdam, Insulindeweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "the destinations from 3980629 Amsterdam, Insulindeweg contradict the riding order 4045456 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3981274",
+          "text": "a destination is offered twice from 3981274 Amsterdam, Centraal Station",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981274",
+          "text": "a stop this ride reaches from 3981274 Amsterdam, Centraal Station is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981274",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981274 Amsterdam, Centraal Station is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981274",
+          "text": "the destinations from 3981274 Amsterdam, Centraal Station contradict the riding order 3981274 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "text": "a destination is offered twice from 3979805 Amsterdam, Mauritskade",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979805",
+          "text": "a stop this ride reaches from 3979805 Amsterdam, Mauritskade is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979805 Amsterdam, Mauritskade is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "text": "the destinations from 3979805 Amsterdam, Mauritskade contradict the riding order 3981274 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "a destination is offered twice from 3980629 Amsterdam, Insulindeweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980629",
+          "text": "a stop this ride reaches from 3980629 Amsterdam, Insulindeweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980629 Amsterdam, Insulindeweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "the destinations from 3980629 Amsterdam, Insulindeweg contradict the riding order 3981274 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "text": "a destination is offered twice from 3979805 Amsterdam, Mauritskade",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979805",
+          "text": "a stop this ride reaches from 3979805 Amsterdam, Mauritskade is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979805 Amsterdam, Mauritskade is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979805",
+          "text": "the destinations from 3979805 Amsterdam, Mauritskade contradict the riding order 3979805 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3979931",
+          "text": "a destination is offered twice from 3979931 Amsterdam, Molukkenstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979931",
+          "text": "a stop this ride reaches from 3979931 Amsterdam, Molukkenstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979931",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979931 Amsterdam, Molukkenstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979931",
+          "text": "the destinations from 3979931 Amsterdam, Molukkenstraat contradict the riding order 3979805 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "a destination is offered twice from 3980629 Amsterdam, Insulindeweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980629",
+          "text": "a stop this ride reaches from 3980629 Amsterdam, Insulindeweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980629 Amsterdam, Insulindeweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "the destinations from 3980629 Amsterdam, Insulindeweg contradict the riding order 3979805 .. 3980992"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-14-d1-destinations",
+      "kind": "destinations",
       "outcome": "passed",
       "reason": null,
       "route": "152331"
@@ -3609,107 +5275,19 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "3979727": [
-              "2",
-              "10"
-            ],
-            "3979768": [
-              "2",
-              "8",
-              "9"
-            ],
-            "3979798": [
-              "6",
-              "12",
-              "13"
-            ],
-            "3979805": [
-              "1",
-              "9"
-            ],
-            "3979886": [
-              "3",
-              "9",
-              "10"
-            ],
-            "3979931": [
-              "5",
-              "13"
-            ],
-            "3980213": [
-              "7",
-              "13",
-              "14"
-            ],
-            "3980234": [
-              "1",
-              "4",
-              "12"
-            ],
-            "3980239": [
-              "5",
-              "11",
-              "12"
-            ],
-            "3980251": [
-              "8",
-              "14",
-              "15"
-            ],
-            "3980549": [
-              "1",
-              "7",
-              "8"
-            ],
-            "3980629": [
-              "7",
-              "15"
-            ],
-            "3980771": [
-              "4",
-              "10",
-              "11"
-            ],
-            "3980804": [
-              "6",
-              "14"
-            ],
-            "3980826": [
-              "3",
-              "11"
-            ],
-            "3980992": [
-              "8",
-              "16"
-            ],
-            "3981274": [
-              "1",
-              "9",
-              "15",
-              "16"
-            ]
-          },
-          "text": "the stop list offers a stop twice: 3980549 Amsterdam, Mauritskade at 1 and 7 and 8, 3980234 Amsterdam, Javaplein at 1 and 4 and 12, 3981274 Amsterdam, Centraal Station at 1 and 9 and 15 and 16, and 14 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
           "folded": [
             [
-              "4045456",
-              "3981274"
-            ],
-            [
-              "3980234",
-              "3981356"
-            ],
-            [
-              "3979768",
-              "3981148"
+              "3980992",
+              "3980163"
             ]
           ],
           "ok": false,
-          "text": "the list offers one station twice in a row: 4045456 Amsterdam, Centraal Station then 3981274 Amsterdam, Centraal Station, 3980234 Amsterdam, Javaplein then 3981356 Amsterdam, Javaplein, 3979768 Amsterdam, Plantage Lepellaan then 3981148 Amsterdam, Plantage Lepellaan"
+          "text": "the list offers one station twice in a row: 3980992 Amsterdam, Flevopark then 3980163 Amsterdam, Flevopark"
         },
         {
           "ok": true,
@@ -3735,7 +5313,7 @@
           "unoffered": []
         },
         {
-          "ok": false,
+          "ok": true,
           "text": "the list contradicts the riding order 3980234 .. 3981274"
         },
         {
@@ -3753,7 +5331,7 @@
           "unoffered": []
         },
         {
-          "ok": false,
+          "ok": true,
           "text": "the list contradicts the riding order 3981274 .. 3980992"
         },
         {
@@ -3771,7 +5349,7 @@
       "id": "gvb-14-d1-stop_list",
       "kind": "stop_list",
       "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "reason": "two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups); trams 1, 7 and 17 also carry wrong direction_ids",
       "route": "152331"
     },
     {
@@ -4064,6 +5642,293 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "3979881",
+          "text": "a destination is offered twice from 3979881 Amsterdam, Dijkgraafplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979881",
+          "text": "a stop this ride reaches from 3979881 Amsterdam, Dijkgraafplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979881",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979881 Amsterdam, Dijkgraafplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979881",
+          "text": "the destinations from 3979881 Amsterdam, Dijkgraafplein contradict the riding order 3979881 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3980752",
+          "text": "a destination is offered twice from 3980752 Amsterdam, Witte de Withstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980752",
+          "text": "a stop this ride reaches from 3980752 Amsterdam, Witte de Withstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980752",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980752 Amsterdam, Witte de Withstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980752",
+          "text": "the destinations from 3980752 Amsterdam, Witte de Withstraat contradict the riding order 3979881 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "a destination is offered twice from 3979826 Amsterdam, Nieuwezijds Kolk",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979826",
+          "text": "a stop this ride reaches from 3979826 Amsterdam, Nieuwezijds Kolk is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979826 Amsterdam, Nieuwezijds Kolk is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "the destinations from 3979826 Amsterdam, Nieuwezijds Kolk contradict the riding order 3979881 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3980305",
+          "text": "a destination is offered twice from 3980305 Amsterdam, Corantijnstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980305",
+          "text": "a stop this ride reaches from 3980305 Amsterdam, Corantijnstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980305",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980305 Amsterdam, Corantijnstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980305",
+          "text": "the destinations from 3980305 Amsterdam, Corantijnstraat contradict the riding order 3980305 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3979912",
+          "text": "a destination is offered twice from 3979912 Amsterdam, Prinsengracht",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979912",
+          "text": "a stop this ride reaches from 3979912 Amsterdam, Prinsengracht is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979912",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979912 Amsterdam, Prinsengracht is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979912",
+          "text": "the destinations from 3979912 Amsterdam, Prinsengracht contradict the riding order 3980305 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "a destination is offered twice from 3979826 Amsterdam, Nieuwezijds Kolk",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979826",
+          "text": "a stop this ride reaches from 3979826 Amsterdam, Nieuwezijds Kolk is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979826 Amsterdam, Nieuwezijds Kolk is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "the destinations from 3979826 Amsterdam, Nieuwezijds Kolk contradict the riding order 3980305 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3981271",
+          "text": "a destination is offered twice from 3981271 Amsterdam, Centraal Station",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981271",
+          "text": "a stop this ride reaches from 3981271 Amsterdam, Centraal Station is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981271",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981271 Amsterdam, Centraal Station is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981271",
+          "text": "the destinations from 3981271 Amsterdam, Centraal Station contradict the riding order 3981271 .. 4132580"
+        },
+        {
+          "ok": true,
+          "origin": "3980180",
+          "text": "a destination is offered twice from 3980180 Amsterdam, Leidseplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980180",
+          "text": "a stop this ride reaches from 3980180 Amsterdam, Leidseplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980180",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980180 Amsterdam, Leidseplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980180",
+          "text": "the destinations from 3980180 Amsterdam, Leidseplein contradict the riding order 3981271 .. 4132580"
+        },
+        {
+          "ok": true,
+          "origin": "3980601",
+          "text": "a destination is offered twice from 3980601 Amsterdam, Corantijnstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980601",
+          "text": "a stop this ride reaches from 3980601 Amsterdam, Corantijnstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980601",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980601 Amsterdam, Corantijnstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980601",
+          "text": "the destinations from 3980601 Amsterdam, Corantijnstraat contradict the riding order 3981271 .. 4132580"
+        },
+        {
+          "ok": true,
+          "origin": "3980599",
+          "text": "a destination is offered twice from 3980599 Amsterdam, Leidseplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980599",
+          "text": "a stop this ride reaches from 3980599 Amsterdam, Leidseplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980599",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980599 Amsterdam, Leidseplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980599",
+          "text": "the destinations from 3980599 Amsterdam, Leidseplein contradict the riding order 3980599 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3980023",
+          "text": "a destination is offered twice from 3980023 Amsterdam, Paleisstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980023",
+          "text": "a stop this ride reaches from 3980023 Amsterdam, Paleisstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980023",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980023 Amsterdam, Paleisstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980023",
+          "text": "the destinations from 3980023 Amsterdam, Paleisstraat contradict the riding order 3980599 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "a destination is offered twice from 3979826 Amsterdam, Nieuwezijds Kolk",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979826",
+          "text": "a stop this ride reaches from 3979826 Amsterdam, Nieuwezijds Kolk is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979826 Amsterdam, Nieuwezijds Kolk is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "the destinations from 3979826 Amsterdam, Nieuwezijds Kolk contradict the riding order 3980599 .. 3981271"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-17-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152324"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "3981271",
             "direction": 0,
@@ -4315,85 +6180,14 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "3979746": [
-              "5",
-              "15"
-            ],
-            "3979826": [
-              "7",
-              "13",
-              "23"
-            ],
-            "3979912": [
-              "2",
-              "8",
-              "18"
-            ],
-            "3980023": [
-              "5",
-              "11",
-              "21"
-            ],
-            "3980305": [
-              "1",
-              "11"
-            ],
-            "3980394": [
-              "6",
-              "16"
-            ],
-            "3980489": [
-              "6",
-              "12",
-              "22"
-            ],
-            "3980573": [
-              "4",
-              "10",
-              "20"
-            ],
-            "3980593": [
-              "2",
-              "12"
-            ],
-            "3980596": [
-              "4",
-              "14"
-            ],
-            "3980599": [
-              "1",
-              "7",
-              "17"
-            ],
-            "3980642": [
-              "3",
-              "9",
-              "19"
-            ],
-            "3980752": [
-              "3",
-              "13"
-            ],
-            "3981271": [
-              "1",
-              "8",
-              "14",
-              "24"
-            ]
-          },
-          "text": "the stop list offers a stop twice: 3980305 Amsterdam, Corantijnstraat at 1 and 11, 3981271 Amsterdam, Centraal Station at 1 and 8 and 14 and 24, 3980599 Amsterdam, Leidseplein at 1 and 7 and 17, and 11 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
-          "folded": [
-            [
-              "3981140",
-              "3980752"
-            ]
-          ],
-          "ok": false,
-          "text": "the list offers one station twice in a row: 3981140 Amsterdam, Witte de Withstraat then 3980752 Amsterdam, Witte de Withstraat"
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
@@ -4419,7 +6213,7 @@
           "unoffered": []
         },
         {
-          "ok": false,
+          "ok": true,
           "text": "the list contradicts the riding order 3981271 .. 4132580"
         },
         {
@@ -4436,8 +6230,8 @@
       "fixture": "gvb",
       "id": "gvb-17-d0-stop_list",
       "kind": "stop_list",
-      "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "outcome": "passed",
+      "reason": null,
       "route": "152324"
     },
     {
@@ -4627,6 +6421,293 @@
       "fixture": "gvb",
       "id": "gvb-17-d0-swapped",
       "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152324"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "3981271",
+          "text": "a destination is offered twice from 3981271 Amsterdam, Centraal Station",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981271",
+          "text": "a stop this ride reaches from 3981271 Amsterdam, Centraal Station is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981271",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981271 Amsterdam, Centraal Station is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981271",
+          "text": "the destinations from 3981271 Amsterdam, Centraal Station contradict the riding order 3981271 .. 3980351"
+        },
+        {
+          "ok": true,
+          "origin": "3980714",
+          "text": "a destination is offered twice from 3980714 Amsterdam, Postjesweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980714",
+          "text": "a stop this ride reaches from 3980714 Amsterdam, Postjesweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980714",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980714 Amsterdam, Postjesweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980714",
+          "text": "the destinations from 3980714 Amsterdam, Postjesweg contradict the riding order 3981271 .. 3980351"
+        },
+        {
+          "ok": true,
+          "origin": "3980728",
+          "text": "a destination is offered twice from 3980728 Amsterdam, Baden Powellweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980728",
+          "text": "a stop this ride reaches from 3980728 Amsterdam, Baden Powellweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980728",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980728 Amsterdam, Baden Powellweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980728",
+          "text": "the destinations from 3980728 Amsterdam, Baden Powellweg contradict the riding order 3981271 .. 3980351"
+        },
+        {
+          "ok": true,
+          "origin": "3979725",
+          "text": "a destination is offered twice from 3979725 Amsterdam, Surinameplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979725",
+          "text": "a stop this ride reaches from 3979725 Amsterdam, Surinameplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979725",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979725 Amsterdam, Surinameplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979725",
+          "text": "the destinations from 3979725 Amsterdam, Surinameplein contradict the riding order 3979725 .. 3980351"
+        },
+        {
+          "ok": true,
+          "origin": "3980933",
+          "text": "a destination is offered twice from 3980933 Amsterdam, Osdorpplein Oost",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980933",
+          "text": "a stop this ride reaches from 3980933 Amsterdam, Osdorpplein Oost is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980933",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980933 Amsterdam, Osdorpplein Oost is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980933",
+          "text": "the destinations from 3980933 Amsterdam, Osdorpplein Oost contradict the riding order 3979725 .. 3980351"
+        },
+        {
+          "ok": true,
+          "origin": "3980728",
+          "text": "a destination is offered twice from 3980728 Amsterdam, Baden Powellweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980728",
+          "text": "a stop this ride reaches from 3980728 Amsterdam, Baden Powellweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980728",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980728 Amsterdam, Baden Powellweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980728",
+          "text": "the destinations from 3980728 Amsterdam, Baden Powellweg contradict the riding order 3979725 .. 3980351"
+        },
+        {
+          "ok": true,
+          "origin": "4015830",
+          "text": "a destination is offered twice from 4015830 Amsterdam, Surinameplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "4015830",
+          "text": "a stop this ride reaches from 4015830 Amsterdam, Surinameplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "4015830",
+          "stray": [],
+          "text": "a destination no trip reaches from 4015830 Amsterdam, Surinameplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "4015830",
+          "text": "the destinations from 4015830 Amsterdam, Surinameplein contradict the riding order 4015830 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3980599",
+          "text": "a destination is offered twice from 3980599 Amsterdam, Leidseplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980599",
+          "text": "a stop this ride reaches from 3980599 Amsterdam, Leidseplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980599",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980599 Amsterdam, Leidseplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980599",
+          "text": "the destinations from 3980599 Amsterdam, Leidseplein contradict the riding order 4015830 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "a destination is offered twice from 3979826 Amsterdam, Nieuwezijds Kolk",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979826",
+          "text": "a stop this ride reaches from 3979826 Amsterdam, Nieuwezijds Kolk is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979826 Amsterdam, Nieuwezijds Kolk is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "the destinations from 3979826 Amsterdam, Nieuwezijds Kolk contradict the riding order 4015830 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3980599",
+          "text": "a destination is offered twice from 3980599 Amsterdam, Leidseplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980599",
+          "text": "a stop this ride reaches from 3980599 Amsterdam, Leidseplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980599",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980599 Amsterdam, Leidseplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980599",
+          "text": "the destinations from 3980599 Amsterdam, Leidseplein contradict the riding order 3980599 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3980023",
+          "text": "a destination is offered twice from 3980023 Amsterdam, Paleisstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980023",
+          "text": "a stop this ride reaches from 3980023 Amsterdam, Paleisstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980023",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980023 Amsterdam, Paleisstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980023",
+          "text": "the destinations from 3980023 Amsterdam, Paleisstraat contradict the riding order 3980599 .. 3981271"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "a destination is offered twice from 3979826 Amsterdam, Nieuwezijds Kolk",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979826",
+          "text": "a stop this ride reaches from 3979826 Amsterdam, Nieuwezijds Kolk is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979826 Amsterdam, Nieuwezijds Kolk is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979826",
+          "text": "the destinations from 3979826 Amsterdam, Nieuwezijds Kolk contradict the riding order 3980599 .. 3981271"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-17-d1-destinations",
+      "kind": "destinations",
       "outcome": "passed",
       "reason": null,
       "route": "152324"
@@ -4885,93 +6966,14 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "3979725": [
-              "1",
-              "15"
-            ],
-            "3979826": [
-              "7",
-              "14"
-            ],
-            "3979912": [
-              "2",
-              "9"
-            ],
-            "3979971": [
-              "8",
-              "22"
-            ],
-            "3980023": [
-              "5",
-              "12"
-            ],
-            "3980050": [
-              "4",
-              "18"
-            ],
-            "3980220": [
-              "2",
-              "16"
-            ],
-            "3980231": [
-              "5",
-              "19"
-            ],
-            "3980240": [
-              "7",
-              "21"
-            ],
-            "3980351": [
-              "10",
-              "24"
-            ],
-            "3980489": [
-              "6",
-              "13"
-            ],
-            "3980573": [
-              "4",
-              "11"
-            ],
-            "3980599": [
-              "1",
-              "8"
-            ],
-            "3980642": [
-              "3",
-              "10"
-            ],
-            "3980728": [
-              "9",
-              "23"
-            ],
-            "3980933": [
-              "6",
-              "20"
-            ],
-            "3981271": [
-              "1",
-              "8",
-              "15"
-            ],
-            "3981436": [
-              "3",
-              "17"
-            ]
-          },
-          "text": "the stop list offers a stop twice: 3981271 Amsterdam, Centraal Station at 1 and 8 and 15, 3979725 Amsterdam, Surinameplein at 1 and 15, 3980599 Amsterdam, Leidseplein at 1 and 8, and 15 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
-          "folded": [
-            [
-              "3980573",
-              "3980418"
-            ]
-          ],
-          "ok": false,
-          "text": "the list offers one station twice in a row: 3980573 Amsterdam, Koningsplein then 3980418 Amsterdam, Koningsplein"
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
@@ -4979,7 +6981,7 @@
           "unoffered": []
         },
         {
-          "ok": false,
+          "ok": true,
           "text": "the list contradicts the riding order 3981271 .. 3980351"
         },
         {
@@ -5014,8 +7016,8 @@
       "fixture": "gvb",
       "id": "gvb-17-d1-stop_list",
       "kind": "stop_list",
-      "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "outcome": "passed",
+      "reason": null,
       "route": "152324"
     },
     {
@@ -5208,6 +7210,293 @@
       "outcome": "passed",
       "reason": null,
       "route": "152324"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "3980163",
+          "text": "a destination is offered twice from 3980163 Amsterdam, Flevopark",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980163",
+          "text": "a stop this ride reaches from 3980163 Amsterdam, Flevopark is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980163",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980163 Amsterdam, Flevopark is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980163",
+          "text": "the destinations from 3980163 Amsterdam, Flevopark contradict the riding order 3980163 .. 3980102"
+        },
+        {
+          "ok": true,
+          "origin": "3980831",
+          "text": "a destination is offered twice from 3980831 Amsterdam, Bilderdijkstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980831",
+          "text": "a stop this ride reaches from 3980831 Amsterdam, Bilderdijkstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980831",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980831 Amsterdam, Bilderdijkstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980831",
+          "text": "the destinations from 3980831 Amsterdam, Bilderdijkstraat contradict the riding order 3980163 .. 3980102"
+        },
+        {
+          "ok": true,
+          "origin": "3980825",
+          "text": "a destination is offered twice from 3980825 Amsterdam, Burgemeester Röellstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980825",
+          "text": "a stop this ride reaches from 3980825 Amsterdam, Burgemeester Röellstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980825",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980825 Amsterdam, Burgemeester Röellstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980825",
+          "text": "the destinations from 3980825 Amsterdam, Burgemeester Röellstraat contradict the riding order 3980163 .. 3980102"
+        },
+        {
+          "ok": true,
+          "origin": "3980004",
+          "text": "a destination is offered twice from 3980004 Amsterdam, Frederiksplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980004",
+          "text": "a stop this ride reaches from 3980004 Amsterdam, Frederiksplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980004",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980004 Amsterdam, Frederiksplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980004",
+          "text": "the destinations from 3980004 Amsterdam, Frederiksplein contradict the riding order 3980004 .. 3980102"
+        },
+        {
+          "ok": true,
+          "origin": "3979816",
+          "text": "a destination is offered twice from 3979816 Amsterdam, Mercatorplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979816",
+          "text": "a stop this ride reaches from 3979816 Amsterdam, Mercatorplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979816",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979816 Amsterdam, Mercatorplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979816",
+          "text": "the destinations from 3979816 Amsterdam, Mercatorplein contradict the riding order 3980004 .. 3980102"
+        },
+        {
+          "ok": true,
+          "origin": "3980825",
+          "text": "a destination is offered twice from 3980825 Amsterdam, Burgemeester Röellstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980825",
+          "text": "a stop this ride reaches from 3980825 Amsterdam, Burgemeester Röellstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980825",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980825 Amsterdam, Burgemeester Röellstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980825",
+          "text": "the destinations from 3980825 Amsterdam, Burgemeester Röellstraat contradict the riding order 3980004 .. 3980102"
+        },
+        {
+          "ok": true,
+          "origin": "3980102",
+          "text": "a destination is offered twice from 3980102 Amsterdam, Sloterpark",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980102",
+          "text": "a stop this ride reaches from 3980102 Amsterdam, Sloterpark is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980102",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980102 Amsterdam, Sloterpark is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980102",
+          "text": "the destinations from 3980102 Amsterdam, Sloterpark contradict the riding order 3980102 .. 3979878"
+        },
+        {
+          "ok": true,
+          "origin": "3980752",
+          "text": "a destination is offered twice from 3980752 Amsterdam, Witte de Withstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980752",
+          "text": "a stop this ride reaches from 3980752 Amsterdam, Witte de Withstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980752",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980752 Amsterdam, Witte de Withstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980752",
+          "text": "the destinations from 3980752 Amsterdam, Witte de Withstraat contradict the riding order 3980102 .. 3979878"
+        },
+        {
+          "ok": true,
+          "origin": "3980057",
+          "text": "a destination is offered twice from 3980057 Amsterdam, Artis/Holocaustmuseum",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980057",
+          "text": "a stop this ride reaches from 3980057 Amsterdam, Artis/Holocaustmuseum is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980057",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980057 Amsterdam, Artis/Holocaustmuseum is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980057",
+          "text": "the destinations from 3980057 Amsterdam, Artis/Holocaustmuseum contradict the riding order 3980102 .. 3979878"
+        },
+        {
+          "ok": true,
+          "origin": "3981181",
+          "text": "a destination is offered twice from 3981181 Amsterdam, Frederiksplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981181",
+          "text": "a stop this ride reaches from 3981181 Amsterdam, Frederiksplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981181",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981181 Amsterdam, Frederiksplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981181",
+          "text": "the destinations from 3981181 Amsterdam, Frederiksplein contradict the riding order 3981181 .. 3979878"
+        },
+        {
+          "ok": true,
+          "origin": "3980735",
+          "text": "a destination is offered twice from 3980735 Amsterdam, Roetersstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980735",
+          "text": "a stop this ride reaches from 3980735 Amsterdam, Roetersstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980735",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980735 Amsterdam, Roetersstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980735",
+          "text": "the destinations from 3980735 Amsterdam, Roetersstraat contradict the riding order 3981181 .. 3979878"
+        },
+        {
+          "ok": true,
+          "origin": "3980057",
+          "text": "a destination is offered twice from 3980057 Amsterdam, Artis/Holocaustmuseum",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980057",
+          "text": "a stop this ride reaches from 3980057 Amsterdam, Artis/Holocaustmuseum is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980057",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980057 Amsterdam, Artis/Holocaustmuseum is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980057",
+          "text": "the destinations from 3980057 Amsterdam, Artis/Holocaustmuseum contradict the riding order 3981181 .. 3979878"
+        }
+      ],
+      "direction": 0,
+      "fixture": "gvb",
+      "id": "gvb-7-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "152328"
     },
     {
       "checks": [
@@ -5463,121 +7752,14 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "3979766": [
-              "2",
-              "20"
-            ],
-            "3979816": [
-              "11",
-              "21"
-            ],
-            "3979878": [
-              "5",
-              "23"
-            ],
-            "3979897": [
-              "2",
-              "12"
-            ],
-            "3979909": [
-              "17",
-              "27"
-            ],
-            "3979969": [
-              "18",
-              "28"
-            ],
-            "3980004": [
-              "1",
-              "11"
-            ],
-            "3980013": [
-              "5",
-              "15"
-            ],
-            "3980057": [
-              "4",
-              "22"
-            ],
-            "3980060": [
-              "10",
-              "20"
-            ],
-            "3980102": [
-              "1",
-              "20",
-              "30"
-            ],
-            "3980149": [
-              "12",
-              "22"
-            ],
-            "3980176": [
-              "13",
-              "23"
-            ],
-            "3980235": [
-              "7",
-              "17"
-            ],
-            "3980270": [
-              "9",
-              "19"
-            ],
-            "3980379": [
-              "4",
-              "14"
-            ],
-            "3980413": [
-              "14",
-              "24"
-            ],
-            "3980469": [
-              "3",
-              "13"
-            ],
-            "3980564": [
-              "16",
-              "26"
-            ],
-            "3980572": [
-              "15",
-              "25"
-            ],
-            "3980735": [
-              "3",
-              "21"
-            ],
-            "3980825": [
-              "19",
-              "29"
-            ],
-            "3980831": [
-              "6",
-              "16"
-            ],
-            "3981140": [
-              "8",
-              "18"
-            ],
-            "3981181": [
-              "1",
-              "19"
-            ]
-          },
-          "text": "the stop list offers a stop twice: 3980004 Amsterdam, Frederiksplein at 1 and 11, 3980102 Amsterdam, Sloterpark at 1 and 20 and 30, 3981181 Amsterdam, Frederiksplein at 1 and 19, and 22 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
-          "folded": [
-            [
-              "3980060",
-              "3980854"
-            ]
-          ],
-          "ok": false,
-          "text": "the list offers one station twice in a row: 3980060 Amsterdam, Willem Schoutenstraat then 3980854 Amsterdam, Willem Schoutenstraat"
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
@@ -5603,7 +7785,7 @@
           "unoffered": []
         },
         {
-          "ok": false,
+          "ok": true,
           "text": "the list contradicts the riding order 3980102 .. 3979878"
         },
         {
@@ -5620,8 +7802,8 @@
       "fixture": "gvb",
       "id": "gvb-7-d0-stop_list",
       "kind": "stop_list",
-      "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "outcome": "passed",
+      "reason": null,
       "route": "152328"
     },
     {
@@ -5819,6 +8001,293 @@
       "kind": "swapped",
       "outcome": "xfailed",
       "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "152328"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "3980102",
+          "text": "a destination is offered twice from 3980102 Amsterdam, Sloterpark",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980102",
+          "text": "a stop this ride reaches from 3980102 Amsterdam, Sloterpark is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980102",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980102 Amsterdam, Sloterpark is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980102",
+          "text": "the destinations from 3980102 Amsterdam, Sloterpark contradict the riding order 3980102 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3980182",
+          "text": "a destination is offered twice from 3980182 Amsterdam, Elandsgracht",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980182",
+          "text": "a stop this ride reaches from 3980182 Amsterdam, Elandsgracht is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980182",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980182 Amsterdam, Elandsgracht is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980182",
+          "text": "the destinations from 3980182 Amsterdam, Elandsgracht contradict the riding order 3980102 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "a destination is offered twice from 3980629 Amsterdam, Insulindeweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980629",
+          "text": "a stop this ride reaches from 3980629 Amsterdam, Insulindeweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980629 Amsterdam, Insulindeweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "the destinations from 3980629 Amsterdam, Insulindeweg contradict the riding order 3980102 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3981181",
+          "text": "a destination is offered twice from 3981181 Amsterdam, Frederiksplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3981181",
+          "text": "a stop this ride reaches from 3981181 Amsterdam, Frederiksplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981181",
+          "stray": [],
+          "text": "a destination no trip reaches from 3981181 Amsterdam, Frederiksplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3981181",
+          "text": "the destinations from 3981181 Amsterdam, Frederiksplein contradict the riding order 3981181 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "4015723",
+          "text": "a destination is offered twice from 4015723 Amsterdam, Dapperstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "4015723",
+          "text": "a stop this ride reaches from 4015723 Amsterdam, Dapperstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "4015723",
+          "stray": [],
+          "text": "a destination no trip reaches from 4015723 Amsterdam, Dapperstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "4015723",
+          "text": "the destinations from 4015723 Amsterdam, Dapperstraat contradict the riding order 3981181 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "a destination is offered twice from 3980629 Amsterdam, Insulindeweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980629",
+          "text": "a stop this ride reaches from 3980629 Amsterdam, Insulindeweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980629 Amsterdam, Insulindeweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980629",
+          "text": "the destinations from 3980629 Amsterdam, Insulindeweg contradict the riding order 3981181 .. 3980992"
+        },
+        {
+          "ok": true,
+          "origin": "3979878",
+          "text": "a destination is offered twice from 3979878 Amsterdam, Plantage Parklaan",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979878",
+          "text": "a stop this ride reaches from 3979878 Amsterdam, Plantage Parklaan is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979878",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979878 Amsterdam, Plantage Parklaan is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979878",
+          "text": "the destinations from 3979878 Amsterdam, Plantage Parklaan contradict the riding order 3979878 .. 3980102"
+        },
+        {
+          "ok": true,
+          "origin": "3980270",
+          "text": "a destination is offered twice from 3980270 Amsterdam, Postjesweg",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980270",
+          "text": "a stop this ride reaches from 3980270 Amsterdam, Postjesweg is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980270",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980270 Amsterdam, Postjesweg is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980270",
+          "text": "the destinations from 3980270 Amsterdam, Postjesweg contradict the riding order 3979878 .. 3980102"
+        },
+        {
+          "ok": true,
+          "origin": "3980825",
+          "text": "a destination is offered twice from 3980825 Amsterdam, Burgemeester Röellstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980825",
+          "text": "a stop this ride reaches from 3980825 Amsterdam, Burgemeester Röellstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980825",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980825 Amsterdam, Burgemeester Röellstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980825",
+          "text": "the destinations from 3980825 Amsterdam, Burgemeester Röellstraat contradict the riding order 3979878 .. 3980102"
+        },
+        {
+          "ok": true,
+          "origin": "3980004",
+          "text": "a destination is offered twice from 3980004 Amsterdam, Frederiksplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980004",
+          "text": "a stop this ride reaches from 3980004 Amsterdam, Frederiksplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980004",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980004 Amsterdam, Frederiksplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980004",
+          "text": "the destinations from 3980004 Amsterdam, Frederiksplein contradict the riding order 3980004 .. 3980102"
+        },
+        {
+          "ok": true,
+          "origin": "3979816",
+          "text": "a destination is offered twice from 3979816 Amsterdam, Mercatorplein",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3979816",
+          "text": "a stop this ride reaches from 3979816 Amsterdam, Mercatorplein is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979816",
+          "stray": [],
+          "text": "a destination no trip reaches from 3979816 Amsterdam, Mercatorplein is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3979816",
+          "text": "the destinations from 3979816 Amsterdam, Mercatorplein contradict the riding order 3980004 .. 3980102"
+        },
+        {
+          "ok": true,
+          "origin": "3980825",
+          "text": "a destination is offered twice from 3980825 Amsterdam, Burgemeester Röellstraat",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "3980825",
+          "text": "a stop this ride reaches from 3980825 Amsterdam, Burgemeester Röellstraat is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980825",
+          "stray": [],
+          "text": "a destination no trip reaches from 3980825 Amsterdam, Burgemeester Röellstraat is offered"
+        },
+        {
+          "ok": true,
+          "origin": "3980825",
+          "text": "the destinations from 3980825 Amsterdam, Burgemeester Röellstraat contradict the riding order 3980004 .. 3980102"
+        }
+      ],
+      "direction": 1,
+      "fixture": "gvb",
+      "id": "gvb-7-d1-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
       "route": "152328"
     },
     {
@@ -6075,145 +8544,14 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "3979766": [
-              "2",
-              "20"
-            ],
-            "3979816": [
-              "11",
-              "15"
-            ],
-            "3979897": [
-              "2",
-              "6"
-            ],
-            "3979909": [
-              "17",
-              "21"
-            ],
-            "3979969": [
-              "18",
-              "22"
-            ],
-            "3980004": [
-              "1",
-              "5"
-            ],
-            "3980013": [
-              "5",
-              "9"
-            ],
-            "3980060": [
-              "10",
-              "14"
-            ],
-            "3980102": [
-              "1",
-              "20",
-              "24"
-            ],
-            "3980149": [
-              "12",
-              "16"
-            ],
-            "3980176": [
-              "13",
-              "17"
-            ],
-            "3980235": [
-              "7",
-              "11"
-            ],
-            "3980270": [
-              "9",
-              "13"
-            ],
-            "3980379": [
-              "4",
-              "8"
-            ],
-            "3980413": [
-              "14",
-              "18"
-            ],
-            "3980469": [
-              "3",
-              "7"
-            ],
-            "3980480": [
-              "7",
-              "25"
-            ],
-            "3980498": [
-              "3",
-              "21"
-            ],
-            "3980564": [
-              "16",
-              "20"
-            ],
-            "3980572": [
-              "15",
-              "19"
-            ],
-            "3980605": [
-              "8",
-              "26"
-            ],
-            "3980629": [
-              "10",
-              "28"
-            ],
-            "3980804": [
-              "9",
-              "27"
-            ],
-            "3980825": [
-              "19",
-              "23"
-            ],
-            "3980831": [
-              "6",
-              "10"
-            ],
-            "3980992": [
-              "11",
-              "29"
-            ],
-            "3981110": [
-              "4",
-              "22"
-            ],
-            "3981140": [
-              "8",
-              "12"
-            ],
-            "3981181": [
-              "1",
-              "19"
-            ],
-            "4015596": [
-              "5",
-              "23"
-            ],
-            "4015723": [
-              "6",
-              "24"
-            ]
-          },
-          "text": "the stop list offers a stop twice: 3980102 Amsterdam, Sloterpark at 1 and 20 and 24, 3981181 Amsterdam, Frederiksplein at 1 and 19, 3980004 Amsterdam, Frederiksplein at 1 and 5, and 28 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
-          "folded": [
-            [
-              "3980752",
-              "3981140"
-            ]
-          ],
-          "ok": false,
-          "text": "the list offers one station twice in a row: 3980752 Amsterdam, Witte de Withstraat then 3981140 Amsterdam, Witte de Withstraat"
+          "folded": [],
+          "ok": true,
+          "text": "the list offers one station twice in a row"
         },
         {
           "ok": true,
@@ -6221,7 +8559,7 @@
           "unoffered": []
         },
         {
-          "ok": false,
+          "ok": true,
           "text": "the list contradicts the riding order 3980102 .. 3980992"
         },
         {
@@ -6256,8 +8594,8 @@
       "fixture": "gvb",
       "id": "gvb-7-d1-stop_list",
       "kind": "stop_list",
-      "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids",
+      "outcome": "passed",
+      "reason": null,
       "route": "152328"
     },
     {
@@ -6460,6 +8798,86 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "HDV08A",
+          "text": "a destination is offered twice from HDV08A Hôtel de Ville - Pantiero",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "HDV08A",
+          "text": "a stop this ride reaches from HDV08A Hôtel de Ville - Pantiero is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "HDV08A",
+          "stray": [],
+          "text": "a destination no trip reaches from HDV08A Hôtel de Ville - Pantiero is offered"
+        },
+        {
+          "ok": true,
+          "origin": "HDV08A",
+          "text": "the destinations from HDV08A Hôtel de Ville - Pantiero contradict the riding order HDV08A .. HDV08R"
+        },
+        {
+          "ok": true,
+          "origin": "GAZ01B",
+          "text": "a destination is offered twice from GAZ01B Gazagnaire Saint Léon",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "GAZ01B",
+          "text": "a stop this ride reaches from GAZ01B Gazagnaire Saint Léon is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "GAZ01B",
+          "stray": [],
+          "text": "a destination no trip reaches from GAZ01B Gazagnaire Saint Léon is offered"
+        },
+        {
+          "ok": true,
+          "origin": "GAZ01B",
+          "text": "the destinations from GAZ01B Gazagnaire Saint Léon contradict the riding order HDV08A .. HDV08R"
+        },
+        {
+          "ok": true,
+          "origin": "GMA0AA",
+          "text": "a destination is offered twice from GMA0AA Gare Maritime",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "GMA0AA",
+          "text": "a stop this ride reaches from GMA0AA Gare Maritime is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "GMA0AA",
+          "stray": [],
+          "text": "a destination no trip reaches from GMA0AA Gare Maritime is offered"
+        },
+        {
+          "ok": true,
+          "origin": "GMA0AA",
+          "text": "the destinations from GMA0AA Gare Maritime contradict the riding order HDV08A .. HDV08R"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-21-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "21"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "HDV08R",
             "direction": 0,
@@ -6617,6 +9035,155 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "TRAY0R",
+          "text": "a destination is offered twice from TRAY0R Le Trayas Notre Dame",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "TRAY0R",
+          "text": "a stop this ride reaches from TRAY0R Le Trayas Notre Dame is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "TRAY0R",
+          "stray": [],
+          "text": "a destination no trip reaches from TRAY0R Le Trayas Notre Dame is offered"
+        },
+        {
+          "ok": true,
+          "origin": "TRAY0R",
+          "text": "the destinations from TRAY0R Le Trayas Notre Dame contradict the riding order TRAY0R .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "RPO16A",
+          "text": "a destination is offered twice from RPO16A Résidence du Port",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "RPO16A",
+          "text": "a stop this ride reaches from RPO16A Résidence du Port is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "RPO16A",
+          "stray": [],
+          "text": "a destination no trip reaches from RPO16A Résidence du Port is offered"
+        },
+        {
+          "ok": true,
+          "origin": "RPO16A",
+          "text": "the destinations from RPO16A Résidence du Port contradict the riding order TRAY0R .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "RSE0AA",
+          "text": "a destination is offered twice from RSE0AA Rue des Serbes",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "RSE0AA",
+          "text": "a stop this ride reaches from RSE0AA Rue des Serbes is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "RSE0AA",
+          "stray": [],
+          "text": "a destination no trip reaches from RSE0AA Rue des Serbes is offered"
+        },
+        {
+          "ok": true,
+          "origin": "RSE0AA",
+          "text": "the destinations from RSE0AA Rue des Serbes contradict the riding order TRAY0R .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "THEC0A",
+          "text": "a destination is offered twice from THEC0A Théoule Plages",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "THEC0A",
+          "text": "a stop this ride reaches from THEC0A Théoule Plages is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "THEC0A",
+          "stray": [],
+          "text": "a destination no trip reaches from THEC0A Théoule Plages is offered"
+        },
+        {
+          "ok": true,
+          "origin": "THEC0A",
+          "text": "the destinations from THEC0A Théoule Plages contradict the riding order THEC0A .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "KI310A",
+          "text": "a destination is offered twice from KI310A Kiosque 31",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "KI310A",
+          "text": "a stop this ride reaches from KI310A Kiosque 31 is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "KI310A",
+          "stray": [],
+          "text": "a destination no trip reaches from KI310A Kiosque 31 is offered"
+        },
+        {
+          "ok": true,
+          "origin": "KI310A",
+          "text": "the destinations from KI310A Kiosque 31 contradict the riding order THEC0A .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "RSE0AA",
+          "text": "a destination is offered twice from RSE0AA Rue des Serbes",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "RSE0AA",
+          "text": "a stop this ride reaches from RSE0AA Rue des Serbes is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "RSE0AA",
+          "stray": [],
+          "text": "a destination no trip reaches from RSE0AA Rue des Serbes is offered"
+        },
+        {
+          "ok": true,
+          "origin": "RSE0AA",
+          "text": "the destinations from RSE0AA Rue des Serbes contradict the riding order THEC0A .. GSNF0R"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-22-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "22"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "GSNF0R",
             "direction": 0,
@@ -6748,118 +9315,9 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "BDMMBA": [
-              "10",
-              "22"
-            ],
-            "CMID0A": [
-              "12",
-              "24"
-            ],
-            "EROMAN": [
-              "11",
-              "23"
-            ],
-            "GMA0AR": [
-              "25",
-              "37"
-            ],
-            "GSNF0R": [
-              "27",
-              "39"
-            ],
-            "HDV08A": [
-              "24",
-              "36"
-            ],
-            "ISL22R": [
-              "2",
-              "14"
-            ],
-            "JHIB0A": [
-              "22",
-              "34"
-            ],
-            "KI290A": [
-              "15",
-              "27"
-            ],
-            "KI310A": [
-              "14",
-              "26"
-            ],
-            "LMOR0A": [
-              "13",
-              "25"
-            ],
-            "MCOL0A": [
-              "20",
-              "32"
-            ],
-            "MIN22R": [
-              "5",
-              "17"
-            ],
-            "MLEA0A": [
-              "19",
-              "31"
-            ],
-            "MMER0A": [
-              "18",
-              "30"
-            ],
-            "MNAD0A": [
-              "21",
-              "33"
-            ],
-            "PLRO0R": [
-              "9",
-              "21"
-            ],
-            "PMID0A": [
-              "23",
-              "35"
-            ],
-            "PNA16A": [
-              "7",
-              "19"
-            ],
-            "PRA16A": [
-              "6",
-              "18"
-            ],
-            "PROC0A": [
-              "17",
-              "29"
-            ],
-            "RAG22R": [
-              "4",
-              "16"
-            ],
-            "RPO16A": [
-              "8",
-              "20"
-            ],
-            "RSE0AA": [
-              "26",
-              "38"
-            ],
-            "THEC0A": [
-              "1",
-              "13"
-            ],
-            "THEG0A": [
-              "3",
-              "15"
-            ],
-            "VERR0A": [
-              "16",
-              "28"
-            ]
-          },
-          "text": "the stop list offers a stop twice: THEC0A Théoule Plages at 1 and 13, ISL22R Le Princes des Iles at 2 and 14, THEG0A Théoule Gare at 3 and 15, and 24 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
           "folded": [],
@@ -6889,8 +9347,8 @@
       "fixture": "palmbus",
       "id": "palmbus-22-d0-stop_list",
       "kind": "stop_list",
-      "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "outcome": "passed",
+      "reason": null,
       "route": "22"
     },
     {
@@ -6990,6 +9448,155 @@
       "fixture": "palmbus",
       "id": "palmbus-22-d0-swapped",
       "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "22"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "a destination is offered twice from GSNF0R Gare SNCF de Cannes",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "a stop this ride reaches from GSNF0R Gare SNCF de Cannes is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "stray": [],
+          "text": "a destination no trip reaches from GSNF0R Gare SNCF de Cannes is offered"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "the destinations from GSNF0R Gare SNCF de Cannes contradict the riding order GSNF0R .. TRAY0A"
+        },
+        {
+          "ok": true,
+          "origin": "PNA16R",
+          "text": "a destination is offered twice from PNA16R Port de la Napoule",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "PNA16R",
+          "text": "a stop this ride reaches from PNA16R Port de la Napoule is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "PNA16R",
+          "stray": [],
+          "text": "a destination no trip reaches from PNA16R Port de la Napoule is offered"
+        },
+        {
+          "ok": true,
+          "origin": "PNA16R",
+          "text": "the destinations from PNA16R Port de la Napoule contradict the riding order GSNF0R .. TRAY0A"
+        },
+        {
+          "ok": true,
+          "origin": "PLA22A",
+          "text": "a destination is offered twice from PLA22A Plage de la Figueirette",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "PLA22A",
+          "text": "a stop this ride reaches from PLA22A Plage de la Figueirette is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "PLA22A",
+          "stray": [],
+          "text": "a destination no trip reaches from PLA22A Plage de la Figueirette is offered"
+        },
+        {
+          "ok": true,
+          "origin": "PLA22A",
+          "text": "the destinations from PLA22A Plage de la Figueirette contradict the riding order GSNF0R .. TRAY0A"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "a destination is offered twice from GSNF0R Gare SNCF de Cannes",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "a stop this ride reaches from GSNF0R Gare SNCF de Cannes is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "stray": [],
+          "text": "a destination no trip reaches from GSNF0R Gare SNCF de Cannes is offered"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "the destinations from GSNF0R Gare SNCF de Cannes contradict the riding order GSNF0R .. THEC0Z"
+        },
+        {
+          "ok": true,
+          "origin": "CMID0R",
+          "text": "a destination is offered twice from CMID0R Cannes Midi",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "CMID0R",
+          "text": "a stop this ride reaches from CMID0R Cannes Midi is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "CMID0R",
+          "stray": [],
+          "text": "a destination no trip reaches from CMID0R Cannes Midi is offered"
+        },
+        {
+          "ok": true,
+          "origin": "CMID0R",
+          "text": "the destinations from CMID0R Cannes Midi contradict the riding order GSNF0R .. THEC0Z"
+        },
+        {
+          "ok": true,
+          "origin": "ISL22A",
+          "text": "a destination is offered twice from ISL22A Le Princes des Iles",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ISL22A",
+          "text": "a stop this ride reaches from ISL22A Le Princes des Iles is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ISL22A",
+          "stray": [],
+          "text": "a destination no trip reaches from ISL22A Le Princes des Iles is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ISL22A",
+          "text": "the destinations from ISL22A Le Princes des Iles contradict the riding order GSNF0R .. THEC0Z"
+        }
+      ],
+      "direction": 1,
+      "fixture": "palmbus",
+      "id": "palmbus-22-d1-destinations",
+      "kind": "destinations",
       "outcome": "passed",
       "reason": null,
       "route": "22"
@@ -7268,6 +9875,86 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "CCO15A",
+          "text": "a destination is offered twice from CCO15A Centre Commercial Minelle",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "CCO15A",
+          "text": "a stop this ride reaches from CCO15A Centre Commercial Minelle is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "CCO15A",
+          "stray": [],
+          "text": "a destination no trip reaches from CCO15A Centre Commercial Minelle is offered"
+        },
+        {
+          "ok": true,
+          "origin": "CCO15A",
+          "text": "the destinations from CCO15A Centre Commercial Minelle contradict the riding order CCO15A .. GSNF0A"
+        },
+        {
+          "ok": true,
+          "origin": "COU0AR",
+          "text": "a destination is offered twice from COU0AR Coubertin",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "COU0AR",
+          "text": "a stop this ride reaches from COU0AR Coubertin is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "COU0AR",
+          "stray": [],
+          "text": "a destination no trip reaches from COU0AR Coubertin is offered"
+        },
+        {
+          "ok": true,
+          "origin": "COU0AR",
+          "text": "the destinations from COU0AR Coubertin contradict the riding order CCO15A .. GSNF0A"
+        },
+        {
+          "ok": true,
+          "origin": "RSE0AA",
+          "text": "a destination is offered twice from RSE0AA Rue des Serbes",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "RSE0AA",
+          "text": "a stop this ride reaches from RSE0AA Rue des Serbes is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "RSE0AA",
+          "stray": [],
+          "text": "a destination no trip reaches from RSE0AA Rue des Serbes is offered"
+        },
+        {
+          "ok": true,
+          "origin": "RSE0AA",
+          "text": "the destinations from RSE0AA Rue des Serbes contradict the riding order CCO15A .. GSNF0A"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-A-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "A"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "GSNF0A",
             "direction": 0,
@@ -7426,6 +10113,86 @@
       "kind": "swapped",
       "outcome": "xfailed",
       "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "A"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "GSNF0A",
+          "text": "a destination is offered twice from GSNF0A Gare SNCF de Cannes",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "GSNF0A",
+          "text": "a stop this ride reaches from GSNF0A Gare SNCF de Cannes is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0A",
+          "stray": [],
+          "text": "a destination no trip reaches from GSNF0A Gare SNCF de Cannes is offered"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0A",
+          "text": "the destinations from GSNF0A Gare SNCF de Cannes contradict the riding order GSNF0A .. CCO15A"
+        },
+        {
+          "ok": true,
+          "origin": "PPO20A",
+          "text": "a destination is offered twice from PPO20A Saint Cassien",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "PPO20A",
+          "text": "a stop this ride reaches from PPO20A Saint Cassien is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "PPO20A",
+          "stray": [],
+          "text": "a destination no trip reaches from PPO20A Saint Cassien is offered"
+        },
+        {
+          "ok": true,
+          "origin": "PPO20A",
+          "text": "the destinations from PPO20A Saint Cassien contradict the riding order GSNF0A .. CCO15A"
+        },
+        {
+          "ok": true,
+          "origin": "EDENPA",
+          "text": "a destination is offered twice from EDENPA Eden Parc",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "EDENPA",
+          "text": "a stop this ride reaches from EDENPA Eden Parc is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "EDENPA",
+          "stray": [],
+          "text": "a destination no trip reaches from EDENPA Eden Parc is offered"
+        },
+        {
+          "ok": true,
+          "origin": "EDENPA",
+          "text": "the destinations from EDENPA Eden Parc contradict the riding order GSNF0A .. CCO15A"
+        }
+      ],
+      "direction": 1,
+      "fixture": "palmbus",
+      "id": "palmbus-A-d1-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
       "route": "A"
     },
     {
@@ -7590,6 +10357,224 @@
       "outcome": "xfailed",
       "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
       "route": "A"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "a destination is offered twice from GSNF0R Gare SNCF de Cannes",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "a stop this ride reaches from GSNF0R Gare SNCF de Cannes is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "stray": [],
+          "text": "a destination no trip reaches from GSNF0R Gare SNCF de Cannes is offered"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "the destinations from GSNF0R Gare SNCF de Cannes contradict the riding order GSNF0R .. MSCE0A"
+        },
+        {
+          "ok": true,
+          "origin": "CJA01R",
+          "text": "a destination is offered twice from CJA01R Cité Jardin",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "CJA01R",
+          "text": "a stop this ride reaches from CJA01R Cité Jardin is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "CJA01R",
+          "stray": [],
+          "text": "a destination no trip reaches from CJA01R Cité Jardin is offered"
+        },
+        {
+          "ok": true,
+          "origin": "CJA01R",
+          "text": "the destinations from CJA01R Cité Jardin contradict the riding order GSNF0R .. MSCE0A"
+        },
+        {
+          "ok": true,
+          "origin": "GOUR0R",
+          "text": "a destination is offered twice from GOUR0R Les Gourettes",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "GOUR0R",
+          "text": "a stop this ride reaches from GOUR0R Les Gourettes is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "GOUR0R",
+          "stray": [],
+          "text": "a destination no trip reaches from GOUR0R Les Gourettes is offered"
+        },
+        {
+          "ok": true,
+          "origin": "GOUR0R",
+          "text": "the destinations from GOUR0R Les Gourettes contradict the riding order GSNF0R .. MSCE0A"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "a destination is offered twice from GSNF0R Gare SNCF de Cannes",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "a stop this ride reaches from GSNF0R Gare SNCF de Cannes is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "stray": [],
+          "text": "a destination no trip reaches from GSNF0R Gare SNCF de Cannes is offered"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "the destinations from GSNF0R Gare SNCF de Cannes contradict the riding order GSNF0R .. BLAN0D"
+        },
+        {
+          "ok": true,
+          "origin": "NDAN6R",
+          "text": "a destination is offered twice from NDAN6R Notre Dame des Anges",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "NDAN6R",
+          "text": "a stop this ride reaches from NDAN6R Notre Dame des Anges is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "NDAN6R",
+          "stray": [],
+          "text": "a destination no trip reaches from NDAN6R Notre Dame des Anges is offered"
+        },
+        {
+          "ok": true,
+          "origin": "NDAN6R",
+          "text": "the destinations from NDAN6R Notre Dame des Anges contradict the riding order GSNF0R .. BLAN0D"
+        },
+        {
+          "ok": true,
+          "origin": "VFE01R",
+          "text": "a destination is offered twice from VFE01R Val des Fées",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "VFE01R",
+          "text": "a stop this ride reaches from VFE01R Val des Fées is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "VFE01R",
+          "stray": [],
+          "text": "a destination no trip reaches from VFE01R Val des Fées is offered"
+        },
+        {
+          "ok": true,
+          "origin": "VFE01R",
+          "text": "the destinations from VFE01R Val des Fées contradict the riding order GSNF0R .. BLAN0D"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "a destination is offered twice from GSNF0R Gare SNCF de Cannes",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "a stop this ride reaches from GSNF0R Gare SNCF de Cannes is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "stray": [],
+          "text": "a destination no trip reaches from GSNF0R Gare SNCF de Cannes is offered"
+        },
+        {
+          "ok": true,
+          "origin": "GSNF0R",
+          "text": "the destinations from GSNF0R Gare SNCF de Cannes contradict the riding order GSNF0R .. TOUR0R"
+        },
+        {
+          "ok": true,
+          "origin": "LIC01R",
+          "text": "a destination is offered twice from LIC01R Louis Icard",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "LIC01R",
+          "text": "a stop this ride reaches from LIC01R Louis Icard is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "LIC01R",
+          "stray": [],
+          "text": "a destination no trip reaches from LIC01R Louis Icard is offered"
+        },
+        {
+          "ok": true,
+          "origin": "LIC01R",
+          "text": "the destinations from LIC01R Louis Icard contradict the riding order GSNF0R .. TOUR0R"
+        },
+        {
+          "ok": true,
+          "origin": "CMOU0R",
+          "text": "a destination is offered twice from CMOU0R Coeur de Mougins",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "CMOU0R",
+          "text": "a stop this ride reaches from CMOU0R Coeur de Mougins is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "CMOU0R",
+          "stray": [],
+          "text": "a destination no trip reaches from CMOU0R Coeur de Mougins is offered"
+        },
+        {
+          "ok": true,
+          "origin": "CMOU0R",
+          "text": "the destinations from CMOU0R Coeur de Mougins contradict the riding order GSNF0R .. TOUR0R"
+        }
+      ],
+      "direction": 0,
+      "fixture": "palmbus",
+      "id": "palmbus-B-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "B"
     },
     {
       "checks": [
@@ -7985,6 +10970,293 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "MSCE0A",
+          "text": "a destination is offered twice from MSCE0A Mouans Sartoux Centre",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "MSCE0A",
+          "text": "a stop this ride reaches from MSCE0A Mouans Sartoux Centre is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "MSCE0A",
+          "stray": [],
+          "text": "a destination no trip reaches from MSCE0A Mouans Sartoux Centre is offered"
+        },
+        {
+          "ok": true,
+          "origin": "MSCE0A",
+          "text": "the destinations from MSCE0A Mouans Sartoux Centre contradict the riding order MSCE0A .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "LRO01A",
+          "text": "a destination is offered twice from LRO01A Les Roses",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "LRO01A",
+          "text": "a stop this ride reaches from LRO01A Les Roses is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "LRO01A",
+          "stray": [],
+          "text": "a destination no trip reaches from LRO01A Les Roses is offered"
+        },
+        {
+          "ok": true,
+          "origin": "LRO01A",
+          "text": "the destinations from LRO01A Les Roses contradict the riding order MSCE0A .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "PVA0AA",
+          "text": "a destination is offered twice from PVA0AA Place Vauban",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "PVA0AA",
+          "text": "a stop this ride reaches from PVA0AA Place Vauban is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "PVA0AA",
+          "stray": [],
+          "text": "a destination no trip reaches from PVA0AA Place Vauban is offered"
+        },
+        {
+          "ok": true,
+          "origin": "PVA0AA",
+          "text": "the destinations from PVA0AA Place Vauban contradict the riding order MSCE0A .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "TOUR0A",
+          "text": "a destination is offered twice from TOUR0A Tournamy",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "TOUR0A",
+          "text": "a stop this ride reaches from TOUR0A Tournamy is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "TOUR0A",
+          "stray": [],
+          "text": "a destination no trip reaches from TOUR0A Tournamy is offered"
+        },
+        {
+          "ok": true,
+          "origin": "TOUR0A",
+          "text": "the destinations from TOUR0A Tournamy contradict the riding order TOUR0A .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "LIC01A",
+          "text": "a destination is offered twice from LIC01A Louis Icard",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "LIC01A",
+          "text": "a stop this ride reaches from LIC01A Louis Icard is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "LIC01A",
+          "stray": [],
+          "text": "a destination no trip reaches from LIC01A Louis Icard is offered"
+        },
+        {
+          "ok": true,
+          "origin": "LIC01A",
+          "text": "the destinations from LIC01A Louis Icard contradict the riding order TOUR0A .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "PVA0AA",
+          "text": "a destination is offered twice from PVA0AA Place Vauban",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "PVA0AA",
+          "text": "a stop this ride reaches from PVA0AA Place Vauban is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "PVA0AA",
+          "stray": [],
+          "text": "a destination no trip reaches from PVA0AA Place Vauban is offered"
+        },
+        {
+          "ok": true,
+          "origin": "PVA0AA",
+          "text": "the destinations from PVA0AA Place Vauban contradict the riding order TOUR0A .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "BLAN0C",
+          "text": "a destination is offered twice from BLAN0C Blanchisserie",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "BLAN0C",
+          "text": "a stop this ride reaches from BLAN0C Blanchisserie is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "BLAN0C",
+          "stray": [],
+          "text": "a destination no trip reaches from BLAN0C Blanchisserie is offered"
+        },
+        {
+          "ok": true,
+          "origin": "BLAN0C",
+          "text": "the destinations from BLAN0C Blanchisserie contradict the riding order BLAN0C .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "NDAN6A",
+          "text": "a destination is offered twice from NDAN6A Notre Dame des Anges",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "NDAN6A",
+          "text": "a stop this ride reaches from NDAN6A Notre Dame des Anges is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "NDAN6A",
+          "stray": [],
+          "text": "a destination no trip reaches from NDAN6A Notre Dame des Anges is offered"
+        },
+        {
+          "ok": true,
+          "origin": "NDAN6A",
+          "text": "the destinations from NDAN6A Notre Dame des Anges contradict the riding order BLAN0C .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "PVA0AA",
+          "text": "a destination is offered twice from PVA0AA Place Vauban",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "PVA0AA",
+          "text": "a stop this ride reaches from PVA0AA Place Vauban is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "PVA0AA",
+          "stray": [],
+          "text": "a destination no trip reaches from PVA0AA Place Vauban is offered"
+        },
+        {
+          "ok": true,
+          "origin": "PVA0AA",
+          "text": "the destinations from PVA0AA Place Vauban contradict the riding order BLAN0C .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "OLI01A",
+          "text": "a destination is offered twice from OLI01A L'Olivet",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "OLI01A",
+          "text": "a stop this ride reaches from OLI01A L'Olivet is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "OLI01A",
+          "stray": [],
+          "text": "a destination no trip reaches from OLI01A L'Olivet is offered"
+        },
+        {
+          "ok": true,
+          "origin": "OLI01A",
+          "text": "the destinations from OLI01A L'Olivet contradict the riding order OLI01A .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "SEV06A",
+          "text": "a destination is offered twice from SEV06A Sévigné",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "SEV06A",
+          "text": "a stop this ride reaches from SEV06A Sévigné is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "SEV06A",
+          "stray": [],
+          "text": "a destination no trip reaches from SEV06A Sévigné is offered"
+        },
+        {
+          "ok": true,
+          "origin": "SEV06A",
+          "text": "the destinations from SEV06A Sévigné contradict the riding order OLI01A .. GSNF0R"
+        },
+        {
+          "ok": true,
+          "origin": "PVA0AA",
+          "text": "a destination is offered twice from PVA0AA Place Vauban",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "PVA0AA",
+          "text": "a stop this ride reaches from PVA0AA Place Vauban is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "PVA0AA",
+          "stray": [],
+          "text": "a destination no trip reaches from PVA0AA Place Vauban is offered"
+        },
+        {
+          "ok": true,
+          "origin": "PVA0AA",
+          "text": "the destinations from PVA0AA Place Vauban contradict the riding order OLI01A .. GSNF0R"
+        }
+      ],
+      "direction": 1,
+      "fixture": "palmbus",
+      "id": "palmbus-B-d1-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "B"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "GSNF0R",
             "direction": 1,
@@ -8236,132 +11508,9 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "BLAN0C": [
-              "1",
-              "7",
-              "11"
-            ],
-            "CABR0A": [
-              "6",
-              "10"
-            ],
-            "CJA01A": [
-              "3",
-              "9",
-              "13"
-            ],
-            "CMOU0A": [
-              "2",
-              "6"
-            ],
-            "GSNF0R": [
-              "13",
-              "17",
-              "23",
-              "27"
-            ],
-            "JUYE0A": [
-              "3",
-              "7"
-            ],
-            "LCA0AA": [
-              "9",
-              "13",
-              "19",
-              "23"
-            ],
-            "LIC01A": [
-              "2",
-              "6",
-              "12",
-              "16"
-            ],
-            "LRO01A": [
-              "4",
-              "10",
-              "14"
-            ],
-            "MADR6A": [
-              "6",
-              "10",
-              "16",
-              "20"
-            ],
-            "MEU0AA": [
-              "11",
-              "15",
-              "21",
-              "25"
-            ],
-            "MIL0AA": [
-              "10",
-              "14",
-              "20",
-              "24"
-            ],
-            "MRO35A": [
-              "4",
-              "8",
-              "14",
-              "18"
-            ],
-            "NDAN6A": [
-              "5",
-              "9",
-              "15",
-              "19"
-            ],
-            "OLI01A": [
-              "1",
-              "5",
-              "11",
-              "15"
-            ],
-            "PDO0AA": [
-              "8",
-              "12",
-              "18",
-              "22"
-            ],
-            "PRO11R": [
-              "3",
-              "7",
-              "13",
-              "17"
-            ],
-            "PVA0AA": [
-              "12",
-              "16",
-              "22",
-              "26"
-            ],
-            "SEV06A": [
-              "7",
-              "11",
-              "17",
-              "21"
-            ],
-            "TOUR0A": [
-              "1",
-              "5"
-            ],
-            "VALM0A": [
-              "4",
-              "8"
-            ],
-            "VAUM0A": [
-              "5",
-              "9"
-            ],
-            "VFE01A": [
-              "2",
-              "8",
-              "12"
-            ]
-          },
-          "text": "the stop list offers a stop twice: TOUR0A Tournamy at 1 and 5, BLAN0C Blanchisserie at 1 and 7 and 11, OLI01A L'Olivet at 1 and 5 and 11 and 15, and 20 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
           "folded": [],
@@ -8409,8 +11558,8 @@
       "fixture": "palmbus",
       "id": "palmbus-B-d1-stop_list",
       "kind": "stop_list",
-      "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "outcome": "passed",
+      "reason": null,
       "route": "B"
     },
     {
@@ -11461,6 +14610,86 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001010",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01001010 Zénith",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001010",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01001010 Zénith is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001010",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01001010 Zénith is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001010",
+          "text": "the destinations from ORLEANS:StopArea:01001010 Zénith contradict the riding order ORLEANS:StopArea:01001010 .. ORLEANS:StopArea:06001010"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00027702",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00027702 Les Ballons",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00027702",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00027702 Les Ballons is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00027702",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00027702 Les Ballons is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00027702",
+          "text": "the destinations from ORLEANS:StopArea:00027702 Les Ballons contradict the riding order ORLEANS:StopArea:01001010 .. ORLEANS:StopArea:06001010"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00049161",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00049161 Zénith",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00049161",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00049161 Zénith is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00049161",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00049161 Zénith is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00049161",
+          "text": "the destinations from ORLEANS:StopArea:00049161 Zénith contradict the riding order ORLEANS:StopArea:01001010 .. ORLEANS:StopArea:06001010"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-22-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:22"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "ORLEANS:StopArea:06001010",
             "direction": 0,
@@ -11611,6 +14840,86 @@
       "fixture": "tao-journeys",
       "id": "tao-journeys-22-d0-swapped",
       "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:22"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001010",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01001010 Zénith",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001010",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01001010 Zénith is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001010",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01001010 Zénith is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001010",
+          "text": "the destinations from ORLEANS:StopArea:01001010 Zénith contradict the riding order ORLEANS:StopArea:01001010 .. ORLEANS:StopArea:06001010"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01042303",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01042303 Brèche",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01042303",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01042303 Brèche is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01042303",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01042303 Brèche is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01042303",
+          "text": "the destinations from ORLEANS:StopArea:01042303 Brèche contradict the riding order ORLEANS:StopArea:01001010 .. ORLEANS:StopArea:06001010"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00049161",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00049161 Zénith",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00049161",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00049161 Zénith is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00049161",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00049161 Zénith is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00049161",
+          "text": "the destinations from ORLEANS:StopArea:00049161 Zénith contradict the riding order ORLEANS:StopArea:01001010 .. ORLEANS:StopArea:06001010"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-22-d1-destinations",
+      "kind": "destinations",
       "outcome": "passed",
       "reason": null,
       "route": "ORLEANS:Line:22"
@@ -11775,6 +15084,155 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00007923",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00007923 Chèques Postaux - M. Ricoud - Quai C",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00007923",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00007923 Chèques Postaux - M. Ricoud - Quai C is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00007923",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00007923 Chèques Postaux - M. Ricoud - Quai C is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00007923",
+          "text": "the destinations from ORLEANS:StopArea:00007923 Chèques Postaux - M. Ricoud - Quai C contradict the riding order ORLEANS:StopArea:00007923 .. ORLEANS:StopArea:01001712"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005500",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00005500 Recherche Scientifique",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005500",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00005500 Recherche Scientifique is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005500",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00005500 Recherche Scientifique is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005500",
+          "text": "the destinations from ORLEANS:StopArea:00005500 Recherche Scientifique contradict the riding order ORLEANS:StopArea:00007923 .. ORLEANS:StopArea:01001712"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00019301",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00019301 Halmagrand",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00019301",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00019301 Halmagrand is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00019301",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00019301 Halmagrand is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00019301",
+          "text": "the destinations from ORLEANS:StopArea:00019301 Halmagrand contradict the riding order ORLEANS:StopArea:00007923 .. ORLEANS:StopArea:01001712"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00035910",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00035910 Petite Mérie",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00035910",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00035910 Petite Mérie is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00035910",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00035910 Petite Mérie is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00035910",
+          "text": "the destinations from ORLEANS:StopArea:00035910 Petite Mérie contradict the riding order ORLEANS:StopArea:00035910 .. ORLEANS:StopArea:01001712"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01036003",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01036003 Théâtre Philipe",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01036003",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01036003 Théâtre Philipe is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01036003",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01036003 Théâtre Philipe is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01036003",
+          "text": "the destinations from ORLEANS:StopArea:01036003 Théâtre Philipe contradict the riding order ORLEANS:StopArea:00035910 .. ORLEANS:StopArea:01001712"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00019301",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00019301 Halmagrand",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00019301",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00019301 Halmagrand is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00019301",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00019301 Halmagrand is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00019301",
+          "text": "the destinations from ORLEANS:StopArea:00019301 Halmagrand contradict the riding order ORLEANS:StopArea:00035910 .. ORLEANS:StopArea:01001712"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-40-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:40"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "ORLEANS:StopArea:01001712",
             "direction": 0,
@@ -11906,70 +15364,9 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "ORLEANS:StopArea:00001220": [
-              "11",
-              "21"
-            ],
-            "ORLEANS:StopArea:00004730": [
-              "3",
-              "13"
-            ],
-            "ORLEANS:StopArea:00005402": [
-              "12",
-              "22"
-            ],
-            "ORLEANS:StopArea:00005500": [
-              "7",
-              "17"
-            ],
-            "ORLEANS:StopArea:00007923": [
-              "0",
-              "10"
-            ],
-            "ORLEANS:StopArea:00019301": [
-              "13",
-              "23"
-            ],
-            "ORLEANS:StopArea:00026500": [
-              "8",
-              "18"
-            ],
-            "ORLEANS:StopArea:00034303": [
-              "1",
-              "11"
-            ],
-            "ORLEANS:StopArea:00038310": [
-              "9",
-              "19"
-            ],
-            "ORLEANS:StopArea:00039751": [
-              "4",
-              "14"
-            ],
-            "ORLEANS:StopArea:00045620": [
-              "10",
-              "20"
-            ],
-            "ORLEANS:StopArea:00047321": [
-              "5",
-              "15"
-            ],
-            "ORLEANS:StopArea:00047361": [
-              "6",
-              "16"
-            ],
-            "ORLEANS:StopArea:01001712": [
-              "14",
-              "24"
-            ],
-            "ORLEANS:StopArea:01036003": [
-              "2",
-              "12"
-            ]
-          },
-          "text": "the stop list offers a stop twice: ORLEANS:StopArea:00007923 Chèques Postaux - M. Ricoud - Quai C at 0 and 10, ORLEANS:StopArea:00034303 Montesquieu at 1 and 11, ORLEANS:StopArea:01036003 Théâtre Philipe at 2 and 12, and 12 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
           "folded": [],
@@ -11999,8 +15396,8 @@
       "fixture": "tao-journeys",
       "id": "tao-journeys-40-d0-stop_list",
       "kind": "stop_list",
-      "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "outcome": "passed",
+      "reason": null,
       "route": "ORLEANS:Line:40"
     },
     {
@@ -12114,6 +15511,362 @@
       "kind": "swapped",
       "outcome": "xfailed",
       "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "ORLEANS:Line:40"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01017071",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01017071",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01017071",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01017071",
+          "text": "the destinations from ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis contradict the riding order ORLEANS:StopArea:01017071 .. ORLEANS:StopArea:00035910"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01036004",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01036004 Théâtre Philipe",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01036004",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01036004 Théâtre Philipe is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01036004",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01036004 Théâtre Philipe is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01036004",
+          "text": "the destinations from ORLEANS:StopArea:01036004 Théâtre Philipe contradict the riding order ORLEANS:StopArea:01017071 .. ORLEANS:StopArea:00035910"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01088001",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01088001 La Pomme",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01088001",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01088001 La Pomme is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01088001",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01088001 La Pomme is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01088001",
+          "text": "the destinations from ORLEANS:StopArea:01088001 La Pomme contradict the riding order ORLEANS:StopArea:01017071 .. ORLEANS:StopArea:00035910"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001712",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01001712 Gare d'Orléans - Quai E",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001712",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01001712 Gare d'Orléans - Quai E is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001712",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01001712 Gare d'Orléans - Quai E is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001712",
+          "text": "the destinations from ORLEANS:StopArea:01001712 Gare d'Orléans - Quai E contradict the riding order ORLEANS:StopArea:01001712 .. ORLEANS:StopArea:00007924"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005501",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00005501 Recherche Scientifique",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005501",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00005501 Recherche Scientifique is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005501",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00005501 Recherche Scientifique is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005501",
+          "text": "the destinations from ORLEANS:StopArea:00005501 Recherche Scientifique contradict the riding order ORLEANS:StopArea:01001712 .. ORLEANS:StopArea:00007924"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00034302",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00034302 Montesquieu",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00034302",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00034302 Montesquieu is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00034302",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00034302 Montesquieu is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00034302",
+          "text": "the destinations from ORLEANS:StopArea:00034302 Montesquieu contradict the riding order ORLEANS:StopArea:01001712 .. ORLEANS:StopArea:00007924"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001712",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01001712 Gare d'Orléans - Quai E",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001712",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01001712 Gare d'Orléans - Quai E is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001712",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01001712 Gare d'Orléans - Quai E is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001712",
+          "text": "the destinations from ORLEANS:StopArea:01001712 Gare d'Orléans - Quai E contradict the riding order ORLEANS:StopArea:01001712 .. ORLEANS:StopArea:00035910"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01036004",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01036004 Théâtre Philipe",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01036004",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01036004 Théâtre Philipe is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01036004",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01036004 Théâtre Philipe is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01036004",
+          "text": "the destinations from ORLEANS:StopArea:01036004 Théâtre Philipe contradict the riding order ORLEANS:StopArea:01001712 .. ORLEANS:StopArea:00035910"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01088001",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01088001 La Pomme",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01088001",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01088001 La Pomme is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01088001",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01088001 La Pomme is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01088001",
+          "text": "the destinations from ORLEANS:StopArea:01088001 La Pomme contradict the riding order ORLEANS:StopArea:01001712 .. ORLEANS:StopArea:00035910"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01017071",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01017071",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01017071",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01017071",
+          "text": "the destinations from ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis contradict the riding order ORLEANS:StopArea:01017071 .. ORLEANS:StopArea:00007923"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00047360",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00047360 Parc Floral",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00047360",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00047360 Parc Floral is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00047360",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00047360 Parc Floral is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00047360",
+          "text": "the destinations from ORLEANS:StopArea:00047360 Parc Floral contradict the riding order ORLEANS:StopArea:01017071 .. ORLEANS:StopArea:00007923"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00007924",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00007924 Chèques Postaux - M. Ricoud - Quai D",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00007924",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00007924 Chèques Postaux - M. Ricoud - Quai D is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00007924",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00007924 Chèques Postaux - M. Ricoud - Quai D is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00007924",
+          "text": "the destinations from ORLEANS:StopArea:00007924 Chèques Postaux - M. Ricoud - Quai D contradict the riding order ORLEANS:StopArea:01017071 .. ORLEANS:StopArea:00007923"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001712",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01001712 Gare d'Orléans - Quai E",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001712",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01001712 Gare d'Orléans - Quai E is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001712",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01001712 Gare d'Orléans - Quai E is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001712",
+          "text": "the destinations from ORLEANS:StopArea:01001712 Gare d'Orléans - Quai E contradict the riding order ORLEANS:StopArea:01001712 .. ORLEANS:StopArea:00007923"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005501",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00005501 Recherche Scientifique",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005501",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00005501 Recherche Scientifique is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005501",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00005501 Recherche Scientifique is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005501",
+          "text": "the destinations from ORLEANS:StopArea:00005501 Recherche Scientifique contradict the riding order ORLEANS:StopArea:01001712 .. ORLEANS:StopArea:00007923"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00007924",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00007924 Chèques Postaux - M. Ricoud - Quai D",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00007924",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00007924 Chèques Postaux - M. Ricoud - Quai D is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00007924",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00007924 Chèques Postaux - M. Ricoud - Quai D is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00007924",
+          "text": "the destinations from ORLEANS:StopArea:00007924 Chèques Postaux - M. Ricoud - Quai D contradict the riding order ORLEANS:StopArea:01001712 .. ORLEANS:StopArea:00007923"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-40-d1-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
       "route": "ORLEANS:Line:40"
     },
     {
@@ -12430,114 +16183,9 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "ORLEANS:StopArea:00001223": [
-              "3",
-              "4"
-            ],
-            "ORLEANS:StopArea:00001600": [
-              "22",
-              "23"
-            ],
-            "ORLEANS:StopArea:00003726": [
-              "15",
-              "16"
-            ],
-            "ORLEANS:StopArea:00004732": [
-              "11",
-              "12"
-            ],
-            "ORLEANS:StopArea:00005401": [
-              "2",
-              "3"
-            ],
-            "ORLEANS:StopArea:00005501": [
-              "7",
-              "8"
-            ],
-            "ORLEANS:StopArea:00007601": [
-              "19",
-              "20"
-            ],
-            "ORLEANS:StopArea:00007923": [
-              "15",
-              "16"
-            ],
-            "ORLEANS:StopArea:00007924": [
-              "14",
-              "15"
-            ],
-            "ORLEANS:StopArea:00010100": [
-              "17",
-              "18"
-            ],
-            "ORLEANS:StopArea:00016101": [
-              "21",
-              "22"
-            ],
-            "ORLEANS:StopArea:00019303": [
-              "1",
-              "2"
-            ],
-            "ORLEANS:StopArea:00026501": [
-              "6",
-              "7"
-            ],
-            "ORLEANS:StopArea:00034302": [
-              "13",
-              "14"
-            ],
-            "ORLEANS:StopArea:00035910": [
-              "24",
-              "25"
-            ],
-            "ORLEANS:StopArea:00038311": [
-              "5",
-              "6"
-            ],
-            "ORLEANS:StopArea:00039750": [
-              "10",
-              "11"
-            ],
-            "ORLEANS:StopArea:00043320": [
-              "20",
-              "21"
-            ],
-            "ORLEANS:StopArea:00045621": [
-              "4",
-              "5"
-            ],
-            "ORLEANS:StopArea:00047320": [
-              "9",
-              "10"
-            ],
-            "ORLEANS:StopArea:00047360": [
-              "8",
-              "9"
-            ],
-            "ORLEANS:StopArea:00049101": [
-              "16",
-              "17"
-            ],
-            "ORLEANS:StopArea:01017071": [
-              "0",
-              "1"
-            ],
-            "ORLEANS:StopArea:01036004": [
-              "12",
-              "13"
-            ],
-            "ORLEANS:StopArea:01077502": [
-              "18",
-              "19"
-            ],
-            "ORLEANS:StopArea:01088001": [
-              "23",
-              "24"
-            ]
-          },
-          "text": "the stop list offers a stop twice: ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis at 0 and 1, ORLEANS:StopArea:00019303 Halmagrand at 1 and 2, ORLEANS:StopArea:00005401 Carré St-Vincent at 2 and 3, and 23 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
           "folded": [],
@@ -12594,8 +16242,8 @@
       "fixture": "tao-journeys",
       "id": "tao-journeys-40-d1-stop_list",
       "kind": "stop_list",
-      "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "outcome": "passed",
+      "reason": null,
       "route": "ORLEANS:Line:40"
     },
     {
@@ -12843,6 +16491,86 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00043200",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00043200 ESAT Rodin",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00043200",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00043200 ESAT Rodin is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00043200",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00043200 ESAT Rodin is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00043200",
+          "text": "the destinations from ORLEANS:StopArea:00043200 ESAT Rodin contradict the riding order ORLEANS:StopArea:00043200 .. ORLEANS:StopArea:01001710"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005502",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00005502 Recherche Scientifique",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005502",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00005502 Recherche Scientifique is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005502",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00005502 Recherche Scientifique is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00005502",
+          "text": "the destinations from ORLEANS:StopArea:00005502 Recherche Scientifique contradict the riding order ORLEANS:StopArea:00043200 .. ORLEANS:StopArea:01001710"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00019301",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00019301 Halmagrand",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00019301",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00019301 Halmagrand is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00019301",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00019301 Halmagrand is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00019301",
+          "text": "the destinations from ORLEANS:StopArea:00019301 Halmagrand contradict the riding order ORLEANS:StopArea:00043200 .. ORLEANS:StopArea:01001710"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-41-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:41"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "ORLEANS:StopArea:01001710",
             "direction": 0,
@@ -12993,6 +16721,86 @@
       "fixture": "tao-journeys",
       "id": "tao-journeys-41-d0-swapped",
       "kind": "swapped",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:41"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001710",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01001710 Gare d'Orléans - Quai G",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001710",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01001710 Gare d'Orléans - Quai G is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001710",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01001710 Gare d'Orléans - Quai G is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01001710",
+          "text": "the destinations from ORLEANS:StopArea:01001710 Gare d'Orléans - Quai G contradict the riding order ORLEANS:StopArea:01001710 .. ORLEANS:StopArea:01030202"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00002201",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00002201 Beaumarchais",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00002201",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00002201 Beaumarchais is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00002201",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00002201 Beaumarchais is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00002201",
+          "text": "the destinations from ORLEANS:StopArea:00002201 Beaumarchais contradict the riding order ORLEANS:StopArea:01001710 .. ORLEANS:StopArea:01030202"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00004701",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00004701 Buffon-Rodin",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00004701",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00004701 Buffon-Rodin is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00004701",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00004701 Buffon-Rodin is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00004701",
+          "text": "the destinations from ORLEANS:StopArea:00004701 Buffon-Rodin contradict the riding order ORLEANS:StopArea:01001710 .. ORLEANS:StopArea:01030202"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-41-d1-destinations",
+      "kind": "destinations",
       "outcome": "passed",
       "reason": null,
       "route": "ORLEANS:Line:41"
@@ -13153,6 +16961,431 @@
       "outcome": "passed",
       "reason": null,
       "route": "ORLEANS:Line:41"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THOPIT2 Hôpital de La Source",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THOPIT2 Hôpital de La Source is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THOPIT2 Hôpital de La Source is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT2",
+          "text": "the destinations from ORLEANS:StopArea:THOPIT2 Hôpital de La Source contradict the riding order ORLEANS:StopArea:THOPIT2 .. ORLEANS:StopArea:TVERNE2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TMOUIL1 Mouillère",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TMOUIL1 Mouillère is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TMOUIL1 Mouillère is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "text": "the destinations from ORLEANS:StopArea:TMOUIL1 Mouillère contradict the riding order ORLEANS:StopArea:THOPIT2 .. ORLEANS:StopArea:TVERNE2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TLAMBA1 Lamballe",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TLAMBA1 Lamballe is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TLAMBA1 Lamballe is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "the destinations from ORLEANS:StopArea:TLAMBA1 Lamballe contradict the riding order ORLEANS:StopArea:THOPIT2 .. ORLEANS:StopArea:TVERNE2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THOPIT1 Hôpital de La Source",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THOPIT1 Hôpital de La Source is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THOPIT1 Hôpital de La Source is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT1",
+          "text": "the destinations from ORLEANS:StopArea:THOPIT1 Hôpital de La Source contradict the riding order ORLEANS:StopArea:THOPIT1 .. ORLEANS:StopArea:TVERNE2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TMOUIL1 Mouillère",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TMOUIL1 Mouillère is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TMOUIL1 Mouillère is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "text": "the destinations from ORLEANS:StopArea:TMOUIL1 Mouillère contradict the riding order ORLEANS:StopArea:THOPIT1 .. ORLEANS:StopArea:TVERNE2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TLAMBA1 Lamballe",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TLAMBA1 Lamballe is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TLAMBA1 Lamballe is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "the destinations from ORLEANS:StopArea:TLAMBA1 Lamballe contradict the riding order ORLEANS:StopArea:THOPIT1 .. ORLEANS:StopArea:TVERNE2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THOPIT2 Hôpital de La Source",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THOPIT2 Hôpital de La Source is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THOPIT2 Hôpital de La Source is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT2",
+          "text": "the destinations from ORLEANS:StopArea:THOPIT2 Hôpital de La Source contradict the riding order ORLEANS:StopArea:THOPIT2 .. ORLEANS:StopArea:TVERNE1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TMOUIL1 Mouillère",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TMOUIL1 Mouillère is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TMOUIL1 Mouillère is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "text": "the destinations from ORLEANS:StopArea:TMOUIL1 Mouillère contradict the riding order ORLEANS:StopArea:THOPIT2 .. ORLEANS:StopArea:TVERNE1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TLAMBA1 Lamballe",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TLAMBA1 Lamballe is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TLAMBA1 Lamballe is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "the destinations from ORLEANS:StopArea:TLAMBA1 Lamballe contradict the riding order ORLEANS:StopArea:THOPIT2 .. ORLEANS:StopArea:TVERNE1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THOPAC1 Hôpital-Accueil",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THOPAC1 Hôpital-Accueil is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THOPAC1 Hôpital-Accueil is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC1",
+          "text": "the destinations from ORLEANS:StopArea:THOPAC1 Hôpital-Accueil contradict the riding order ORLEANS:StopArea:THOPAC1 .. ORLEANS:StopArea:TVERNE2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TCSMAR1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TCSMAR1 Saint-Marceau",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TCSMAR1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TCSMAR1 Saint-Marceau is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TCSMAR1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TCSMAR1 Saint-Marceau is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TCSMAR1",
+          "text": "the destinations from ORLEANS:StopArea:TCSMAR1 Saint-Marceau contradict the riding order ORLEANS:StopArea:THOPAC1 .. ORLEANS:StopArea:TVERNE2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TLAMBA1 Lamballe",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TLAMBA1 Lamballe is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TLAMBA1 Lamballe is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "the destinations from ORLEANS:StopArea:TLAMBA1 Lamballe contradict the riding order ORLEANS:StopArea:THOPAC1 .. ORLEANS:StopArea:TVERNE2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THOPAC1 Hôpital-Accueil",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THOPAC1 Hôpital-Accueil is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THOPAC1 Hôpital-Accueil is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC1",
+          "text": "the destinations from ORLEANS:StopArea:THOPAC1 Hôpital-Accueil contradict the riding order ORLEANS:StopArea:THOPAC1 .. ORLEANS:StopArea:TVERNE1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TCSMAR1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TCSMAR1 Saint-Marceau",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TCSMAR1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TCSMAR1 Saint-Marceau is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TCSMAR1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TCSMAR1 Saint-Marceau is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TCSMAR1",
+          "text": "the destinations from ORLEANS:StopArea:TCSMAR1 Saint-Marceau contradict the riding order ORLEANS:StopArea:THOPAC1 .. ORLEANS:StopArea:TVERNE1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TLAMBA1 Lamballe",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TLAMBA1 Lamballe is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TLAMBA1 Lamballe is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "the destinations from ORLEANS:StopArea:TLAMBA1 Lamballe contradict the riding order ORLEANS:StopArea:THOPAC1 .. ORLEANS:StopArea:TVERNE1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THOPIT1 Hôpital de La Source",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THOPIT1 Hôpital de La Source is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THOPIT1 Hôpital de La Source is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPIT1",
+          "text": "the destinations from ORLEANS:StopArea:THOPIT1 Hôpital de La Source contradict the riding order ORLEANS:StopArea:THOPIT1 .. ORLEANS:StopArea:TVERNE1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TMOUIL1 Mouillère",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TMOUIL1 Mouillère is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TMOUIL1 Mouillère is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL1",
+          "text": "the destinations from ORLEANS:StopArea:TMOUIL1 Mouillère contradict the riding order ORLEANS:StopArea:THOPIT1 .. ORLEANS:StopArea:TVERNE1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TLAMBA1 Lamballe",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TLAMBA1 Lamballe is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TLAMBA1 Lamballe is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLAMBA1",
+          "text": "the destinations from ORLEANS:StopArea:TLAMBA1 Lamballe contradict the riding order ORLEANS:StopArea:THOPIT1 .. ORLEANS:StopArea:TVERNE1"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-A-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:A"
     },
     {
       "checks": [
@@ -13528,144 +17761,23 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "ORLEANS:StopArea:TAUBRA1": [
-              "22",
-              "23"
-            ],
-            "ORLEANS:StopArea:TAULNA1": [
-              "7",
-              "8"
-            ],
-            "ORLEANS:StopArea:TBOLIE1": [
-              "1",
-              "2"
-            ],
-            "ORLEANS:StopArea:TBUSTI1": [
-              "23",
-              "24"
-            ],
-            "ORLEANS:StopArea:TCAMPU1": [
-              "5",
-              "6"
-            ],
-            "ORLEANS:StopArea:TCOLIG1": [
-              "20",
-              "21"
-            ],
-            "ORLEANS:StopArea:TCOMET1": [
-              "11",
-              "12"
-            ],
-            "ORLEANS:StopArea:TCSMAR1": [
-              "13",
-              "14"
-            ],
-            "ORLEANS:StopArea:TFLORA1": [
-              "4",
-              "5"
-            ],
-            "ORLEANS:StopArea:TGARDO1": [
-              "18",
-              "19"
-            ],
-            "ORLEANS:StopArea:TGAULA1": [
-              "16",
-              "17"
-            ],
-            "ORLEANS:StopArea:THOPAC1": [
-              "0",
-              "1"
-            ],
-            "ORLEANS:StopArea:TINDIE1": [
-              "3",
-              "4"
-            ],
-            "ORLEANS:StopArea:TLAMBA1": [
-              "24",
-              "25"
-            ],
-            "ORLEANS:StopArea:TLARRY1": [
-              "8",
-              "9"
-            ],
-            "ORLEANS:StopArea:TLBRAL1": [
-              "19",
-              "20"
-            ],
-            "ORLEANS:StopArea:TLIBER1": [
-              "21",
-              "22"
-            ],
-            "ORLEANS:StopArea:TLORET1": [
-              "6",
-              "7"
-            ],
-            "ORLEANS:StopArea:TMOUIL1": [
-              "12",
-              "13"
-            ],
-            "ORLEANS:StopArea:TPOSTA1": [
-              "2",
-              "3"
-            ],
-            "ORLEANS:StopArea:TREPUB1": [
-              "17",
-              "18"
-            ],
-            "ORLEANS:StopArea:TROYAL1": [
-              "15",
-              "16"
-            ],
-            "ORLEANS:StopArea:TTOURE1": [
-              "14",
-              "15"
-            ],
-            "ORLEANS:StopArea:TVERNE1": [
-              "25",
-              "26"
-            ],
-            "ORLEANS:StopArea:TVERNE2": [
-              "25",
-              "26"
-            ],
-            "ORLEANS:StopArea:TVHUGO1": [
-              "9",
-              "10"
-            ],
-            "ORLEANS:StopArea:TZENIT1": [
-              "10",
-              "11"
-            ]
-          },
-          "text": "the stop list offers a stop twice: ORLEANS:StopArea:THOPAC1 Hôpital-Accueil at 0 and 1, ORLEANS:StopArea:TBOLIE1 Bolière at 1 and 2, ORLEANS:StopArea:TPOSTA1 Chèques Postaux - Michel Ricoud at 2 and 3, and 24 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
           "folded": [
             [
-              "ORLEANS:StopArea:THOPIT2",
-              "ORLEANS:StopArea:THOPIT1"
-            ],
-            [
-              "ORLEANS:StopArea:TZENIT1",
-              "ORLEANS:StopArea:TZENIT1"
-            ],
-            [
-              "ORLEANS:StopArea:TVERNE2",
-              "ORLEANS:StopArea:TVERNE1"
+              "ORLEANS:StopArea:THOPIT1",
+              "ORLEANS:StopArea:THOPIT2"
             ],
             [
               "ORLEANS:StopArea:TVERNE1",
               "ORLEANS:StopArea:TVERNE2"
-            ],
-            [
-              "ORLEANS:StopArea:TVERNE2",
-              "ORLEANS:StopArea:TVERNE1"
             ]
           ],
           "ok": false,
-          "text": "the list offers one station twice in a row: ORLEANS:StopArea:THOPIT2 Hôpital de La Source then ORLEANS:StopArea:THOPIT1 Hôpital de La Source, ORLEANS:StopArea:TZENIT1 Zénith then ORLEANS:StopArea:TZENIT1 Zénith, ORLEANS:StopArea:TVERNE2 Jules Verne then ORLEANS:StopArea:TVERNE1 Jules Verne, and 2 more"
+          "text": "the list offers one station twice in a row: ORLEANS:StopArea:THOPIT1 Hôpital de La Source then ORLEANS:StopArea:THOPIT2 Hôpital de La Source, ORLEANS:StopArea:TVERNE1 Jules Verne then ORLEANS:StopArea:TVERNE2 Jules Verne"
         },
         {
           "ok": true,
@@ -13727,7 +17839,7 @@
       "id": "tao-journeys-A-d0-stop_list",
       "kind": "stop_list",
       "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "reason": "two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)",
       "route": "ORLEANS:Line:A"
     },
     {
@@ -14038,6 +18150,293 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TVERNE2 Jules Verne",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TVERNE2 Jules Verne is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TVERNE2 Jules Verne is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE2",
+          "text": "the destinations from ORLEANS:StopArea:TVERNE2 Jules Verne contradict the riding order ORLEANS:StopArea:TVERNE2 .. ORLEANS:StopArea:THOPIT2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TMOUIL2 Mouillère",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TMOUIL2 Mouillère is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TMOUIL2 Mouillère is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "text": "the destinations from ORLEANS:StopArea:TMOUIL2 Mouillère contradict the riding order ORLEANS:StopArea:TVERNE2 .. ORLEANS:StopArea:THOPIT2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "text": "the destinations from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil contradict the riding order ORLEANS:StopArea:TVERNE2 .. ORLEANS:StopArea:THOPIT2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TVERNE2 Jules Verne",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TVERNE2 Jules Verne is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TVERNE2 Jules Verne is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE2",
+          "text": "the destinations from ORLEANS:StopArea:TVERNE2 Jules Verne contradict the riding order ORLEANS:StopArea:TVERNE2 .. ORLEANS:StopArea:THOPIT1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TMOUIL2 Mouillère",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TMOUIL2 Mouillère is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TMOUIL2 Mouillère is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "text": "the destinations from ORLEANS:StopArea:TMOUIL2 Mouillère contradict the riding order ORLEANS:StopArea:TVERNE2 .. ORLEANS:StopArea:THOPIT1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "text": "the destinations from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil contradict the riding order ORLEANS:StopArea:TVERNE2 .. ORLEANS:StopArea:THOPIT1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TVERNE1 Jules Verne",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TVERNE1 Jules Verne is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TVERNE1 Jules Verne is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE1",
+          "text": "the destinations from ORLEANS:StopArea:TVERNE1 Jules Verne contradict the riding order ORLEANS:StopArea:TVERNE1 .. ORLEANS:StopArea:THOPIT1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TMOUIL2 Mouillère",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TMOUIL2 Mouillère is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TMOUIL2 Mouillère is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "text": "the destinations from ORLEANS:StopArea:TMOUIL2 Mouillère contradict the riding order ORLEANS:StopArea:TVERNE1 .. ORLEANS:StopArea:THOPIT1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "text": "the destinations from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil contradict the riding order ORLEANS:StopArea:TVERNE1 .. ORLEANS:StopArea:THOPIT1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TVERNE1 Jules Verne",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TVERNE1 Jules Verne is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TVERNE1 Jules Verne is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TVERNE1",
+          "text": "the destinations from ORLEANS:StopArea:TVERNE1 Jules Verne contradict the riding order ORLEANS:StopArea:TVERNE1 .. ORLEANS:StopArea:THOPIT2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TMOUIL2 Mouillère",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TMOUIL2 Mouillère is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TMOUIL2 Mouillère is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TMOUIL2",
+          "text": "the destinations from ORLEANS:StopArea:TMOUIL2 Mouillère contradict the riding order ORLEANS:StopArea:TVERNE1 .. ORLEANS:StopArea:THOPIT2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THOPAC2",
+          "text": "the destinations from ORLEANS:StopArea:THOPAC2 Hôpital-Accueil contradict the riding order ORLEANS:StopArea:TVERNE1 .. ORLEANS:StopArea:THOPIT2"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-A-d1-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:A"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "ORLEANS:StopArea:THOPIT1",
             "direction": 1,
@@ -14296,16 +18695,16 @@
         {
           "folded": [
             [
-              "ORLEANS:StopArea:TVERNE2",
-              "ORLEANS:StopArea:TVERNE1"
+              "ORLEANS:StopArea:TVERNE1",
+              "ORLEANS:StopArea:TVERNE2"
             ],
             [
-              "ORLEANS:StopArea:THOPIT2",
-              "ORLEANS:StopArea:THOPIT1"
+              "ORLEANS:StopArea:THOPIT1",
+              "ORLEANS:StopArea:THOPIT2"
             ]
           ],
           "ok": false,
-          "text": "the list offers one station twice in a row: ORLEANS:StopArea:TVERNE2 Jules Verne then ORLEANS:StopArea:TVERNE1 Jules Verne, ORLEANS:StopArea:THOPIT2 Hôpital de La Source then ORLEANS:StopArea:THOPIT1 Hôpital de La Source"
+          "text": "the list offers one station twice in a row: ORLEANS:StopArea:TVERNE1 Jules Verne then ORLEANS:StopArea:TVERNE2 Jules Verne, ORLEANS:StopArea:THOPIT1 Hôpital de La Source then ORLEANS:StopArea:THOPIT2 Hôpital de La Source"
         },
         {
           "ok": true,
@@ -14349,7 +18748,7 @@
       "id": "tao-journeys-A-d1-stop_list",
       "kind": "stop_list",
       "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "reason": "two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)",
       "route": "ORLEANS:Line:A"
     },
     {
@@ -14566,6 +18965,293 @@
       "outcome": "xfailed",
       "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
       "route": "ORLEANS:Line:A"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TPOMPI2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TPOMPI2 Georges Pompidou",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TPOMPI2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TPOMPI2 Georges Pompidou is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TPOMPI2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TPOMPI2 Georges Pompidou is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TPOMPI2",
+          "text": "the destinations from ORLEANS:StopArea:TPOMPI2 Georges Pompidou contradict the riding order ORLEANS:StopArea:TPOMPI2 .. ORLEANS:StopArea:THAMEA1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THALMA2 Halmagrand",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THALMA2 Halmagrand is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THALMA2 Halmagrand is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA2",
+          "text": "the destinations from ORLEANS:StopArea:THALMA2 Halmagrand contradict the riding order ORLEANS:StopArea:TPOMPI2 .. ORLEANS:StopArea:THAMEA1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLBLUM2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TLBLUM2 Léon Blum",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLBLUM2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TLBLUM2 Léon Blum is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLBLUM2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TLBLUM2 Léon Blum is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLBLUM2",
+          "text": "the destinations from ORLEANS:StopArea:TLBLUM2 Léon Blum contradict the riding order ORLEANS:StopArea:TPOMPI2 .. ORLEANS:StopArea:THAMEA1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TPOMPI2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TPOMPI2 Georges Pompidou",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TPOMPI2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TPOMPI2 Georges Pompidou is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TPOMPI2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TPOMPI2 Georges Pompidou is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TPOMPI2",
+          "text": "the destinations from ORLEANS:StopArea:TPOMPI2 Georges Pompidou contradict the riding order ORLEANS:StopArea:TPOMPI2 .. ORLEANS:StopArea:THAMEA2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THALMA2 Halmagrand",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THALMA2 Halmagrand is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THALMA2 Halmagrand is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA2",
+          "text": "the destinations from ORLEANS:StopArea:THALMA2 Halmagrand contradict the riding order ORLEANS:StopArea:TPOMPI2 .. ORLEANS:StopArea:THAMEA2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLBLUM2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TLBLUM2 Léon Blum",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLBLUM2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TLBLUM2 Léon Blum is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLBLUM2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TLBLUM2 Léon Blum is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLBLUM2",
+          "text": "the destinations from ORLEANS:StopArea:TLBLUM2 Léon Blum contradict the riding order ORLEANS:StopArea:TPOMPI2 .. ORLEANS:StopArea:THAMEA2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TPOMPI2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TPOMPI2 Georges Pompidou",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TPOMPI2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TPOMPI2 Georges Pompidou is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TPOMPI2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TPOMPI2 Georges Pompidou is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TPOMPI2",
+          "text": "the destinations from ORLEANS:StopArea:TPOMPI2 Georges Pompidou contradict the riding order ORLEANS:StopArea:TPOMPI2 .. ORLEANS:StopArea:TAMBER2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGAULB2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TGAULB2 De Gaulle",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGAULB2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TGAULB2 De Gaulle is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGAULB2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TGAULB2 De Gaulle is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGAULB2",
+          "text": "the destinations from ORLEANS:StopArea:TGAULB2 De Gaulle contradict the riding order ORLEANS:StopArea:TPOMPI2 .. ORLEANS:StopArea:TAMBER2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGVILL2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TGVILL2 Grand Villiers",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGVILL2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TGVILL2 Grand Villiers is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGVILL2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TGVILL2 Grand Villiers is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGVILL2",
+          "text": "the destinations from ORLEANS:StopArea:TGVILL2 Grand Villiers contradict the riding order ORLEANS:StopArea:TPOMPI2 .. ORLEANS:StopArea:TAMBER2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGAUBR2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TGAUBR2 Gaudier-Brzeska",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGAUBR2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TGAUBR2 Gaudier-Brzeska is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGAUBR2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TGAUBR2 Gaudier-Brzeska is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGAUBR2",
+          "text": "the destinations from ORLEANS:StopArea:TGAUBR2 Gaudier-Brzeska contradict the riding order ORLEANS:StopArea:TGAUBR2 .. ORLEANS:StopArea:THAMEA1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TCLARC2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TCLARC2 Clos de l'Arche",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TCLARC2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TCLARC2 Clos de l'Arche is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TCLARC2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TCLARC2 Clos de l'Arche is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TCLARC2",
+          "text": "the destinations from ORLEANS:StopArea:TCLARC2 Clos de l'Arche contradict the riding order ORLEANS:StopArea:TGAUBR2 .. ORLEANS:StopArea:THAMEA1"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLBLUM2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TLBLUM2 Léon Blum",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLBLUM2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TLBLUM2 Léon Blum is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLBLUM2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TLBLUM2 Léon Blum is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TLBLUM2",
+          "text": "the destinations from ORLEANS:StopArea:TLBLUM2 Léon Blum contradict the riding order ORLEANS:StopArea:TGAUBR2 .. ORLEANS:StopArea:THAMEA1"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-B-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:B"
     },
     {
       "checks": [
@@ -14821,44 +19507,19 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "ORLEANS:StopArea:TCLARC2": [
-              "3",
-              "22"
-            ],
-            "ORLEANS:StopArea:TGAUBR2": [
-              "0",
-              "19"
-            ],
-            "ORLEANS:StopArea:THAMEA1": [
-              "5",
-              "24"
-            ],
-            "ORLEANS:StopArea:TLBLUM2": [
-              "4",
-              "23"
-            ],
-            "ORLEANS:StopArea:TPTBOR2": [
-              "1",
-              "20"
-            ],
-            "ORLEANS:StopArea:TVERVI2": [
-              "2",
-              "21"
-            ]
-          },
-          "text": "the stop list offers a stop twice: ORLEANS:StopArea:TGAUBR2 Gaudier-Brzeska at 0 and 19, ORLEANS:StopArea:TPTBOR2 Pont Bordeau at 1 and 20, ORLEANS:StopArea:TVERVI2 Verville at 2 and 21, and 3 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
           "folded": [
             [
-              "ORLEANS:StopArea:THAMEA1",
-              "ORLEANS:StopArea:THAMEA2"
+              "ORLEANS:StopArea:THAMEA2",
+              "ORLEANS:StopArea:THAMEA1"
             ]
           ],
           "ok": false,
-          "text": "the list offers one station twice in a row: ORLEANS:StopArea:THAMEA1 Clos du Hameau then ORLEANS:StopArea:THAMEA2 Clos du Hameau"
+          "text": "the list offers one station twice in a row: ORLEANS:StopArea:THAMEA2 Clos du Hameau then ORLEANS:StopArea:THAMEA1 Clos du Hameau"
         },
         {
           "ok": true,
@@ -14902,7 +19563,7 @@
       "id": "tao-journeys-B-d0-stop_list",
       "kind": "stop_list",
       "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "reason": "two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)",
       "route": "ORLEANS:Line:B"
     },
     {
@@ -15111,6 +19772,224 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THAMEA1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THAMEA1 Clos du Hameau",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THAMEA1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THAMEA1 Clos du Hameau is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THAMEA1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THAMEA1 Clos du Hameau is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THAMEA1",
+          "text": "the destinations from ORLEANS:StopArea:THAMEA1 Clos du Hameau contradict the riding order ORLEANS:StopArea:THAMEA1 .. ORLEANS:StopArea:TPOMPI2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THALMA1 Halmagrand",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THALMA1 Halmagrand is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THALMA1 Halmagrand is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA1",
+          "text": "the destinations from ORLEANS:StopArea:THALMA1 Halmagrand contradict the riding order ORLEANS:StopArea:THAMEA1 .. ORLEANS:StopArea:TPOMPI2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TTFONT1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TTFONT1 Trois Fontaines",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TTFONT1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TTFONT1 Trois Fontaines is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TTFONT1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TTFONT1 Trois Fontaines is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TTFONT1",
+          "text": "the destinations from ORLEANS:StopArea:TTFONT1 Trois Fontaines contradict the riding order ORLEANS:StopArea:THAMEA1 .. ORLEANS:StopArea:TPOMPI2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TAMBER1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TAMBER1 Ambert",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TAMBER1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TAMBER1 Ambert is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TAMBER1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TAMBER1 Ambert is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TAMBER1",
+          "text": "the destinations from ORLEANS:StopArea:TAMBER1 Ambert contradict the riding order ORLEANS:StopArea:TAMBER1 .. ORLEANS:StopArea:TPOMPI2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGAULB1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TGAULB1 De Gaulle",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGAULB1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TGAULB1 De Gaulle is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGAULB1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TGAULB1 De Gaulle is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TGAULB1",
+          "text": "the destinations from ORLEANS:StopArea:TGAULB1 De Gaulle contradict the riding order ORLEANS:StopArea:TAMBER1 .. ORLEANS:StopArea:TPOMPI2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TTFONT1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TTFONT1 Trois Fontaines",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TTFONT1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TTFONT1 Trois Fontaines is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TTFONT1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TTFONT1 Trois Fontaines is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TTFONT1",
+          "text": "the destinations from ORLEANS:StopArea:TTFONT1 Trois Fontaines contradict the riding order ORLEANS:StopArea:TAMBER1 .. ORLEANS:StopArea:TPOMPI2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THAMEA2",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THAMEA2 Clos du Hameau",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THAMEA2",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THAMEA2 Clos du Hameau is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THAMEA2",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THAMEA2 Clos du Hameau is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THAMEA2",
+          "text": "the destinations from ORLEANS:StopArea:THAMEA2 Clos du Hameau contradict the riding order ORLEANS:StopArea:THAMEA2 .. ORLEANS:StopArea:TPOMPI2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:THALMA1 Halmagrand",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:THALMA1 Halmagrand is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:THALMA1 Halmagrand is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:THALMA1",
+          "text": "the destinations from ORLEANS:StopArea:THALMA1 Halmagrand contradict the riding order ORLEANS:StopArea:THAMEA2 .. ORLEANS:StopArea:TPOMPI2"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TTFONT1",
+          "text": "a destination is offered twice from ORLEANS:StopArea:TTFONT1 Trois Fontaines",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TTFONT1",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:TTFONT1 Trois Fontaines is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TTFONT1",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:TTFONT1 Trois Fontaines is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:TTFONT1",
+          "text": "the destinations from ORLEANS:StopArea:TTFONT1 Trois Fontaines contradict the riding order ORLEANS:StopArea:THAMEA2 .. ORLEANS:StopArea:TPOMPI2"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-B-d1-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:B"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "ORLEANS:StopArea:TPOMPI2",
             "direction": 1,
@@ -15302,91 +20181,19 @@
     {
       "checks": [
         {
-          "ok": false,
-          "repeated": {
-            "ORLEANS:StopArea:TAMBER1": [
-              "0",
-              "6"
-            ],
-            "ORLEANS:StopArea:TBEAUM1": [
-              "12",
-              "18"
-            ],
-            "ORLEANS:StopArea:TCAHDV1": [
-              "7",
-              "13"
-            ],
-            "ORLEANS:StopArea:TCXMOR1": [
-              "10",
-              "16"
-            ],
-            "ORLEANS:StopArea:TDRHOM1": [
-              "3",
-              "9"
-            ],
-            "ORLEANS:StopArea:TGAULB1": [
-              "9",
-              "15"
-            ],
-            "ORLEANS:StopArea:TGVILL1": [
-              "1",
-              "7"
-            ],
-            "ORLEANS:StopArea:THALMA1": [
-              "6",
-              "12"
-            ],
-            "ORLEANS:StopArea:TJDARC1": [
-              "8",
-              "14"
-            ],
-            "ORLEANS:StopArea:TMADEL1": [
-              "11",
-              "17"
-            ],
-            "ORLEANS:StopArea:TMLKIN1": [
-              "16",
-              "22"
-            ],
-            "ORLEANS:StopArea:TMOZAR1": [
-              "2",
-              "8"
-            ],
-            "ORLEANS:StopArea:TPEURO1": [
-              "14",
-              "20"
-            ],
-            "ORLEANS:StopArea:TPOMPI2": [
-              "18",
-              "24"
-            ],
-            "ORLEANS:StopArea:TPTDUN1": [
-              "13",
-              "19"
-            ],
-            "ORLEANS:StopArea:TRIOBE1": [
-              "4",
-              "10"
-            ],
-            "ORLEANS:StopArea:TTANGU1": [
-              "15",
-              "21"
-            ],
-            "ORLEANS:StopArea:TTFONT1": [
-              "17",
-              "23"
-            ],
-            "ORLEANS:StopArea:TVIGNA1": [
-              "5",
-              "11"
-            ]
-          },
-          "text": "the stop list offers a stop twice: ORLEANS:StopArea:TAMBER1 Ambert at 0 and 6, ORLEANS:StopArea:TGVILL1 Grand Villiers at 1 and 7, ORLEANS:StopArea:TMOZAR1 Mozart at 2 and 8, and 16 more"
+          "ok": true,
+          "repeated": {},
+          "text": "the stop list offers a stop twice"
         },
         {
-          "folded": [],
-          "ok": true,
-          "text": "the list offers one station twice in a row"
+          "folded": [
+            [
+              "ORLEANS:StopArea:THAMEA2",
+              "ORLEANS:StopArea:THAMEA1"
+            ]
+          ],
+          "ok": false,
+          "text": "the list offers one station twice in a row: ORLEANS:StopArea:THAMEA2 Clos du Hameau then ORLEANS:StopArea:THAMEA1 Clos du Hameau"
         },
         {
           "ok": true,
@@ -15421,7 +20228,7 @@
       "id": "tao-journeys-B-d1-stop_list",
       "kind": "stop_list",
       "outcome": "xfailed",
-      "reason": "the stop selector offers a stop twice or out of riding order (discussion #198)",
+      "reason": "two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)",
       "route": "ORLEANS:Line:B"
     },
     {
@@ -15585,6 +20392,86 @@
     {
       "checks": [
         {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01086001",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01086001 Résidence Universitaire",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01086001",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01086001 Résidence Universitaire is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01086001",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01086001 Résidence Universitaire is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01086001",
+          "text": "the destinations from ORLEANS:StopArea:01086001 Résidence Universitaire contradict the riding order ORLEANS:StopArea:01086001 .. ORLEANS:StopArea:01002003"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00041020",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00041020 Poterne",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00041020",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00041020 Poterne is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00041020",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00041020 Poterne is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00041020",
+          "text": "the destinations from ORLEANS:StopArea:00041020 Poterne contradict the riding order ORLEANS:StopArea:01086001 .. ORLEANS:StopArea:01002003"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01002004",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01002004 Libération-Interives",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01002004",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01002004 Libération-Interives is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01002004",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01002004 Libération-Interives is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01002004",
+          "text": "the destinations from ORLEANS:StopArea:01002004 Libération-Interives contradict the riding order ORLEANS:StopArea:01086001 .. ORLEANS:StopArea:01002003"
+        }
+      ],
+      "direction": 0,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-N-d0-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
+      "route": "ORLEANS:Line:N"
+    },
+    {
+      "checks": [
+        {
           "asked": {
             "destination": "ORLEANS:StopArea:01002003",
             "direction": 0,
@@ -15743,6 +20630,86 @@
       "kind": "swapped",
       "outcome": "xfailed",
       "reason": "the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction",
+      "route": "ORLEANS:Line:N"
+    },
+    {
+      "checks": [
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01002003",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01002003 Libération-Interives",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01002003",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01002003 Libération-Interives is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01002003",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01002003 Libération-Interives is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01002003",
+          "text": "the destinations from ORLEANS:StopArea:01002003 Libération-Interives contradict the riding order ORLEANS:StopArea:01002003 .. ORLEANS:StopArea:01086001"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01078703",
+          "text": "a destination is offered twice from ORLEANS:StopArea:01078703 Les Halles",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01078703",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:01078703 Les Halles is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01078703",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:01078703 Les Halles is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:01078703",
+          "text": "the destinations from ORLEANS:StopArea:01078703 Les Halles contradict the riding order ORLEANS:StopArea:01002003 .. ORLEANS:StopArea:01086001"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00004730",
+          "text": "a destination is offered twice from ORLEANS:StopArea:00004730 L'Indien",
+          "twice": []
+        },
+        {
+          "missing": [],
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00004730",
+          "text": "a stop this ride reaches from ORLEANS:StopArea:00004730 L'Indien is not offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00004730",
+          "stray": [],
+          "text": "a destination no trip reaches from ORLEANS:StopArea:00004730 L'Indien is offered"
+        },
+        {
+          "ok": true,
+          "origin": "ORLEANS:StopArea:00004730",
+          "text": "the destinations from ORLEANS:StopArea:00004730 L'Indien contradict the riding order ORLEANS:StopArea:01002003 .. ORLEANS:StopArea:01086001"
+        }
+      ],
+      "direction": 1,
+      "fixture": "tao-journeys",
+      "id": "tao-journeys-N-d1-destinations",
+      "kind": "destinations",
+      "outcome": "passed",
+      "reason": null,
       "route": "ORLEANS:Line:N"
     },
     {

--- a/tests_provider/results.txt
+++ b/tests_provider/results.txt
@@ -1,15 +1,18 @@
-test_journeys.py case results -- 95 case(s)
+test_journeys.py case results -- 124 case(s)
+
+case: gvb-1-d0-destinations
+  result: PASSED
 
 case: gvb-1-d0-pairs
   result: PASSED
 
 case: gvb-1-d0-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 4138837 Amsterdam, Leidseplein at 1 and 4 and 16 and 19, 3979966 Amsterdam, Rhijnvis Feithstraat at 1 and 13, 3980187 Amsterdam, Rijksmuseum at 2 and 5 and 17 and 20, and 12 more
+  result: PASSED
 
 case: gvb-1-d0-swapped
+  result: PASSED
+
+case: gvb-1-d1-destinations
   result: PASSED
 
 case: gvb-1-d1-pairs
@@ -17,37 +20,38 @@ case: gvb-1-d1-pairs
 
 case: gvb-1-d1-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list offers a stop twice: 3979966 Amsterdam, Rhijnvis Feithstraat at 1 and 2, 3979725 Amsterdam, Surinameplein at 1 and 16 and 19, 3980938 Amsterdam, Jan Pieter Heijestraat at 2 and 3, and 24 more
-    the list offers one station twice in a row: 3979766 Amsterdam, Weesperplein then 3980631 Amsterdam, Weesperplein
+    the list offers one station twice in a row: 3979810 Amsterdam, Azartplein then 3980295 Amsterdam, Azartplein
 
 case: gvb-1-d1-swapped
+  result: PASSED
+
+case: gvb-13-d0-destinations
   result: PASSED
 
 case: gvb-13-d0-pairs
   result: PASSED
 
 case: gvb-13-d0-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 3979794 Amsterdam, Mercatorplein at 1 and 10, 3980464 Amsterdam, Marco Polostraat at 2 and 11, 3980544 Amsterdam, Admiraal de Ruijterweg at 3 and 12, and 10 more
-    the list offers one station twice in a row: 3980268 Amsterdam, Elandsgracht then 3980182 Amsterdam, Elandsgracht
+  result: PASSED
 
 case: gvb-13-d0-swapped
+  result: PASSED
+
+case: gvb-13-d1-destinations
   result: PASSED
 
 case: gvb-13-d1-pairs
   result: PASSED
 
 case: gvb-13-d1-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 3980794 Amsterdam, Admiraal Helfrichstraat at 1 and 14, 3980974 Amsterdam, Jan Voermanstraat at 2 and 15, 3980162 Amsterdam, Jan Tooropstraat at 3 and 16, and 6 more
+  result: PASSED
 
 case: gvb-13-d1-swapped
+  result: PASSED
+
+case: gvb-14-d0-destinations
   result: PASSED
 
 case: gvb-14-d0-pairs
@@ -55,12 +59,14 @@ case: gvb-14-d0-pairs
 
 case: gvb-14-d0-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list offers a stop twice: 3981274 Amsterdam, Centraal Station at 1 and 16, 3979805 Amsterdam, Mauritskade at 1 and 9, 3980549 Amsterdam, Mauritskade at 1 and 8, and 16 more
-    the list offers one station twice in a row: 3980489 Amsterdam, Dam then 3980251 Amsterdam, Dam, 3981274 Amsterdam, Centraal Station then 4045456 Amsterdam, Centraal Station
+    the list offers one station twice in a row: 3980992 Amsterdam, Flevopark then 3980163 Amsterdam, Flevopark, 3980251 Amsterdam, Dam then 3980489 Amsterdam, Dam
 
 case: gvb-14-d0-swapped
+  result: PASSED
+
+case: gvb-14-d1-destinations
   result: PASSED
 
 case: gvb-14-d1-pairs
@@ -68,54 +74,45 @@ case: gvb-14-d1-pairs
 
 case: gvb-14-d1-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list offers a stop twice: 3980549 Amsterdam, Mauritskade at 1 and 7 and 8, 3980234 Amsterdam, Javaplein at 1 and 4 and 12, 3981274 Amsterdam, Centraal Station at 1 and 9 and 15 and 16, and 14 more
-    the list offers one station twice in a row: 4045456 Amsterdam, Centraal Station then 3981274 Amsterdam, Centraal Station, 3980234 Amsterdam, Javaplein then 3981356 Amsterdam, Javaplein, 3979768 Amsterdam, Plantage Lepellaan then 3981148 Amsterdam, Plantage Lepellaan
-    the list contradicts the riding order 3980234 .. 3981274
-    the list contradicts the riding order 3981274 .. 3980992
+    the list offers one station twice in a row: 3980992 Amsterdam, Flevopark then 3980163 Amsterdam, Flevopark
 
 case: gvb-14-d1-swapped
+  result: PASSED
+
+case: gvb-17-d0-destinations
   result: PASSED
 
 case: gvb-17-d0-pairs
   result: PASSED
 
 case: gvb-17-d0-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 3980305 Amsterdam, Corantijnstraat at 1 and 11, 3981271 Amsterdam, Centraal Station at 1 and 8 and 14 and 24, 3980599 Amsterdam, Leidseplein at 1 and 7 and 17, and 11 more
-    the list offers one station twice in a row: 3981140 Amsterdam, Witte de Withstraat then 3980752 Amsterdam, Witte de Withstraat
-    the list contradicts the riding order 3981271 .. 4132580
+  result: PASSED
 
 case: gvb-17-d0-swapped
+  result: PASSED
+
+case: gvb-17-d1-destinations
   result: PASSED
 
 case: gvb-17-d1-pairs
   result: PASSED
 
 case: gvb-17-d1-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 3981271 Amsterdam, Centraal Station at 1 and 8 and 15, 3979725 Amsterdam, Surinameplein at 1 and 15, 3980599 Amsterdam, Leidseplein at 1 and 8, and 15 more
-    the list offers one station twice in a row: 3980573 Amsterdam, Koningsplein then 3980418 Amsterdam, Koningsplein
-    the list contradicts the riding order 3981271 .. 3980351
+  result: PASSED
 
 case: gvb-17-d1-swapped
+  result: PASSED
+
+case: gvb-7-d0-destinations
   result: PASSED
 
 case: gvb-7-d0-pairs
   result: PASSED
 
 case: gvb-7-d0-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 3980004 Amsterdam, Frederiksplein at 1 and 11, 3980102 Amsterdam, Sloterpark at 1 and 20 and 30, 3981181 Amsterdam, Frederiksplein at 1 and 19, and 22 more
-    the list offers one station twice in a row: 3980060 Amsterdam, Willem Schoutenstraat then 3980854 Amsterdam, Willem Schoutenstraat
-    the list contradicts the riding order 3980102 .. 3979878
+  result: PASSED
 
 case: gvb-7-d0-swapped
   result: XFAILED
@@ -123,22 +120,23 @@ case: gvb-7-d0-swapped
   detail:
     asked 3979878 -> 3980102 on 152328 d0 (stop 23 to stop 1 of a 23-stop ride, this direction does not make it): got 3979878 -> 3980102 on 152328 d1, trip 380799628
 
+case: gvb-7-d1-destinations
+  result: PASSED
+
 case: gvb-7-d1-pairs
   result: PASSED
 
 case: gvb-7-d1-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 3980102 Amsterdam, Sloterpark at 1 and 20 and 24, 3981181 Amsterdam, Frederiksplein at 1 and 19, 3980004 Amsterdam, Frederiksplein at 1 and 5, and 28 more
-    the list offers one station twice in a row: 3980752 Amsterdam, Witte de Withstraat then 3981140 Amsterdam, Witte de Withstraat
-    the list contradicts the riding order 3980102 .. 3980992
+  result: PASSED
 
 case: gvb-7-d1-swapped
   result: XFAILED
   reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
   detail:
     asked 3980102 -> 3979878 on 152328 d1 (stop 24 to stop 1 of a 24-stop ride, this direction does not make it): got 3980102 -> 3979878 on 152328 d0, trip 380799711
+
+case: palmbus-21-d0-destinations
+  result: PASSED
 
 case: palmbus-21-d0-pairs
   result: PASSED
@@ -149,16 +147,19 @@ case: palmbus-21-d0-stop_list
 case: palmbus-21-d0-swapped
   result: PASSED
 
+case: palmbus-22-d0-destinations
+  result: PASSED
+
 case: palmbus-22-d0-pairs
   result: PASSED
 
 case: palmbus-22-d0-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
-  detail:
-    the stop list offers a stop twice: THEC0A Théoule Plages at 1 and 13, ISL22R Le Princes des Iles at 2 and 14, THEG0A Théoule Gare at 3 and 15, and 24 more
+  result: PASSED
 
 case: palmbus-22-d0-swapped
+  result: PASSED
+
+case: palmbus-22-d1-destinations
   result: PASSED
 
 case: palmbus-22-d1-pairs
@@ -168,6 +169,9 @@ case: palmbus-22-d1-stop_list
   result: PASSED
 
 case: palmbus-22-d1-swapped
+  result: PASSED
+
+case: palmbus-A-d0-destinations
   result: PASSED
 
 case: palmbus-A-d0-pairs
@@ -182,6 +186,9 @@ case: palmbus-A-d0-swapped
   detail:
     asked GSNF0A -> CCO15A on A d0 (stop 35 to stop 1 of a 35-stop ride, this direction does not make it): got GSNF0A -> CCO15A on A d1, trip 1418363764878
 
+case: palmbus-A-d1-destinations
+  result: PASSED
+
 case: palmbus-A-d1-pairs
   result: PASSED
 
@@ -193,6 +200,9 @@ case: palmbus-A-d1-swapped
   reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
   detail:
     asked CCO15A -> GSNF0A on A d1 (stop 36 to stop 1 of a 36-stop ride, this direction does not make it): got CCO15A -> GSNF0A on A d0, trip 1418363764404
+
+case: palmbus-B-d0-destinations
+  result: PASSED
 
 case: palmbus-B-d0-pairs
   result: PASSED
@@ -206,14 +216,14 @@ case: palmbus-B-d0-swapped
   detail:
     asked MSCE0A -> GSNF0R on B d0 (stop 29 to stop 1 of a 29-stop ride, this direction does not make it): got MSCE0A -> GSNF0R on B d1, trip 1418363764159
 
+case: palmbus-B-d1-destinations
+  result: PASSED
+
 case: palmbus-B-d1-pairs
   result: PASSED
 
 case: palmbus-B-d1-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
-  detail:
-    the stop list offers a stop twice: TOUR0A Tournamy at 1 and 5, BLAN0C Blanchisserie at 1 and 7 and 11, OLI01A L'Olivet at 1 and 5 and 11 and 15, and 20 more
+  result: PASSED
 
 case: palmbus-B-d1-swapped
   result: XFAILED
@@ -266,6 +276,9 @@ case: sncf-journeys-P8(CDD3F95:)-d1-pairs
     asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 8 of a 8-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
     asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 5 of a 5-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
 
+case: tao-journeys-22-d0-destinations
+  result: PASSED
+
 case: tao-journeys-22-d0-pairs
   result: PASSED
 
@@ -273,6 +286,9 @@ case: tao-journeys-22-d0-stop_list
   result: PASSED
 
 case: tao-journeys-22-d0-swapped
+  result: PASSED
+
+case: tao-journeys-22-d1-destinations
   result: PASSED
 
 case: tao-journeys-22-d1-pairs
@@ -284,14 +300,14 @@ case: tao-journeys-22-d1-stop_list
 case: tao-journeys-22-d1-swapped
   result: PASSED
 
+case: tao-journeys-40-d0-destinations
+  result: PASSED
+
 case: tao-journeys-40-d0-pairs
   result: PASSED
 
 case: tao-journeys-40-d0-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
-  detail:
-    the stop list offers a stop twice: ORLEANS:StopArea:00007923 Chèques Postaux - M. Ricoud - Quai C at 0 and 10, ORLEANS:StopArea:00034303 Montesquieu at 1 and 11, ORLEANS:StopArea:01036003 Théâtre Philipe at 2 and 12, and 12 more
+  result: PASSED
 
 case: tao-journeys-40-d0-swapped
   result: XFAILED
@@ -300,20 +316,23 @@ case: tao-journeys-40-d0-swapped
     asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d0 (stop 15 to stop 1 of a 15-stop ride, this direction does not make it): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001
     asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401
 
+case: tao-journeys-40-d1-destinations
+  result: PASSED
+
 case: tao-journeys-40-d1-pairs
   result: PASSED
 
 case: tao-journeys-40-d1-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
-  detail:
-    the stop list offers a stop twice: ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis at 0 and 1, ORLEANS:StopArea:00019303 Halmagrand at 1 and 2, ORLEANS:StopArea:00005401 Carré St-Vincent at 2 and 3, and 23 more
+  result: PASSED
 
 case: tao-journeys-40-d1-swapped
   result: XFAILED
   reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
   detail:
     asked ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d1 (stop 26 to stop 1 of a 26-stop ride, this direction does not make it): got ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0, trip ORLEANS:VehicleJourney:40_A_86_10_4002_1_070100
+
+case: tao-journeys-41-d0-destinations
+  result: PASSED
 
 case: tao-journeys-41-d0-pairs
   result: PASSED
@@ -322,6 +341,9 @@ case: tao-journeys-41-d0-stop_list
   result: PASSED
 
 case: tao-journeys-41-d0-swapped
+  result: PASSED
+
+case: tao-journeys-41-d1-destinations
   result: PASSED
 
 case: tao-journeys-41-d1-pairs
@@ -333,15 +355,17 @@ case: tao-journeys-41-d1-stop_list
 case: tao-journeys-41-d1-swapped
   result: PASSED
 
+case: tao-journeys-A-d0-destinations
+  result: PASSED
+
 case: tao-journeys-A-d0-pairs
   result: PASSED
 
 case: tao-journeys-A-d0-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)
   detail:
-    the stop list offers a stop twice: ORLEANS:StopArea:THOPAC1 Hôpital-Accueil at 0 and 1, ORLEANS:StopArea:TBOLIE1 Bolière at 1 and 2, ORLEANS:StopArea:TPOSTA1 Chèques Postaux - Michel Ricoud at 2 and 3, and 24 more
-    the list offers one station twice in a row: ORLEANS:StopArea:THOPIT2 Hôpital de La Source then ORLEANS:StopArea:THOPIT1 Hôpital de La Source, ORLEANS:StopArea:TZENIT1 Zénith then ORLEANS:StopArea:TZENIT1 Zénith, ORLEANS:StopArea:TVERNE2 Jules Verne then ORLEANS:StopArea:TVERNE1 Jules Verne, and 2 more
+    the list offers one station twice in a row: ORLEANS:StopArea:THOPIT1 Hôpital de La Source then ORLEANS:StopArea:THOPIT2 Hôpital de La Source, ORLEANS:StopArea:TVERNE1 Jules Verne then ORLEANS:StopArea:TVERNE2 Jules Verne
 
 case: tao-journeys-A-d0-swapped
   result: XFAILED
@@ -352,14 +376,17 @@ case: tao-journeys-A-d0-swapped
     asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900
     asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_468_10_A01_1_145630
 
+case: tao-journeys-A-d1-destinations
+  result: PASSED
+
 case: tao-journeys-A-d1-pairs
   result: PASSED
 
 case: tao-journeys-A-d1-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)
   detail:
-    the list offers one station twice in a row: ORLEANS:StopArea:TVERNE2 Jules Verne then ORLEANS:StopArea:TVERNE1 Jules Verne, ORLEANS:StopArea:THOPIT2 Hôpital de La Source then ORLEANS:StopArea:THOPIT1 Hôpital de La Source
+    the list offers one station twice in a row: ORLEANS:StopArea:TVERNE1 Jules Verne then ORLEANS:StopArea:TVERNE2 Jules Verne, ORLEANS:StopArea:THOPIT1 Hôpital de La Source then ORLEANS:StopArea:THOPIT2 Hôpital de La Source
 
 case: tao-journeys-A-d1-swapped
   result: XFAILED
@@ -370,15 +397,17 @@ case: tao-journeys-A-d1-swapped
     asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_467_10_A01_1_060100
     asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_466_10_A01_1_155930
 
+case: tao-journeys-B-d0-destinations
+  result: PASSED
+
 case: tao-journeys-B-d0-pairs
   result: PASSED
 
 case: tao-journeys-B-d0-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)
   detail:
-    the stop list offers a stop twice: ORLEANS:StopArea:TGAUBR2 Gaudier-Brzeska at 0 and 19, ORLEANS:StopArea:TPTBOR2 Pont Bordeau at 1 and 20, ORLEANS:StopArea:TVERVI2 Verville at 2 and 21, and 3 more
-    the list offers one station twice in a row: ORLEANS:StopArea:THAMEA1 Clos du Hameau then ORLEANS:StopArea:THAMEA2 Clos du Hameau
+    the list offers one station twice in a row: ORLEANS:StopArea:THAMEA2 Clos du Hameau then ORLEANS:StopArea:THAMEA1 Clos du Hameau
 
 case: tao-journeys-B-d0-swapped
   result: XFAILED
@@ -387,14 +416,17 @@ case: tao-journeys-B-d0-swapped
     asked ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_173_10_B01_1_055030
     asked ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_175_10_B09_1_201110
 
+case: tao-journeys-B-d1-destinations
+  result: PASSED
+
 case: tao-journeys-B-d1-pairs
   result: PASSED
 
 case: tao-journeys-B-d1-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)
   detail:
-    the stop list offers a stop twice: ORLEANS:StopArea:TAMBER1 Ambert at 0 and 6, ORLEANS:StopArea:TGVILL1 Grand Villiers at 1 and 7, ORLEANS:StopArea:TMOZAR1 Mozart at 2 and 8, and 16 more
+    the list offers one station twice in a row: ORLEANS:StopArea:THAMEA2 Clos du Hameau then ORLEANS:StopArea:THAMEA1 Clos du Hameau
 
 case: tao-journeys-B-d1-swapped
   result: XFAILED
@@ -402,6 +434,9 @@ case: tao-journeys-B-d1-swapped
   detail:
     asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d1 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_167_10_B01_1_050300
     asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d1 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_168_10_B06_1_195730
+
+case: tao-journeys-N-d0-destinations
+  result: PASSED
 
 case: tao-journeys-N-d0-pairs
   result: PASSED
@@ -414,6 +449,9 @@ case: tao-journeys-N-d0-swapped
   reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
   detail:
     asked ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d0 (stop 30 to stop 1 of a 30-stop ride, this direction does not make it): got ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d1, trip ORLEANS:VehicleJourney:N_R_16_21_2184_4_013000
+
+case: tao-journeys-N-d1-destinations
+  result: PASSED
 
 case: tao-journeys-N-d1-pairs
   result: PASSED

--- a/tests_provider/test_journeys.py
+++ b/tests_provider/test_journeys.py
@@ -7,6 +7,9 @@ fixture zip, with the clock pinned to a day the trips actually run:
     stop_list   each stop_id once, in an order every trip agrees with, and
                 one entry for two platforms of a place called one after the
                 other
+    destinations  from an origin, get_destination_stop_list offers every
+                stop a trip rides to after it, once, in riding order, and
+                nothing no trip through that origin reaches
     pairs       origin before destination on some trip: get_next_departure
                 answers it, on the right stops, in riding order, arriving no
                 earlier than it departs
@@ -16,7 +19,7 @@ fixture zip, with the clock pinned to a day the trips actually run:
 Trains (route_type 2) ride their own path in get_next_departure, matched by
 stop name with no direction: for them the pairs are checked by name, the
 answer must stay on the asked line, and a swapped pair is legitimate, it is
-the return journey, so only `pairs` is checked.
+the return journey, so only `pairs` is checked, by name.
 
 One test per fixture, route, direction and promise; its message lists every
 pair that broke the promise. The promises are about what the sensors say,
@@ -56,9 +59,11 @@ import fixture_db  # noqa: E402
 gtfs_helper = ha_stub.load("gtfs_helper")
 get_next_departure = gtfs_helper.get_next_departure
 get_stop_list = gtfs_helper.get_stop_list
+get_destination_stop_list = gtfs_helper.get_destination_stop_list
 
 FIXTURES = Path(__file__).parent / "fixtures"
-KINDS = ("stop_list", "pairs", "swapped")
+KINDS = ("stop_list", "destinations", "pairs", "swapped")
+TRAIN_KINDS = ("pairs",)
 
 
 class Fixture:
@@ -219,6 +224,12 @@ def served_between(patterns, origins, destinations):
     return False
 
 
+def sample_origins(pattern):
+    """The first stop, one in the middle, and the one before last."""
+    picks = sorted({0, len(pattern) // 2, max(0, len(pattern) - 2)})
+    return [i for i in picks if i < len(pattern) - 1]
+
+
 def sample_pairs(pattern):
     """First to last, first to middle, middle to last: the ends and a leg."""
     seen = []
@@ -250,20 +261,19 @@ class Check:
 # Cases known to fail on main today, each with what breaks the promise.
 # The marks are strict: the day a fix lands, its marks have to go with it,
 # which is how a fix PR and the test that turns green arrive together.
-SELECTOR = ("the stop selector offers a stop twice or out of riding order "
-            "(discussion #198)")
-SELECTOR_GVB = SELECTOR + "; trams 1, 7 and 17 also carry wrong direction_ids"
+PLATFORMS = ("two platforms of one place, called one after the other, are "
+             "offered as two entries (fix/stop-platform-groups)")
+PLATFORMS_GVB = PLATFORMS + "; trams 1, 7 and 17 also carry wrong direction_ids"
 SWAPPED = ("the swapped pair is answered although the asked direction does "
            "not ride it: the query filters neither route nor direction")
 TRAIN = ("a train journey is matched by stop name prefix on any line, not "
          "the asked one")
 KNOWN = {
-    **{f"gvb-{r}-d{d}-stop_list": SELECTOR_GVB
-       for r in ("1", "7", "13", "14", "17") for d in (0, 1)},
-    "palmbus-22-d0-stop_list": SELECTOR,
-    "palmbus-B-d1-stop_list": SELECTOR,
-    **{f"tao-journeys-{r}-d{d}-stop_list": SELECTOR
-       for r in ("40", "A", "B") for d in (0, 1)},
+    "gvb-1-d1-stop_list": PLATFORMS_GVB,
+    "gvb-14-d0-stop_list": PLATFORMS_GVB,
+    "gvb-14-d1-stop_list": PLATFORMS_GVB,
+    **{f"tao-journeys-{r}-d{d}-stop_list": PLATFORMS
+       for r in ("A", "B") for d in (0, 1)},
     **{f"{line}-d{d}-swapped": SWAPPED
        for line in ("gvb-7", "palmbus-A", "palmbus-B", "tao-journeys-40",
                     "tao-journeys-A", "tao-journeys-B", "tao-journeys-N")
@@ -291,7 +301,7 @@ def _cases():
             ids = [ids] if isinstance(ids, str) else ids
             for route_id in ids:
                 train = fx.route_types.get(route_id) == 2
-                kinds = ("pairs",) if train else KINDS
+                kinds = TRAIN_KINDS if train else KINDS
                 shown = label if len(ids) == 1 else f"{label}({route_id[-8:]})"
                 for direction in directions_of(fx.schedule, route_id):
                     for kind in kinds:
@@ -317,7 +327,7 @@ def test_journeys(record_property, fixture, route_id, direction, kind):
     dt_util.set_default_time_zone(dt_util.get_time_zone(fx.agency_tz))
     check = Check()
     if fx.route_types.get(route_id) == 2:
-        check_train_route(check, fx, route_id, direction)
+        check_train_route(check, fx, route_id, direction, kind)
     else:
         check_route(check, fx, route_id, direction, kind)
     record_property("case", {"fixture": fixture, "route": route_id,
@@ -408,8 +418,53 @@ def check_route(check, fx, route_id, direction, kind):
                                 f"{pattern[0]} .. {pattern[-1]}")
         return
 
-    hass = fx.hass()
     route_type = str(fx.route_types.get(route_id))
+    if kind == "destinations":
+        # From an origin, the trips that call at it and the rest of their
+        # ride: the list must hold every such stop, once, in the order the
+        # ride makes, and no stop no trip through that origin reaches. The
+        # origin is matched on its own record, so the pattern's stops are
+        # expected under their own records too.
+        for pattern in grouped:
+            for o in sample_origins(pattern):
+                origin = pattern[o]
+                offered = [entry.split(": ", 1)[0] for entry in
+                           get_destination_stop_list(schedule, route_id,
+                                                     query_direction, origin)]
+                who = f"from {named(fx, origin)}"
+                twice = sorted({s for s in offered if offered.count(s) > 1})
+                text = f"a destination is offered twice {who}"
+                if twice:
+                    text += ": " + listed([named(fx, s) for s in twice])
+                check.note(not twice, text, origin=origin, twice=twice)
+                after = []
+                for stop in pattern[o + 1:]:
+                    if stop not in after:
+                        after.append(stop)
+                missing = [s for s in after if s not in offered]
+                text = f"a stop this ride reaches {who} is not offered"
+                if missing:
+                    text += (": " + listed([named(fx, s) for s in missing])
+                             + f" (on the ride {pattern[0]} .. {pattern[-1]})")
+                check.note(not missing, text, origin=origin, missing=missing)
+                reachable = set()
+                for other in grouped:
+                    if origin in other:
+                        reachable.update(other[other.index(origin) + 1:])
+                stray = [s for s in offered if s not in reachable]
+                text = f"a destination no trip reaches {who} is offered"
+                if stray:
+                    text += ": " + listed([named(fx, s) for s in stray])
+                check.note(not stray, text, origin=origin, stray=stray)
+                pos = {s: n for n, s in enumerate(offered)}
+                known = [pos[s] for s in after if s in pos]
+                descents = sum(1 for a, b in zip(known, known[1:]) if a >= b)
+                check.note(descents == 0, f"the destinations {who} contradict "
+                           f"the riding order {pattern[0]} .. {pattern[-1]}",
+                           origin=origin)
+        return
+
+    hass = fx.hass()
     with freeze_time(fx.instant_on("1970-01-01")) as clock:
         for pattern, trip_ids in sorted(grouped.items()):
             # the same stand-in reading as above, so a pair asks for the
@@ -546,7 +601,7 @@ def _data_for(schedule, route_id, route_type, entries, position,
     }
 
 
-def check_train_route(check, fx, route_id, direction):
+def check_train_route(check, fx, route_id, direction, kind):
     schedule = fx.schedule
     short_name = fx.route_short_names[route_id]
     hass = fx.hass()


### PR DESCRIPTION
This is the stop selector improvement from #181 and #198, on its own: three commits, nothing about today/tomorrow, next service dates or the database.

**What changes**

- The stop list of a route and direction is walked from its fullest trip, so each stop appears once, in riding order. Sorting the union of all trips by stop_sequence interleaved the start of a route with its middle (TAO tram B, 110 short runs) and offered a stop once per number it was seen under (Palm Bus 22: 52 entries for 26 stops).
- Repeated names are numbered in calling order (#1, #2): a loop calls at its terminus twice under its own ids, a square carries four stops of one name. Same-name stops stay distinct entries; folding by name would show departures a rider cannot take.
- The flow asks for the origin first, then offers the destination among the stops a trip really reaches from it, so a pair no trip rides never gets to the sensor. The old retry screen goes; when nothing runs today or tomorrow the destination screen comes back with that said and the picks kept.
- Texts in strings.json and the five translations.

**Tests**

- tests_provider: a `destinations` promise joins the tree (from three stops of each sequence, every stop the trips through it ride to after it, once, in riding order, nothing else). Eleven stop_list marks are lifted; the seven left all fail on two platforms of one place offered one after the other, which is a separate change. 99 passed, 25 xfailed.
- tests/: 10 passed.
- The two screens were driven on the TAO fixture db outside HA: origin list, destination list, the screen shown again on `stop_incorrect` with defaults kept, the entry created, the train renaming, the `no_destination` and `no_stops` aborts.

Config entries are unchanged: the sensor still receives `stop_id: Name (sequence)` entries and queries on the id.
