### PR TITLE
One stop list per line, and the pair of stops decides the direction

### DIFF
--- a/custom_components/gtfs2/config_flow.py
+++ b/custom_components/gtfs2/config_flow.py
@@ -37,6 +37,7 @@ from .const import (
     CONF_ROUTE_TYPE,
     CONF_ROUTE,
     CONF_DIRECTION,
+    CONF_LOOP_DIRECTION,
     CONF_ORIGIN,
     CONF_DESTINATION,
     CONF_NAME,
@@ -57,6 +58,7 @@ from .gtfs_helper import (
     get_route_list,
     get_stop_list,
     get_destination_stop_list,
+    get_pair_direction,
     get_datasources,
     remove_datasource,
     check_datasource_index,
@@ -324,7 +326,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data_schema=vol.Schema(
                     {
                         vol.Required(CONF_ROUTE, default = ""): selector.SelectSelector(selector.SelectSelectorConfig(options=route_list, translation_key="route",custom_value=True)),
-                        vol.Required(CONF_DIRECTION): selector.SelectSelector(selector.SelectSelectorConfig(options=["0", "1"], translation_key="direction")),
                     },
                 ),
                 description_placeholders=TRANSLATION_DESCRIPTION_PLACEHOLDERS,
@@ -333,12 +334,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         user_input[CONF_ROUTE_TYPE] = user_input.get(CONF_ROUTE).split('##')[0] 
         user_input[CONF_ROUTE] = user_input.get(CONF_ROUTE).split('##')[1].split(": (")[0]   
                
+        # no direction is asked: the rider picks where they are and where they
+        # go, and the order of the stops on a trip says which way that is
+        user_input[CONF_DIRECTION] = None
         self._user_inputs.update(user_input)
         _LOGGER.debug(f"UserInputs Route: {self._user_inputs}")
         return await self.async_step_stops()
 
     async def async_step_stops(self, user_input: dict | None = None) -> FlowResult:
-        """Pick the origin: every stop the route rides in this direction."""
+        """Pick the origin: every place the line rides, both ways round."""
         errors: dict[str, str] = {}
         if user_input is None:
             try:
@@ -346,7 +350,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     get_stop_list,
                     self._pygtfs,
                     self._user_inputs[CONF_ROUTE],
-                    self._user_inputs[CONF_DIRECTION],
+                    None,
                 )
                 if not stops:
                     raise ValueError("no stops")
@@ -387,6 +391,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if data[CONF_ROUTE_TYPE] == '2':
                 data[CONF_ORIGIN] = _stop_name_of(data[CONF_ORIGIN])
                 data[CONF_DESTINATION] = _stop_name_of(data[CONF_DESTINATION])
+            else:
+                # the pair says which way the rider goes, except with a loop's
+                # terminus at one end: then the entry keeps the shorter rotation
+                data[CONF_LOOP_DIRECTION] = await self.hass.async_add_executor_job(
+                    get_pair_direction,
+                    self._pygtfs,
+                    data[CONF_ROUTE],
+                    data[CONF_ORIGIN].split(": ")[0],
+                    data[CONF_DESTINATION].split(": ")[0],
+                )
             _LOGGER.debug(f"UserInputs Destination: {data}")
             check_config = await self._check_config(data)
             if check_config == "stop_incorrect":
@@ -400,7 +414,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             get_destination_stop_list,
             self._pygtfs,
             self._user_inputs[CONF_ROUTE],
-            self._user_inputs[CONF_DIRECTION],
+            None,
             self._user_inputs[CONF_ORIGIN].split(": ")[0],
         )
         if not destinations:

--- a/custom_components/gtfs2/config_flow.py
+++ b/custom_components/gtfs2/config_flow.py
@@ -56,6 +56,7 @@ from .gtfs_helper import (
     get_next_departure,
     get_route_list,
     get_stop_list,
+    get_destination_stop_list,
     get_datasources,
     remove_datasource,
     check_datasource_index,
@@ -75,6 +76,16 @@ TRANSLATION_DESCRIPTION_PLACEHOLDERS = {
     "docu_configuring_options": "https://github.com/vingerha/gtfs2/wiki/04:-Configuring-a-route's-options-(inc.-adding-real%E2%80%90time)",
     "model": "Example model",
 }
+
+
+def _stop_name_of(entry):
+    """The stop name inside a picker entry "stop_id: Name #2 (12)": the
+    number given to a repeated name and the sequence are display only."""
+    name = entry.split(": ", 1)[1].rsplit(" (", 1)[0]
+    if " #" in name and name.rsplit(" #", 1)[1].isdigit():
+        name = name.rsplit(" #", 1)[0]
+    return name
+
 
 @config_entries.HANDLERS.register(DOMAIN)
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -327,83 +338,87 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_stops()
 
     async def async_step_stops(self, user_input: dict | None = None) -> FlowResult:
-        """Handle the route step."""
+        """Pick the origin: every stop the route rides in this direction."""
         errors: dict[str, str] = {}
         if user_input is None:
             try:
-                stops = get_stop_list(
+                stops = await self.hass.async_add_executor_job(
+                    get_stop_list,
                     self._pygtfs,
                     self._user_inputs[CONF_ROUTE],
                     self._user_inputs[CONF_DIRECTION],
                 )
-                last_stop = stops[-1:][0]
+                if not stops:
+                    raise ValueError("no stops")
                 return self.async_show_form(
                     step_id="stops",
                     data_schema=vol.Schema(
                         {
                             vol.Required(CONF_ORIGIN): vol.In(stops),
-                            vol.Required(CONF_DESTINATION, default=last_stop): vol.In(stops),
-                            vol.Required(CONF_NAME): str,
                         },
                     ),
                     description_placeholders=TRANSLATION_DESCRIPTION_PLACEHOLDERS,
                     errors=errors,
                 )
-            except:
+            except Exception:  # pylint: disable=broad-except
                 _LOGGER.debug(f"Likely no stops for this route: {[CONF_ROUTE]}")
                 return self.async_abort(reason="no_stops")
-                
-        # when train route-type, use the names of the selected stops       
-        if self._user_inputs[CONF_ROUTE_TYPE] == '2':
-            user_input[CONF_ORIGIN] = user_input.get(CONF_ORIGIN).split(': ')[1].split(" (")[0] 
-            user_input[CONF_DESTINATION] = user_input.get(CONF_DESTINATION).split(': ')[1].split(" (")[0]  
-            
+
         self._user_inputs.update(user_input)
-        _LOGGER.debug(f"UserInputs Stops: {self._user_inputs}")
-        check_config = await self._check_config(self._user_inputs)
-        if check_config:
-            return await self.async_step_stops_retry()
-        else:
-            return self.async_create_entry(
-                title=user_input[CONF_NAME], data=self._user_inputs
-            )
-            
-    async def async_step_stops_retry(self, user_input: dict | None = None) -> FlowResult:
-        """Handle the route step."""
+        _LOGGER.debug(f"UserInputs Origin: {self._user_inputs}")
+        return await self.async_step_destination()
+
+    async def async_step_destination(self, user_input: dict | None = None) -> FlowResult:
+        """Pick the destination among the stops a trip really rides to from
+        the chosen origin, so the pair can always be matched to a trip.
+
+        A pair no trip rides cannot be picked any more, so the only check
+        left is whether a trip is still to come. When none is, the screen
+        comes back with that said, the picks kept, and the user can choose
+        another destination.
+        """
         errors: dict[str, str] = {}
-        if user_input is None:
-            try:
-                stops = get_stop_list(
-                    self._pygtfs,
-                    self._user_inputs[CONF_ROUTE],
-                    self._user_inputs[CONF_DIRECTION],
-                )
-                last_stop = stops[-1:][0]
-                return self.async_show_form(
-                    step_id="stops_retry",
-                    data_schema=vol.Schema(
-                        {
-                            vol.Required(CONF_ORIGIN, default = self._user_inputs[CONF_ORIGIN]): vol.In(stops),
-                            vol.Required(CONF_DESTINATION, default = self._user_inputs[CONF_DESTINATION]): vol.In(stops),
-                            vol.Required(CONF_NAME): str,
-                        },
-                    ),
-                    description_placeholders=TRANSLATION_DESCRIPTION_PLACEHOLDERS,
-                    errors=errors,
-                )
-            except:
-                _LOGGER.debug(f"Likely no stops for this route: {[CONF_ROUTE]}")
-                return self.async_abort(reason="no_stops")
-        self._user_inputs.update(user_input)
-        _LOGGER.debug(f"UserInputs Stops: {self._user_inputs}")
-        check_config = await self._check_config(self._user_inputs)
-        if check_config:
-            return await self.async_step_stops_retry()
-        else:
-            return self.async_create_entry(
-                title=user_input[CONF_NAME], data=self._user_inputs
-            )            
-            
+        if user_input is not None:
+            data = {**self._user_inputs, **user_input}
+            # when train route-type, use the names of the selected stops: a
+            # platform id is not something the rider picks, the station is.
+            # The picker entries stay untouched in _user_inputs, the screen
+            # may have to be shown again
+            if data[CONF_ROUTE_TYPE] == '2':
+                data[CONF_ORIGIN] = _stop_name_of(data[CONF_ORIGIN])
+                data[CONF_DESTINATION] = _stop_name_of(data[CONF_DESTINATION])
+            _LOGGER.debug(f"UserInputs Destination: {data}")
+            check_config = await self._check_config(data)
+            if check_config == "stop_incorrect":
+                errors["base"] = "stop_incorrect"
+            elif check_config:
+                return self.async_abort(reason=check_config)
+            else:
+                return self.async_create_entry(title=data[CONF_NAME], data=data)
+
+        destinations = await self.hass.async_add_executor_job(
+            get_destination_stop_list,
+            self._pygtfs,
+            self._user_inputs[CONF_ROUTE],
+            self._user_inputs[CONF_DIRECTION],
+            self._user_inputs[CONF_ORIGIN].split(": ")[0],
+        )
+        if not destinations:
+            # the origin is the last stop of every trip that calls at it
+            return self.async_abort(reason="no_destination")
+        picked = user_input or {}
+        return self.async_show_form(
+            step_id="destination",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_DESTINATION, default=picked.get(CONF_DESTINATION, destinations[-1])): vol.In(destinations),
+                    vol.Required(CONF_NAME, default=picked.get(CONF_NAME, vol.UNDEFINED)): str,
+                },
+            ),
+            description_placeholders=TRANSLATION_DESCRIPTION_PLACEHOLDERS,
+            errors=errors,
+        )
+
     async def async_step_stops_train(self, user_input: dict | None = None) -> FlowResult:
         """Handle the stops when train, as often impossible to select ID"""
         errors: dict[str, str] = {}

--- a/custom_components/gtfs2/const.py
+++ b/custom_components/gtfs2/const.py
@@ -277,6 +277,9 @@ CONF_AGENCY = "agency"
 CONF_ROUTE_TYPE = "route_type"
 CONF_ROUTE = "route"
 CONF_DIRECTION = "direction"
+# the rotation an entry keeps at a loop's terminus, the only direction the
+# departure query reads: entries created before it carry none
+CONF_LOOP_DIRECTION = "loop_direction"
 CONF_ORIGIN = "origin"
 CONF_DESTINATION = "destination"
 CONF_NAME = "name"

--- a/custom_components/gtfs2/coordinator.py
+++ b/custom_components/gtfs2/coordinator.py
@@ -83,6 +83,8 @@ class GTFSUpdateCoordinator(DataUpdateCoordinator):
             "file": data["file"],
             "route_type": data["route_type"],
             "route": data["route"],
+            # kept only at a loop's terminus, absent everywhere else
+            "loop_direction": data.get("loop_direction"),
             "extracting": False,
             "next_departure": {},
             "next_departure_realtime_attr": {},

--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import statistics
 import os
 import glob
 import json
@@ -42,21 +43,48 @@ from .gtfs_rt_helper import get_rt_route_trip_statuses, get_gtfs_rt, safe_file_p
 _LOGGER = logging.getLogger(__name__)
 
 
-def _fetch_departure_rows(route_type, origin, destination, schedule):
-    """Run the static-GTFS SQL query and return matching rows as plain dicts."""
+def _fetch_departure_rows(route_type, origin, destination, schedule, direction=None, route=None):
+    """Run the static-GTFS SQL query and return matching rows as plain dicts.
+
+    direction is only given by an entry at a loop's terminus
+    (get_pair_direction, stored as loop_direction); the pair and the order of
+    the stops decide it everywhere else, and the direction older entries
+    store is not read."""
     if route_type == "2":
         route_type_where = f"route.route_type in (2,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117)"
         start_station_id = str(origin)+'%'
         end_station_id = str(destination)+'%'
         start_station_where = f"AND origin_stop_time.stop_id in (select stop_id from stops where stop_name like :origin_station_id)"
         end_station_where = f"AND destination_stop_time.stop_id in (select stop_id from stops where stop_name like :end_station_id)"
+        shortest_ride_where = ""
+        direction_where = ""
+        route_where = ""
         _LOGGER.debug("Setting up TRAIN Route for start/end : %s / %s ", start_station_id, end_station_id)
     else:
         route_type_where = "1=1"
         start_station_id = origin.split(': ')[0]
         end_station_id = destination.split(': ')[0]
-        start_station_where = f"AND origin_stop_time.stop_id = :origin_station_id"
-        end_station_where = f"AND destination_stop_time.stop_id = :end_station_id"
+        # both ends are matched on the whole place, every record of it: the
+        # entry holds one record, the vehicle may call at another (the other
+        # side of the road, the other quay of a terminus)
+        origin_group = _place_group("origin_station_id")
+        end_group = _place_group("end_station_id")
+        start_station_where = "AND origin_stop_time.stop_id IN " + origin_group
+        end_station_where = "AND destination_stop_time.stop_id IN " + end_group
+        # a trip passing a place twice offers the pair twice (Palm Bus 21 calls
+        # at Gare SNCF de Cannes on its way out and on its way back): the ride
+        # is the shortest one, no other call at either end between the two
+        shortest_ride_where = f"""AND NOT EXISTS (
+                SELECT 1 FROM stop_times between_stop
+                WHERE between_stop.trip_id = trip.trip_id
+                  AND between_stop.stop_sequence > origin_stop_time.stop_sequence
+                  AND between_stop.stop_sequence < destination_stop_time.stop_sequence
+                  AND (between_stop.stop_id IN {origin_group}
+                       OR between_stop.stop_id IN {end_group}))"""
+        direction_where = ("AND (trip.direction_id = :direction OR trip.direction_id IS NULL)"
+                           if str(direction) in ("0", "1") else "")
+        # a place is shared by every line calling at it: the entry's line only
+        route_where = "AND trip.route_id = :route" if route else ""
         _LOGGER.debug("Setting up Route for start/end : %s / %s ", start_station_id, end_station_id)
 
     limit = 24 * 60 * 60 * 2
@@ -75,6 +103,9 @@ def _fetch_departure_rows(route_type, origin, destination, schedule):
             WHERE {route_type_where}
               {start_station_where}
               {end_station_where}
+              {direction_where}
+              {route_where}
+              {shortest_ride_where}
               AND origin_stop_time.stop_sequence < destination_stop_time.stop_sequence
           ),
           cal_expand(service_id, d, end_date, monday, tuesday, wednesday, thursday, friday, saturday, sunday) AS (
@@ -182,6 +213,8 @@ def _fetch_departure_rows(route_type, origin, destination, schedule):
             {
                 "origin_station_id": start_station_id,
                 "end_station_id": end_station_id,
+                "direction": int(direction) if str(direction) in ("0", "1") else None,
+                "route": route,
                 "limit": limit,
                 "route_type": route_type,
             },
@@ -294,6 +327,7 @@ def _interpret_departure_rows(hass, rows, start_station_id, now, now_local_tz,
     timetable_remaining_headsign = []
     timetable_upcoming_trips = []
     timetable_upcoming_arrivals = []
+    timetable_upcoming_origin_stops = []
     max_remaining = 10
     count = 0
     for key, value in sorted(timetable.items()):
@@ -315,6 +349,8 @@ def _interpret_departure_rows(hass, rows, start_station_id, now, now_local_tz,
             timetable_upcoming_arrivals.append(
                 dt_util.as_utc(upcoming_arrival).isoformat()
             )
+            # the record it leaves from: a place may be served from either
+            timetable_upcoming_origin_stops.append(str(value.get("origin_stop_id")))
             count += 1
             if count >= max_remaining:
                 break
@@ -382,6 +418,7 @@ def _interpret_departure_rows(hass, rows, start_station_id, now, now_local_tz,
         "next_departures_headsign": timetable_remaining_headsign,
         "next_departures_trip_id": timetable_upcoming_trips,
         "next_departures_destination_arrival_times": timetable_upcoming_arrivals,
+        "next_departures_origin_stop_id": timetable_upcoming_origin_stops,
     }
 
     return data_returned
@@ -407,6 +444,8 @@ def get_next_departure(hass, _data):
 
     rows, start_station_id = _fetch_departure_rows(
         route_type, _data["origin"], _data["destination"], schedule,
+        direction=_data.get("loop_direction"),
+        route=(_data.get("route") or "").split(": ")[0] or None,
     )
 
     return _interpret_departure_rows(
@@ -589,138 +628,482 @@ def get_route_list(schedule, data):
     _LOGGER.debug(f"routes: {routes}")
     return routes
 
-def _walk_stops(rows):
-    """Order (trip_id, stop_id, stop_name, stop_sequence) rows, given by trip
-    and sequence, into one stop each, in riding order.
+# The trips of one direction ride a handful of distinct stop patterns, a
+# few thousand times each over the feed's calendar (TAO tram A: 4214 trips,
+# 27 stops). The walk only needs each pattern once, so one trip stands for
+# every trip that rides the same stops in the same order: the lowest
+# trip_id of the pattern, which is also the trip _ride_of would have walked
+# first among them, so the result is the one reading every trip gives.
+# The signature is concatenated in scan order on purpose: sorting it
+# first costs more than reading every trip did (TAO A: 4.2 s against 2.8
+# for the six lines, 1.2 s this way). Should the order ever vary between
+# two trips of one pattern, that pattern is read twice, never lost.
+_STOP_ROWS = """
+    with ride as (
+        select t.trip_id, group_concat(st.stop_sequence || ':' || st.stop_id) as stops
+        from trips t
+        inner join stop_times st on st.trip_id = t.trip_id
+        where t.route_id = :route_id
+        and (:direction is null or t.direction_id = :direction or t.direction_id is null)
+        group by t.trip_id
+    ), sample as (
+        select min(trip_id) as trip_id from ride group by stops
+    )
+    SELECT st.trip_id, s.stop_id, s.stop_name, st.stop_sequence, s.parent_station, station.stop_name,
+           s.stop_lat, s.stop_lon
+    from sample
+    inner join stop_times st on st.trip_id = sample.trip_id
+    inner join stops s on s.stop_id = st.stop_id
+    left join stops station on station.stop_id = s.parent_station
+    order by st.trip_id, st.stop_sequence
+"""
 
-    Trips of one direction do not all run the full length, and a partial
-    trip renumbers stop_sequence from 0, so sorting the union of all trips
-    by stop_sequence interleaves the start of the route with its middle
-    (TAO tram B: 110 short runs from mid-route) and offers a stop once per
-    number it was seen under (Palm Bus 22: 52 entries for 26 stops). Walk
-    the fullest trip first instead, it is the route as the rider rides it,
-    then slot each stop it skips right after the stop preceding it on a
-    trip that does serve it.
 
-    Returns the ordered stop_ids, their names, and the sequence each was
-    first seen under.
-    """
+# A place is what the rider waits at, whatever the feed writes it as. Most
+# feeds give each side of the road a record of its own, one per direction,
+# and some give one per platform: Zou files the two poles of Pont de la
+# Brague, 8 m apart, under one parent station, and half of the line's trips
+# are entered on the pole across the road from the way they drive. Picking a
+# record hid the trips entered on the other one. So a place is the parent
+# station when the feed has one; when it has none (TAO: 9 parents for 1359
+# poles), the records of the same name within PLACE_LAT / PLACE_LON of each
+# other, about 150 m, which gathered the three poles of Zenith, 107 m apart
+# at most, and keeps apart two villages' "Centre". The box is measured from
+# the record the entry holds, so the list and the queries agree on it.
+PLACE_LAT = 0.00135
+
+
+PLACE_LON = 0.002
+
+
+def _place_group(param):
+    """SQL "(...)" of every stop_id of the place of the stop bound to :param."""
+    return f"""(
+    select sibling.stop_id
+    from stops chosen, stops sibling
+    where chosen.stop_id = :{param}
+      and (sibling.stop_id = chosen.stop_id
+           or (chosen.parent_station is not null
+               and chosen.parent_station <> ''
+               and sibling.parent_station = chosen.parent_station)
+           or ((chosen.parent_station is null or chosen.parent_station = '')
+               and (sibling.parent_station is null or sibling.parent_station = '')
+               and sibling.stop_name = chosen.stop_name
+               and abs(sibling.stop_lat - chosen.stop_lat) <= {PLACE_LAT}
+               and abs(sibling.stop_lon - chosen.stop_lon) <= {PLACE_LON})))"""
+
+
+_STOP_GROUP = _place_group("origin")
+
+
+def _same_place(a, b):
+    """The rule of _place_group, on (name, parent, lat, lon) tuples."""
+    if a[1] or b[1]:
+        return bool(a[1]) and a[1] == b[1]
+    try:
+        return (a[0] == b[0]
+                and abs(float(a[2]) - float(b[2])) <= PLACE_LAT
+                and abs(float(a[3]) - float(b[3])) <= PLACE_LON)
+    except (TypeError, ValueError):
+        return False
+
+
+def _trips_of(rows):
+    """{trip_id: [(stop_id, stop_sequence)]} and {stop_id: (name, parent,
+    lat, lon, station_name)} out of _STOP_ROWS shaped rows."""
     trips = {}
-    names = {}
-    for trip_id, stop_id, stop_name, stop_sequence in rows:
+    info = {}
+    for trip_id, stop_id, stop_name, stop_sequence, parent_station, station_name, lat, lon in rows:
         trips.setdefault(trip_id, []).append((stop_id, stop_sequence))
-        names[stop_id] = stop_name
-    order = []
-    kept_seq = {}
-    for _trip_id, trip_stops in sorted(
-        trips.items(), key=lambda kv: (-len(kv[1]), kv[0])
-    ):
-        prev = -1
-        for stop_id, stop_sequence in trip_stops:
-            if stop_id in kept_seq:
-                prev = order.index(stop_id)
+        info[stop_id] = (stop_name, parent_station or "", lat, lon, station_name)
+    return trips, info
+
+
+def _places_of(trips, info):
+    """{stop_id: place}, a place being named by the first of its records the
+    line calls at, fullest trip first: that record is what the entry keeps,
+    and the one the queries widen to the whole place again."""
+    place = {}
+    seeds = []
+    for _trip_id, trip_stops in sorted(trips.items(), key=lambda kv: (-len(kv[1]), kv[0])):
+        for stop_id, _seq in trip_stops:
+            if stop_id in place:
                 continue
-            prev += 1
-            order.insert(prev, stop_id)
-            kept_seq[stop_id] = stop_sequence
-    return order, names, kept_seq
+            # measured from the seed only, as the SQL box is from the entry's
+            # record: a chain of near records never drifts a place further
+            seed = next((s for s in seeds if _same_place(info[s], info[stop_id])), None)
+            if seed is None:
+                seeds.append(stop_id)
+                seed = stop_id
+            place[stop_id] = seed
+    return place
 
 
-def _homonym_ranks(order, names):
-    """{stop_id: n} for the stops whose name the line meets more than once.
+def _segments_of(places):
+    """A trip read as places, cut where it comes back to a place it already
+    passed: the next piece starts from the last place, so pieces stay tied.
+    A racket (Palm Bus 21 out and back through Gare SNCF) or a loop (TAO 22,
+    Zenith to Zenith) gives two pieces, each passing a place once."""
+    pieces, current = [], []
+    for p in places:
+        if current and p == current[-1]:
+            continue
+        if p in current:
+            pieces.append(current)
+            current = [current[-1], p]
+        else:
+            current.append(p)
+    if len(current) > 1 or not pieces:
+        pieces.append(current)
+    return pieces
 
-    A circular line calls at its terminus twice under ids of its own (TAO 22
-    runs Zenith to Zenith and offers three stops all reading "Zenith"), a
-    square carries four stops of one name (GVB's Surinameplein). Two entries
-    reading the same thing leave the choice to chance, so the repeats are
-    numbered in the order the line calls at them. Same-name stops stay
-    distinct entries: the two sides of a street are two stops, and folding
-    them by name would show a rider departures they cannot take.
+
+def _chain_of(trips, place):
+    """One order of places for the whole line, both ways round.
+
+    direction_id cannot be trusted to split a line: on GVB tram 1 a third of
+    the trips carry the other way's label, and the spec itself keeps it for
+    publishing timetables, not for routing. The order of the stops can: the
+    fullest piece is laid first, and every other piece is read forward or
+    backward, whichever way the places it shares with the chain already
+    agree with, then its places are slotted in after the place preceding
+    them. A piece sharing nothing yet waits for the chain to grow.
+    """
+    pieces = {}
+    for _trip_id, trip_stops in trips.items():
+        for piece in _segments_of([place[s] for s, _seq in trip_stops]):
+            pieces.setdefault(tuple(piece), 0)
+            pieces[tuple(piece)] += 1
+    pending = sorted(pieces, key=lambda p: (-len(p), -pieces[p], p))
+    order = []
+    while pending:
+        waiting = []
+        for piece in pending:
+            position = {p: i for i, p in enumerate(order)}
+            shared = [position[p] for p in piece if p in position]
+            if not order:
+                forward = True
+            elif len(shared) < 2:
+                waiting.append(piece)
+                continue
+            else:
+                up = sum(1 for a, b in zip(shared, shared[1:]) if b > a)
+                down = sum(1 for a, b in zip(shared, shared[1:]) if b < a)
+                forward = up >= down
+            prev = -1
+            for p in (piece if forward else reversed(piece)):
+                if p in position:
+                    prev = order.index(p)
+                    continue
+                prev += 1
+                order.insert(prev, p)
+                position = {q: i for i, q in enumerate(order)}
+        if len(waiting) == len(pending):
+            # nothing left shares two places with the chain: keep them in
+            # riding order at the end rather than lose them
+            for piece in waiting:
+                order.extend(p for p in piece if p not in order)
+            break
+        pending = waiting
+    return order
+
+
+def _ride_of(rows):
+    """One entry per place, in riding order, out of _STOP_ROWS shaped rows.
+
+    Returns the kept [stop_id, name, sequence], stop_id being the record that
+    names the place, the station names by stop_id, which the labels read,
+    and the {stop_id: place} the entries were drawn from.
+    """
+    trips, info = _trips_of(rows)
+    place = _places_of(trips, info)
+    order = _chain_of(trips, place)
+    first_seq = {}
+    for _trip_id, trip_stops in sorted(trips.items(), key=lambda kv: (-len(kv[1]), kv[0])):
+        for stop_id, seq in trip_stops:
+            first_seq.setdefault(stop_id, seq)
+    kept = [[p, info[p][0], first_seq[p]] for p in order]
+    station_names = {stop_id: values[4] for stop_id, values in info.items()}
+    return kept, station_names, place
+
+
+def _labels_of(kept, station_names):
+    """{stop_id: readable name} for the stops whose name the line meets
+    more than once; a stop met once keeps its plain name.
+
+    Records of one place are already one entry, so a repeat left here is two
+    places of the same name. The feed sometimes knows what tells them apart:
+    on line 1 in Amsterdam one "Surinameplein" belongs to the Surinameplein
+    station and the other to Hoofdweg, two hundred metres away. Often it
+    does not: Zou 926 calls at five villages' "Centre". So a repeat carries
+    its station when the station adds something, and falls back on its rank
+    in the order the line calls at them when it does not. The value keeps
+    the id untouched, only the readable part changes.
     """
     by_name = {}
-    for stop_id in order:
-        by_name.setdefault(names[stop_id], []).append(stop_id)
-    rank = {}
-    for group in by_name.values():
-        if len(group) > 1:
-            for n, stop_id in enumerate(group, 1):
-                rank[stop_id] = n
-    return rank
+    for x in kept:
+        by_name.setdefault(x[1], []).append(x)
+    label = {}
+    for name, group in by_name.items():
+        if len(group) == 1:
+            continue
+        for x in group:
+            station_name = station_names.get(x[0])
+            label[x[0]] = (f"{name} ({station_name})"
+                           if station_name and station_name not in name
+                           else name)
+        # the station settles it only if it settles it for everyone: where
+        # two of them still read the same, those keep their rank instead,
+        # and a stop the station already told apart keeps its plain reading
+        still_shared = [x for x in group
+                        if [y for y in group if label[y[0]] == label[x[0]]][1:]]
+        for n, x in enumerate(still_shared, 1):
+            label[x[0]] = f"{label[x[0]]} #{n}"
+    return label
 
 
-def _stop_entries(order, names, kept_seq, rank):
-    """The picker's entries, "stop_id: Name (sequence)". The value keeps the
-    id untouched, the sensor queries on it; only the readable part changes."""
-    stops = []
-    for stop_id in order:
-        shown = names[stop_id]
-        if stop_id in rank:
-            shown = f"{shown} #{rank[stop_id]}"
-        stops.append(f"{stop_id}: {shown} ({kept_seq[stop_id]})")
-    return stops
+def _entries_of(kept, label):
+    """The picker's entries, "stop_id: Name (sequence)": get_next_departure
+    cuts the id back out of the value, only the name is the user's to read."""
+    return [f"{x[0]}: {label.get(x[0], x[1])} ({x[2]})" for x in kept]
 
 
-def _route_stop_rows(schedule, route_id, direction):
-    sql_stops = """
-    SELECT st.trip_id, s.stop_id, s.stop_name, st.stop_sequence
-    from trips t
-    inner join stop_times st on st.trip_id = t.trip_id
-    inner join stops s on s.stop_id = st.stop_id
-    where t.route_id = :route_id
-    and (t.direction_id = :direction or t.direction_id is null)
-    order by st.trip_id, st.stop_sequence
+def _direction_param(direction):
+    """None for no direction (the whole line), else 0 or 1."""
+    if direction is None or str(direction) not in ("0", "1"):
+        return None
+    return int(direction)
+
+
+def get_stop_list(schedule, route_id, direction=None):
+    """Every place a route rides, one entry each, in riding order.
+
+    Without a direction, the whole line both ways round, which is what the
+    flow offers: the rider picks where they are, not a label of the feed.
+    A direction still narrows it to that direction's trips.
     """
+    _LOGGER.debug("Getting stops list for route: %s direction: %s", route_id, direction)
     with schedule.engine.connect() as conn:
-        return conn.execute(text(sql_stops), {
-            "route_id": route_id, "direction": int(direction)}).fetchall()
-
-
-def get_stop_list(schedule, route_id, direction):
-    """Every stop a route rides in one direction, once each, in riding order."""
-    _LOGGER.debug("Getting stops list for route: %s", route_id)
-    order, names, kept_seq = _walk_stops(_route_stop_rows(schedule, route_id, direction))
-    stops = _stop_entries(order, names, kept_seq, _homonym_ranks(order, names))
+        rows = conn.execute(text(_STOP_ROWS), {
+            "route_id": route_id, "direction": _direction_param(direction)}).fetchall()
+    kept, station_names, _place = _ride_of(rows)
+    stops = _entries_of(kept, _labels_of(kept, station_names))
     _LOGGER.debug(f"Route stops: {stops}")
     return stops
 
 
 def get_destination_stop_list(schedule, route_id, direction, origin_stop_id):
-    """The stops reachable from origin_stop_id on this route and direction.
+    """The places a trip really reaches from the departure place.
 
     Only the trips that call at the origin are read, and of each only the
     part after it, so every entry offered can be paired with the origin on
-    at least one trip: a pair that no trip rides never reaches the sensor.
-    Whether that trip runs today is another question, answered by
-    get_next_service_date. Same walk as get_stop_list, so the list reads as
-    the rest of the ride, and the same numbering of repeated names, so a
-    stop reads the same on both screens. A loop that calls at the origin
-    twice is read from its first call, which keeps the way back on offer.
+    at least one trip and nothing has to be rejected afterwards. Whether
+    that trip runs today is the coordinator's business. The origin is
+    matched as a whole place, every record of it, the way the departure
+    query matches it; a loop that calls at it twice is read from the first
+    call, which keeps the way back on offer. Without a direction both ways
+    round are read, each in riding order from the origin. The entries are
+    the line's, records and labels, so a stop reads the same on both
+    screens; the origin's own place is not offered.
     """
     _LOGGER.debug("Getting destinations for route: %s direction: %s from: %s",
                   route_id, direction, origin_stop_id)
-    sql_stops = """
-    SELECT st.trip_id, s.stop_id, s.stop_name, st.stop_sequence
-    from trips t
-    inner join (
+    # same sampling as _STOP_ROWS, on the part of each trip after the origin
+    sql = f"""
+    with through as (
         select trip_id, min(stop_sequence) as origin_sequence
-        from stop_times where stop_id = :origin group by trip_id
-    ) o on o.trip_id = t.trip_id
-    inner join stop_times st on st.trip_id = t.trip_id
+        from stop_times where stop_id in {_STOP_GROUP} group by trip_id
+    ), ride as (
+        select t.trip_id, group_concat(st.stop_sequence || ':' || st.stop_id) as stops
+        from trips t
+        inner join through o on o.trip_id = t.trip_id
+        inner join stop_times st on st.trip_id = t.trip_id
+            and st.stop_sequence > o.origin_sequence
+        where t.route_id = :route_id
+        and (:direction is null or t.direction_id = :direction or t.direction_id is null)
+        group by t.trip_id
+    ), sample as (
+        select min(trip_id) as trip_id from ride group by stops
+    )
+    SELECT st.trip_id, s.stop_id, s.stop_name, st.stop_sequence, s.parent_station, station.stop_name,
+           s.stop_lat, s.stop_lon
+    from sample
+    inner join through o on o.trip_id = sample.trip_id
+    inner join stop_times st on st.trip_id = sample.trip_id
         and st.stop_sequence > o.origin_sequence
     inner join stops s on s.stop_id = st.stop_id
-    where t.route_id = :route_id
-    and (t.direction_id = :direction or t.direction_id is null)
+    left join stops station on station.stop_id = s.parent_station
     order by st.trip_id, st.stop_sequence
-    """
+    """  # noqa: S608
+    scope = {"route_id": route_id, "direction": _direction_param(direction)}
     with schedule.engine.connect() as conn:
-        rows = conn.execute(text(sql_stops), {
-            "route_id": route_id, "direction": int(direction),
-            "origin": origin_stop_id}).fetchall()
-    whole, whole_names, _ = _walk_stops(_route_stop_rows(schedule, route_id, direction))
-    order, names, kept_seq = _walk_stops(rows)
-    stops = _stop_entries(order, names, kept_seq, _homonym_ranks(whole, whole_names))
+        whole = conn.execute(text(_STOP_ROWS), scope).fetchall()
+        rows = conn.execute(text(sql), {**scope, "origin": origin_stop_id}).fetchall()
+    line, station_names, place = _ride_of(whole)
+    position = {x[0]: i for i, x in enumerate(line)}
+    by_place = {x[0]: x for x in line}
+    trips, _info = _trips_of(rows)
+    origin_place = place.get(origin_stop_id, origin_stop_id)
+    # Riding order first: a place comes after every place some trip calls at
+    # just before it on its way from the origin, so two branches that meet
+    # again (GVB 1 reaches Leidseplein by Overtoom or by Jan Pieter
+    # Heijestraat) keep each ride's order. A later call at the origin starts
+    # the ride again (Palm Bus 21 passes Gare SNCF out and back), and a place
+    # met again on the same ride starts a new stretch rather than closing a
+    # circle. Among places no ride orders, nearest first: the fewest stops
+    # any trip takes to reach them, the line's far side of the origin before
+    # its near side. From a loop's terminus every stop is reached both ways
+    # round and the rides order nothing for good; the nearest is taken
+    # there, the shorter way round.
+    reach, before = {}, {}
+    for _trip_id, trip_stops in trips.items():
+        # the rows start right after the trip's first call at the origin
+        count, previous, stretch = 0, None, set()
+        for stop_id, _seq in trip_stops:
+            p = place.get(stop_id, stop_id)
+            if p == origin_place:
+                count, previous, stretch = 0, None, set()
+                continue
+            count += 1
+            reach[p] = min(reach.get(p, count), count)
+            before.setdefault(p, set())
+            if p in stretch:
+                stretch = {p}
+            elif previous is not None and previous != p:
+                before[p].add(previous)
+                stretch.add(p)
+            else:
+                stretch.add(p)
+            previous = p
+    home = position.get(origin_place, -1)
+
+    def nearest(p):
+        return (position.get(p, 0) < home, reach[p], position.get(p, 0))
+
+    order, placed = [], set()
+    while len(order) < len(reach):
+        ready = [p for p in reach if p not in placed and not (before[p] - placed)]
+        # nothing free: a loop's rotations order each other round, take the nearest
+        p = min(ready or [p for p in reach if p not in placed], key=nearest)
+        order.append(p)
+        placed.add(p)
+    kept = [by_place[p] for p in order if p in by_place]
+    stops = _entries_of(kept, _labels_of(line, station_names))
     _LOGGER.debug(f"Destinations from {origin_stop_id}: {stops}")
     return stops
+
+
+def get_pair_direction(schedule, route_id, origin_stop_id, destination_stop_id):
+    """The direction an entry must keep for this pair, or None.
+
+    The pair and the order of the stops on one trip say which way the
+    rider goes, whatever the labels. Only a loop leaves it open: TAO 22 runs
+    Zenith to Zenith both ways round, and a trip leaving Zenith reaches any
+    stop of the loop, the short way on one rotation and the long way on the
+    other; on that line the 29 pairs with Zenith at one end are the only
+    ones where this happens, out of 870: a trip calls at the terminus at
+    both ends, so it rides a pair with the terminus at one end whichever
+    way round it goes. Then the rotation with the fewest stops is kept,
+    when its trips agree on one direction.
+
+    Stops rather than minutes: on TAO 22 both pick the same rotation for 54
+    of the 58 pairs, the 2 that differ are 42 seconds apart, and Zou 989
+    gives every stop of a trip the same time, so minutes decide nothing
+    there. They settle a tie in stops (a stop halfway round), by the median
+    ride time of each rotation; a tie on both keeps no direction.
+    """
+    with schedule.engine.connect() as conn:
+        rows = conn.execute(text(_STOP_ROWS), {"route_id": route_id, "direction": None}).fetchall()
+        labels = dict(conn.execute(text(
+            "select trip_id, direction_id from trips where route_id = :route_id"),
+            {"route_id": route_id}).fetchall())
+    trips, info = _trips_of(rows)
+    place = _places_of(trips, info)
+    origin = place.get(origin_stop_id, origin_stop_id)
+    destination = place.get(destination_stop_id, destination_stop_id)
+    termini = {place[s[0][0]] for s in trips.values() if place[s[0][0]] == place[s[-1][0]]}
+    if origin not in termini and destination not in termini:
+        return None
+    rides = []
+    for trip_id, trip_stops in trips.items():
+        seq = [place[s] for s, _ in trip_stops]
+        best = None
+        last_origin = None
+        for i, p in enumerate(seq):
+            if p == origin:
+                last_origin = i
+            elif p == destination and last_origin is not None:
+                if best is None or i - last_origin < best[1] - best[0]:
+                    best = (last_origin, i)
+                last_origin = None
+        if best:
+            rides.append((best[1] - best[0], labels.get(trip_id)))
+    if len({label for _length, label in rides}) < 2:
+        return None
+    fewest = min(length for length, _label in rides)
+    agreed = {str(label) for length, label in rides if length == fewest and label is not None}
+    if len(agreed) > 1:
+        agreed = _quickest_rotations(schedule, route_id, origin_stop_id,
+                                     destination_stop_id, agreed)
+    direction = agreed.pop() if len(agreed) == 1 else None
+    _LOGGER.debug("Pair %s -> %s on %s is served both ways round, keeping direction %s",
+                  origin_stop_id, destination_stop_id, route_id, direction)
+    return direction
+
+
+def _clock_seconds(value):
+    """Seconds into the service day of a stop_times time, as the database
+    holds it: "07:10:00", or a pygtfs datetime on 1970-01-01, the next day
+    for a time past midnight."""
+    text_value = str(value or "")
+    days = 0
+    if " " in text_value:
+        day, text_value = text_value.split(" ", 1)
+        days = max(0, int(day[-2:]) - 1)
+    hours, minutes, seconds = text_value.split(":")[:3]
+    return days * 86400 + int(hours) * 3600 + int(minutes) * 60 + int(float(seconds))
+
+
+def _quickest_rotations(schedule, route_id, origin_stop_id, destination_stop_id, candidates):
+    """Of the direction labels in candidates, the one whose shortest rides of
+    the pair take the least time, by the median over its trips; all of them
+    when that does not tell them apart."""
+    origin_group = _place_group("origin")
+    destination_group = _place_group("destination")
+    sql = f"""
+    select t.direction_id, o.departure_time, d.arrival_time
+    from trips t
+    inner join stop_times o on o.trip_id = t.trip_id
+    inner join stop_times d on d.trip_id = t.trip_id
+    where t.route_id = :route_id
+      and o.stop_id in {origin_group}
+      and d.stop_id in {destination_group}
+      and o.stop_sequence < d.stop_sequence
+      and not exists (
+          select 1 from stop_times between_stop
+          where between_stop.trip_id = t.trip_id
+            and between_stop.stop_sequence > o.stop_sequence
+            and between_stop.stop_sequence < d.stop_sequence
+            and (between_stop.stop_id in {origin_group}
+                 or between_stop.stop_id in {destination_group}))
+    """  # noqa: S608
+    minutes = {}
+    try:
+        with schedule.engine.connect() as conn:
+            for label, departs, arrives in conn.execute(text(sql), {
+                    "route_id": route_id, "origin": origin_stop_id,
+                    "destination": destination_stop_id}):
+                if str(label) in candidates:
+                    minutes.setdefault(str(label), []).append(
+                        (_clock_seconds(arrives) - _clock_seconds(departs)) / 60)
+    except (TypeError, ValueError) as ex:
+        _LOGGER.debug("Could not time the rotations of %s -> %s: %s",
+                      origin_stop_id, destination_stop_id, ex)
+        return set(candidates)
+    medians = {label: statistics.median(values) for label, values in minutes.items() if values}
+    if len(medians) < 2 or len(set(medians.values())) < len(medians):
+        return set(candidates)
+    return {min(medians, key=medians.get)}
 
 
 def get_agency_list(schedule, data):

--- a/custom_components/gtfs2/gtfs_helper.py
+++ b/custom_components/gtfs2/gtfs_helper.py
@@ -589,30 +589,140 @@ def get_route_list(schedule, data):
     _LOGGER.debug(f"routes: {routes}")
     return routes
 
-def get_stop_list(schedule, route_id, direction):
-    _LOGGER.debug("Getting stops list for route: %s", route_id)
-    sql_stops = f"""
-    SELECT distinct(s.stop_id), s.stop_name, st.stop_sequence
+def _walk_stops(rows):
+    """Order (trip_id, stop_id, stop_name, stop_sequence) rows, given by trip
+    and sequence, into one stop each, in riding order.
+
+    Trips of one direction do not all run the full length, and a partial
+    trip renumbers stop_sequence from 0, so sorting the union of all trips
+    by stop_sequence interleaves the start of the route with its middle
+    (TAO tram B: 110 short runs from mid-route) and offers a stop once per
+    number it was seen under (Palm Bus 22: 52 entries for 26 stops). Walk
+    the fullest trip first instead, it is the route as the rider rides it,
+    then slot each stop it skips right after the stop preceding it on a
+    trip that does serve it.
+
+    Returns the ordered stop_ids, their names, and the sequence each was
+    first seen under.
+    """
+    trips = {}
+    names = {}
+    for trip_id, stop_id, stop_name, stop_sequence in rows:
+        trips.setdefault(trip_id, []).append((stop_id, stop_sequence))
+        names[stop_id] = stop_name
+    order = []
+    kept_seq = {}
+    for _trip_id, trip_stops in sorted(
+        trips.items(), key=lambda kv: (-len(kv[1]), kv[0])
+    ):
+        prev = -1
+        for stop_id, stop_sequence in trip_stops:
+            if stop_id in kept_seq:
+                prev = order.index(stop_id)
+                continue
+            prev += 1
+            order.insert(prev, stop_id)
+            kept_seq[stop_id] = stop_sequence
+    return order, names, kept_seq
+
+
+def _homonym_ranks(order, names):
+    """{stop_id: n} for the stops whose name the line meets more than once.
+
+    A circular line calls at its terminus twice under ids of its own (TAO 22
+    runs Zenith to Zenith and offers three stops all reading "Zenith"), a
+    square carries four stops of one name (GVB's Surinameplein). Two entries
+    reading the same thing leave the choice to chance, so the repeats are
+    numbered in the order the line calls at them. Same-name stops stay
+    distinct entries: the two sides of a street are two stops, and folding
+    them by name would show a rider departures they cannot take.
+    """
+    by_name = {}
+    for stop_id in order:
+        by_name.setdefault(names[stop_id], []).append(stop_id)
+    rank = {}
+    for group in by_name.values():
+        if len(group) > 1:
+            for n, stop_id in enumerate(group, 1):
+                rank[stop_id] = n
+    return rank
+
+
+def _stop_entries(order, names, kept_seq, rank):
+    """The picker's entries, "stop_id: Name (sequence)". The value keeps the
+    id untouched, the sensor queries on it; only the readable part changes."""
+    stops = []
+    for stop_id in order:
+        shown = names[stop_id]
+        if stop_id in rank:
+            shown = f"{shown} #{rank[stop_id]}"
+        stops.append(f"{stop_id}: {shown} ({kept_seq[stop_id]})")
+    return stops
+
+
+def _route_stop_rows(schedule, route_id, direction):
+    sql_stops = """
+    SELECT st.trip_id, s.stop_id, s.stop_name, st.stop_sequence
     from trips t
     inner join stop_times st on st.trip_id = t.trip_id
     inner join stops s on s.stop_id = st.stop_id
-    where  t.route_id = '{route_id}'
-    and (t.direction_id = {direction} or t.direction_id is null)
-    order by st.stop_sequence
-    """  # noqa: S608
-    stops_list = []
-    stops = []
+    where t.route_id = :route_id
+    and (t.direction_id = :direction or t.direction_id is null)
+    order by st.trip_id, st.stop_sequence
+    """
     with schedule.engine.connect() as conn:
-        rows = conn.execute(text(sql_stops), {"q": "q"}).fetchall()
-    for row_cursor in rows:
-        row = row_cursor._asdict()
-        stops_list.append(list(row_cursor))
-    for x in stops_list:
-        val = x[0] + ": " + x[1] + ' (' + str(x[2]) + ')'
-        stops.append(val)
+        return conn.execute(text(sql_stops), {
+            "route_id": route_id, "direction": int(direction)}).fetchall()
+
+
+def get_stop_list(schedule, route_id, direction):
+    """Every stop a route rides in one direction, once each, in riding order."""
+    _LOGGER.debug("Getting stops list for route: %s", route_id)
+    order, names, kept_seq = _walk_stops(_route_stop_rows(schedule, route_id, direction))
+    stops = _stop_entries(order, names, kept_seq, _homonym_ranks(order, names))
     _LOGGER.debug(f"Route stops: {stops}")
-    return stops 
-    
+    return stops
+
+
+def get_destination_stop_list(schedule, route_id, direction, origin_stop_id):
+    """The stops reachable from origin_stop_id on this route and direction.
+
+    Only the trips that call at the origin are read, and of each only the
+    part after it, so every entry offered can be paired with the origin on
+    at least one trip: a pair that no trip rides never reaches the sensor.
+    Whether that trip runs today is another question, answered by
+    get_next_service_date. Same walk as get_stop_list, so the list reads as
+    the rest of the ride, and the same numbering of repeated names, so a
+    stop reads the same on both screens. A loop that calls at the origin
+    twice is read from its first call, which keeps the way back on offer.
+    """
+    _LOGGER.debug("Getting destinations for route: %s direction: %s from: %s",
+                  route_id, direction, origin_stop_id)
+    sql_stops = """
+    SELECT st.trip_id, s.stop_id, s.stop_name, st.stop_sequence
+    from trips t
+    inner join (
+        select trip_id, min(stop_sequence) as origin_sequence
+        from stop_times where stop_id = :origin group by trip_id
+    ) o on o.trip_id = t.trip_id
+    inner join stop_times st on st.trip_id = t.trip_id
+        and st.stop_sequence > o.origin_sequence
+    inner join stops s on s.stop_id = st.stop_id
+    where t.route_id = :route_id
+    and (t.direction_id = :direction or t.direction_id is null)
+    order by st.trip_id, st.stop_sequence
+    """
+    with schedule.engine.connect() as conn:
+        rows = conn.execute(text(sql_stops), {
+            "route_id": route_id, "direction": int(direction),
+            "origin": origin_stop_id}).fetchall()
+    whole, whole_names, _ = _walk_stops(_route_stop_rows(schedule, route_id, direction))
+    order, names, kept_seq = _walk_stops(rows)
+    stops = _stop_entries(order, names, kept_seq, _homonym_ranks(whole, whole_names))
+    _LOGGER.debug(f"Destinations from {origin_stop_id}: {stops}")
+    return stops
+
+
 def get_agency_list(schedule, data):
     _LOGGER.debug("Getting agencies with data: %s", data)
     sql_agencies = f"""

--- a/custom_components/gtfs2/sensor.py
+++ b/custom_components/gtfs2/sensor.py
@@ -158,11 +158,18 @@ class GTFSDepartureSensor(CoordinatorEntity, SensorEntity):
         self._route = None
         self._agency = None
         self._origin = None
-        self._destination = None        
+        self._destination = None
+        # The entry holds one record of each end's place; the departure says
+        # which record the vehicle really calls at, often the pole across the
+        # road from the entry's one. The station attributes, its position
+        # among them, describe where to wait, so they follow the departure.
+        departure_ends = self._departure or {}
+        origin_id = departure_ends.get("origin_stop_id") or self.origin
+        destination_id = departure_ends.get("destination_stop_id") or self.destination
         # Fetch valid stop information once
         # exclude check if route_type =2 (trains) as no ID is used
         if not self._origin and not self.extracting and self._route_type != "2":
-            stops = self._pygtfs.stops_by_id(self.origin)
+            stops = self._pygtfs.stops_by_id(origin_id) or self._pygtfs.stops_by_id(self.origin)
             if not stops:
                 self._available = False
                 _LOGGER.warning("Origin stop ID %s not found", self.origin)
@@ -172,7 +179,8 @@ class GTFSDepartureSensor(CoordinatorEntity, SensorEntity):
             self._origin = self.origin
         # exclude check if route_type =2 (trains) as no ID is used
         if not self._destination and not self.extracting and self._route_type != "2":
-            stops = self._pygtfs.stops_by_id(self.destination)
+            stops = (self._pygtfs.stops_by_id(destination_id)
+                     or self._pygtfs.stops_by_id(self.destination))
             if not stops:
                 self._available = False
                 _LOGGER.warning(
@@ -437,6 +445,13 @@ class GTFSDepartureSensor(CoordinatorEntity, SensorEntity):
         if self._next_departures:
             self._attributes["next_departures_destination_arrival_times"] = self._departure[
                 "next_departures_destination_arrival_times"][:10] 
+
+        # Add the stop each next departure leaves from: a place can be served
+        # from two of its records in turn (a terminus's quays)
+        self._attributes["next_departures_origin_stop_id"] = []
+        if self._next_departures:
+            self._attributes["next_departures_origin_stop_id"] = self._departure.get(
+                "next_departures_origin_stop_id", [])[:10]
 
       
         self._attributes["gtfs_updated_at"] = self.coordinator.data[

--- a/custom_components/gtfs2/strings.json
+++ b/custom_components/gtfs2/strings.json
@@ -49,8 +49,7 @@
       },	  
       "route": {
         "data": {
-          "route": "Name of the route",
-          "direction": "Principal/initial direction of the vehicle"
+          "route": "Name of the route"
         },
 		"description": "Select from the options below [(docu)]({docu_new_route})"
       },

--- a/custom_components/gtfs2/strings.json
+++ b/custom_components/gtfs2/strings.json
@@ -56,22 +56,17 @@
       },
       "stops": {
         "data": {
-          "origin": "Origin Stop",
-          "destination": "Destination Stop",
-          "name": "Name of the route",
-          "include_tomorrow": "Include tomorrow"
+          "origin": "Origin Stop"
         },
-		"description": "Select from the options below [(docu)]({docu_new_route})"
+        "description": "Select the origin stop, listed in riding order [(docu)]({docu_new_route})"
       },
-      "stops_retry": {
+      "destination": {
         "data": {
-          "origin": "Origin Stop",
           "destination": "Destination Stop",
-          "name": "Name of the route",
-          "include_tomorrow": "Include tomorrow"
+          "name": "Name of the route"
         },
-		"description": "No trip found between selected stops, try again [(docu)]({docu_new_route})"
-      },	  
+        "description": "Select the destination among the stops a trip really rides to from the chosen origin [(docu)]({docu_new_route})"
+      },
 	  "stops_train": {
         "data": {
           "origin": "Enter the city of departure",
@@ -104,6 +99,8 @@
       "stop_incorrect": "Start and/or End destination incorrect, \n possibly no transport 'today' or not in same direction, \n please check logs",
 	  "no_data_file": "Data collection issue: URL incorrect or filename not in the correct folder",
 	  "no_stops": "Data collection issue: probably no stops for the selected route",
+	  "no_destination": "No stop can be reached from the selected origin in this direction",
+	  "generic_failure": "Overall failure, check logs",
 	  "no_zip_file": "Data collection issue: ZIP file not existing in the correct folder, note that it is capital-sensitive",
 	  "stop_limit_reached": "Detected a high number of stops for this radius, \npossibly impacting system performance. \n You can change the limit at your own risk before changing the radius.",
 	  "extracting": "(Still) extracting data, this will take time [(docu)]({docu_extracting})"

--- a/custom_components/gtfs2/translations/de.json
+++ b/custom_components/gtfs2/translations/de.json
@@ -56,20 +56,17 @@
       },
       "stops": {
         "data": {
-          "origin": "Origin Stop",
-          "destination": "Zielhaltestelle",
-          "name": "Name der Route"
+          "origin": "Starthaltestelle"
         },
-        "description": "Wählen Sie aus den Optionen unten [(docu)]({docu_new_route})"
+        "description": "Wählen Sie die Starthaltestelle, in Fahrtreihenfolge [(docu)]({docu_new_route})"
       },
-      "stops_retry": {
+      "destination": {
         "data": {
-          "origin": "Origin Stop",
           "destination": "Zielhaltestelle",
           "name": "Name der Route"
         },
-        "description": "Kein Trip gefunden, bitte Haltestelle(n) ändern [(docu)]({docu_new_route})"
-      },	  
+        "description": "Wählen Sie das Ziel unter den Haltestellen, die eine Fahrt ab der gewählten Starthaltestelle tatsächlich anfährt [(docu)]({docu_new_route})"
+      },
       "stops_train": {
         "data": {
           "origin": "Wählen sie die Stadt ihrer Abfahrt",
@@ -100,6 +97,8 @@
       "files_deleted": "Datenquelle gelöscht, dies kann sich auf bestehende Routen auswirken",
       "stop_incorrect": "Start- und/oder Endziel falsch, möglicherweise kein Transport ‚heute‘ oder nicht in die gleiche Richtung, Protokolle prüfen",
 	  "no_stops": "Problem bei der Datenerfassung: wahrscheinlich keine Stops für die gewählte Route",
+	  "no_destination": "Von der gewählten Starthaltestelle ist in dieser Richtung keine Haltestelle erreichbar",
+	  "generic_failure": "Gesamtfehler, Protokolle prüfen",
       "no_data_file": "Problem bei der Datenerfassung: URL falsch oder Dateiname nicht im richtigen Ordner",
       "no_zip_file": "Problem bei der Datenerfassung: ZIP-Datei ist nicht im richtigen Ordner vorhanden. Beachten Sie, dass Groß- und Kleinschreibung berücksichtigt werden muss",
 	  "stop_limit_reached": "Es wurde eine hohe Anzahl von Stopps für diesen Umkreis festgestellt. \n Es besteht die Gefahr einer Beeinträchtigung der Systemleistung. \n Sie können die Limite auf eigenes Risiko ändern, bevor Sie den Umkreis ändern",

--- a/custom_components/gtfs2/translations/de.json
+++ b/custom_components/gtfs2/translations/de.json
@@ -49,8 +49,7 @@
       },
       "route": {
         "data": {
-          "route": "Name der Route",
-          "direction": "Haupt-/Anfangsrichtung des Fahrzeugs"
+          "route": "Name der Route"
         },
         "description": "Wählen Sie aus den Optionen unten [(docu)]({docu_new_route})"
       },

--- a/custom_components/gtfs2/translations/en.json
+++ b/custom_components/gtfs2/translations/en.json
@@ -56,20 +56,17 @@
       },
       "stops": {
         "data": {
-          "origin": "Origin Stop",
-          "destination": "Destination Stop",
-          "name": "Name of the route"
+          "origin": "Origin Stop"
         },
-		"description": "Select from the options below [(docu)]({docu_new_route})"
+        "description": "Select the origin stop, listed in riding order [(docu)]({docu_new_route})"
       },
-      "stops_retry": {
+      "destination": {
         "data": {
-          "origin": "Origin Stop",
           "destination": "Destination Stop",
           "name": "Name of the route"
         },
-		"description": "No trip found between selected stops, try again [(docu)]({docu_new_route})"
-      },	  
+        "description": "Select the destination among the stops a trip really rides to from the chosen origin [(docu)]({docu_new_route})"
+      },
 	  "stops_train": {
         "data": {
           "origin": "Enter the city of departure",
@@ -101,6 +98,8 @@
       "stop_incorrect": "Start and/or End destination incorrect, \n possibly no transport 'today' or not in same direction, \n please check logs",
 	  "no_data_file": "Data collection issue: URL incorrect or filename not in the correct folder",
 	  "no_stops": "Data collection issue: probably no stops for the selected route",
+	  "no_destination": "No stop can be reached from the selected origin in this direction",
+	  "generic_failure": "Overall failure, check logs",
 	  "no_zip_file": "Data collection issue: ZIP file not existing in the correct folder, note that it is capital-sensitive",
 	  "stop_limit_reached": "Detected a high number of stops for this radius, \npossibly impacting system performance. \n You can change the limit at your own risk before changing the radius.",
 	  "extracting": "(Still) extracting data, this will take time [(docu)]({docu_extracting})"

--- a/custom_components/gtfs2/translations/en.json
+++ b/custom_components/gtfs2/translations/en.json
@@ -49,8 +49,7 @@
       },	  
       "route": {
         "data": {
-          "route": "Name of the route",
-          "direction": "Principal/initial direction of the vehicle"
+          "route": "Name of the route"
         },
 		"description": "Select from the options below [(docu)]({docu_new_route})"
       },

--- a/custom_components/gtfs2/translations/es.json
+++ b/custom_components/gtfs2/translations/es.json
@@ -56,20 +56,17 @@
       },
       "stops": {
         "data": {
-          "origin": "Parada de origen",
-          "destination": "Parada de destino",
-          "name": "Nombre de la ruta"
+          "origin": "Parada de origen"
         },
-		"description": "Seleccione una de las siguientes opciones [(docu)]({docu_new_route})"
+        "description": "Seleccione la parada de origen, en orden de recorrido [(docu)]({docu_new_route})"
       },
-      "stops_retry": {
+      "destination": {
         "data": {
-          "origin": "Parada de origen",
           "destination": "Parada de destino",
           "name": "Nombre de la ruta"
         },
-		"description": "Viaje no encontrado, Inténtalo de nuevo con otra parada(s). [(docu)]({docu_new_route})"
-      },	  
+        "description": "Seleccione el destino entre las paradas a las que un viaje llega realmente desde el origen elegido [(docu)]({docu_new_route})"
+      },
 	  "stops_train": {
         "data": {
           "origin": "Introduzca la ciudad de salida",
@@ -101,6 +98,8 @@
       "stop_incorrect": "Destino inicial y/o final incorrecto, posiblemente no hay transporte 'hoy' o no en la misma dirección, compruebe los registros",
 	  "no_data_file": "Problema de recopilación de datos: URL incorrecta o nombre de archivo que no está en la carpeta correcta",
 	  "no_stops": "Problema de recogida de datos: probablemente no hay paradas en la ruta seleccionada",
+	  "no_destination": "Ninguna parada es alcanzable desde el origen seleccionado en esta dirección",
+	  "generic_failure": "Fallo general, compruebe los registros",
 	  "no_zip_file": "Problema con la recogida de datos: El archivo ZIP no existe en la carpeta correcta, tenga en cuenta que es sensible a las mayúsculas",
 	  "stop_limit_reached": "Se detectó una gran cantidad de paradas para este radio, \nlo que posiblemente afecte el rendimiento del sistema. \nPuedes cambiar el límite bajo tu propia responsabilidad antes de cambiar el radio",
 	  "extracting": "(Todavía) extrayendo datos, esto llevará tiempo [(docu)]({docu_extracting})"

--- a/custom_components/gtfs2/translations/es.json
+++ b/custom_components/gtfs2/translations/es.json
@@ -49,8 +49,7 @@
       },	  
       "route": {
         "data": {
-          "route": "Nombre de la ruta",
-          "direction": "Dirección principal/inicial del vehículo"
+          "route": "Nombre de la ruta"
         },
 		"description": "Seleccione una de las siguientes opciones [(docu)]({docu_new_route})"
       },

--- a/custom_components/gtfs2/translations/fr.json
+++ b/custom_components/gtfs2/translations/fr.json
@@ -49,8 +49,7 @@
       },		  
       "route": {
         "data": {
-          "route": "Nom de la route",
-          "direction": "Direction principale/initiale du véhicule"
+          "route": "Nom de la route"
         },
 		"description": "Sélectionnez parmi les options [(docu)]({docu_new_route})"
       },

--- a/custom_components/gtfs2/translations/fr.json
+++ b/custom_components/gtfs2/translations/fr.json
@@ -56,20 +56,17 @@
       },
       "stops": {
         "data": {
-          "origin": "Arrêt d'origine",
-          "destination": "Arrêt de destination",
-          "name": "Nom de la ligne"
+          "origin": "Arrêt d'origine"
         },
-		"description": "Sélectionnez parmi les options [(docu)]({docu_new_route})"
+        "description": "Sélectionnez l'arrêt d'origine, dans l'ordre de passage [(docu)]({docu_new_route})"
       },
-      "stops_retry": {
+      "destination": {
         "data": {
-          "origin": "Arrêt d'origine",
           "destination": "Arrêt de destination",
           "name": "Nom de la ligne"
         },
-		"description": "Échoué, svp re-essayer avec d'autre arrêt(s) [(docu)]({docu_new_route})"
-      },	  
+        "description": "Sélectionnez la destination parmi les arrêts qu'un trajet dessert réellement depuis l'origine choisie [(docu)]({docu_new_route})"
+      },
 	  "stops_train": {
         "data": {
           "origin": "Ville de départ",
@@ -101,6 +98,8 @@
       "stop_incorrect": "Arrêt de départ et/ou de fin incorrecte, éventuellement pas de transport « aujourd'hui » ou pas dans la même direction, vérifiez logs d'érreur",
 	  "no_data_file": "Problème de collecte de données : URL incorrecte ou nom de fichier ne se trouve pas dans le bon dossier",
 	  "no_stops": "Problème de collecte de données : probablement pas des stops pour la route sélectionné",
+	  "no_destination": "Aucun arrêt n'est atteignable depuis l'origine choisie dans cette direction",
+	  "generic_failure": "Échec global, vérifiez les logs d'erreur",
 	  "no_zip_file": "Problème de collecte de données : fichier ZIP ne se trouve pas dans le bon dossier, note: sensible à la casse",
 	  "stop_limit_reached": "Un nombre élevé d'arrêts a été détecté pour ce rayon, \nrisque d'impact sur les performances du système. \n Vous pouvez modifier la limite à votre propre risque avant de modifier le rayon",
 	  "extracting": "Extraction des données en cours, cela prend du temps [(docu)]({docu_extracting})"

--- a/custom_components/gtfs2/translations/pt.json
+++ b/custom_components/gtfs2/translations/pt.json
@@ -56,20 +56,17 @@
       },
       "stops": {
         "data": {
-          "origin": "Paragem de origem",
-          "destination": "Paragem de destino",
-          "name": "Nome da rota"
+          "origin": "Paragem de origem"
         },
-		"description": "Selecione uma das opções abaixo [(docu)]({docu_new_route})"
+        "description": "Selecione a paragem de origem, por ordem de passagem [(docu)]({docu_new_route})"
       },
-      "stops_retry": {
+      "destination": {
         "data": {
-          "origin": "Paragem de origem",
           "destination": "Paragem de destino",
           "name": "Nome da rota"
         },
-		"description": "Viagem não encontrada, tente novamente com outra paragem(s) [(docu)]({docu_new_route})"
-      },	  
+        "description": "Selecione o destino entre as paragens que uma viagem alcança realmente a partir da origem escolhida [(docu)]({docu_new_route})"
+      },
 	  "stops_train": {
         "data": {
           "origin": "Introduza a cidade de partida",
@@ -101,6 +98,8 @@
       "stop_incorrect": "Paragem de início e/ou de fim incorreta, \n possivelmente sem transporte 'hoje' ou não na mesma direção, \n por favor, verifique os logs",
 	  "no_data_file": "Problema de recolha de dados: URL incorreta ou nome do ficheiro não está na pasta correta",
 	  "no_stops": "Problema de recolha de dados: provavelmente sem paragens para a rota selecionada",
+	  "no_destination": "Nenhuma paragem é alcançável a partir da origem selecionada nesta direção",
+	  "generic_failure": "Falha geral, verifique os logs",
 	  "no_zip_file": "Problema de recolha de dados: Ficheiro ZIP não existe na pasta correta, note que é sensível a maiúsculas",
 	  "stop_limit_reached": "Foi detectado um grande número de paragens neste raio, \nrisco de impacto no desempenho do sistema. \n Pode alterar o limite por sua conta e risco antes de alterar o raio",
 	  "extracting": "(Ainda) a extrair dados, isso vai demorar [(docu)]({docu_extracting})"

--- a/custom_components/gtfs2/translations/pt.json
+++ b/custom_components/gtfs2/translations/pt.json
@@ -49,8 +49,7 @@
       },	  
       "route": {
         "data": {
-          "route": "Nome da rota",
-          "direction": "Direção principal/inicial do veículo"
+          "route": "Nome da rota"
         },
 		"description": "Selecione uma das opções abaixo [(docu)]({docu_new_route})"
       },

--- a/tests/case_route/case_1c_static_route_output_interpret_departure_rows.txt
+++ b/tests/case_route/case_1c_static_route_output_interpret_departure_rows.txt
@@ -60,5 +60,8 @@
   ],
   'next_departures_destination_arrival_times': [
     '2026-09-03T22:36:00+00:00'
+  ],
+  'next_departures_origin_stop_id': [
+    'origin_stop_id'
   ]
 }

--- a/tests/case_route/case_1d_static_route_output_coordinator_data.txt
+++ b/tests/case_route/case_1d_static_route_output_coordinator_data.txt
@@ -72,6 +72,9 @@
   ],
   'next_departures_destination_arrival_times': [
     '2026-09-03T22:36:00+00:00'
+  ],
+  'next_departures_origin_stop_id': [
+    'origin_stop_id'
   ]
   },
   'next_departure_realtime_attr': {

--- a/tests/case_route/case_2c_static_route_output_interpret_departure_rows.txt
+++ b/tests/case_route/case_2c_static_route_output_interpret_departure_rows.txt
@@ -65,5 +65,9 @@
   'next_departures_destination_arrival_times': [
     '2026-09-03T12:36:00+00:00',
     '2026-09-03T13:21:00+00:00'
+  ],
+  'next_departures_origin_stop_id': [
+    'origin_stop_id',
+    'origin_stop_id'
   ]
 }

--- a/tests/case_route/case_2d_static_route_output_coordinator_data.txt
+++ b/tests/case_route/case_2d_static_route_output_coordinator_data.txt
@@ -77,6 +77,10 @@
   'next_departures_destination_arrival_times': [
     '2026-09-03T12:36:00+00:00',
     '2026-09-03T13:21:00+00:00'
+  ],
+  'next_departures_origin_stop_id': [
+    'origin_stop_id',
+    'origin_stop_id'
   ]
   },
   'next_departure_realtime_attr': {

--- a/tests/case_route/case_3c_static_route_output_interpret_departure_rows.txt
+++ b/tests/case_route/case_3c_static_route_output_interpret_departure_rows.txt
@@ -65,5 +65,9 @@
   'next_departures_destination_arrival_times': [
     '2026-09-03T12:36:00+00:00',
     '2026-09-04T13:21:00+00:00'
+  ],
+  'next_departures_origin_stop_id': [
+    'origin_stop_id',
+    'origin_stop_id'
   ]
 }

--- a/tests/case_route/case_3d_static_route_output_coordinator_data.txt
+++ b/tests/case_route/case_3d_static_route_output_coordinator_data.txt
@@ -77,6 +77,10 @@
   'next_departures_destination_arrival_times': [
     '2026-09-03T12:36:00+00:00',
     '2026-09-04T13:21:00+00:00'
+  ],
+  'next_departures_origin_stop_id': [
+    'origin_stop_id',
+    'origin_stop_id'
   ]
   },
   'next_departure_realtime_attr': {

--- a/tests/case_route/case_4c_static_route_output_interpret_departure_rows.txt
+++ b/tests/case_route/case_4c_static_route_output_interpret_departure_rows.txt
@@ -65,5 +65,9 @@
   'next_departures_destination_arrival_times': [
     '2026-09-04T12:36:00+00:00',
     '2026-09-04T13:21:00+00:00'
+  ],
+  'next_departures_origin_stop_id': [
+    'origin_stop_id',
+    'origin_stop_id'
   ]
 }

--- a/tests/case_route/case_4d_static_route_output_coordinator_data.txt
+++ b/tests/case_route/case_4d_static_route_output_coordinator_data.txt
@@ -77,6 +77,10 @@
   'next_departures_destination_arrival_times': [
     '2026-09-04T12:36:00+00:00',
     '2026-09-04T13:21:00+00:00'
+  ],
+  'next_departures_origin_stop_id': [
+    'origin_stop_id',
+    'origin_stop_id'
   ]
   },
   'next_departure_realtime_attr': {

--- a/tests/case_route/case_5c_static_route_output_interpret_departure_rows.txt
+++ b/tests/case_route/case_5c_static_route_output_interpret_departure_rows.txt
@@ -60,5 +60,8 @@
   ],
   'next_departures_destination_arrival_times': [
     '2026-09-03T22:36:00+00:00'
+  ],
+  'next_departures_origin_stop_id': [
+    'origin_stop_id'
   ]
 }

--- a/tests/case_route/case_5d_static_route_output_coordinator_data.txt
+++ b/tests/case_route/case_5d_static_route_output_coordinator_data.txt
@@ -72,6 +72,9 @@
   ],
   'next_departures_destination_arrival_times': [
     '2026-09-03T22:36:00+00:00'
+  ],
+  'next_departures_origin_stop_id': [
+    'origin_stop_id'
   ]
   },
   'next_departure_realtime_attr': {

--- a/tests/case_route_combined/case_1_static_realtime_output_combined.txt
+++ b/tests/case_route_combined/case_1_static_realtime_output_combined.txt
@@ -8,6 +8,7 @@
   'file': 'zou_proximite',
   'route_type': '3',
   'route': 'route_id',
+  'loop_direction': None,
   'extracting': False,
   'next_departure': {
     'trip_id': 'trip_id_1',
@@ -76,6 +77,10 @@
     'next_departures_destination_arrival_times': [
       '2026-09-03T12:36:00+00:00',
       '2026-09-03T13:36:00+00:00'
+    ],
+    'next_departures_origin_stop_id': [
+      'origin_stop_id',
+      'origin_stop_id'
     ]
   },
   'next_departure_realtime_attr': {

--- a/tests/case_route_combined/case_2_static_realtime_output_combined.txt
+++ b/tests/case_route_combined/case_2_static_realtime_output_combined.txt
@@ -8,6 +8,7 @@
   'file': 'zou_proximite',
   'route_type': '3',
   'route': 'route_id',
+  'loop_direction': None,
   'extracting': False,
   'next_departure': {
     'trip_id': 'trip_id_1',
@@ -76,6 +77,10 @@
     'next_departures_destination_arrival_times': [
       '2026-09-03T12:36:00+00:00',
       '2026-09-04T13:36:00+00:00'
+    ],
+    'next_departures_origin_stop_id': [
+      'origin_stop_id',
+      'origin_stop_id'
     ]
   },
   'next_departure_realtime_attr': {

--- a/tests/case_route_combined/case_4_static_realtime_output_combined.txt
+++ b/tests/case_route_combined/case_4_static_realtime_output_combined.txt
@@ -8,6 +8,7 @@
   'file': 'zou_proximite',
   'route_type': '3',
   'route': 'route_id',
+  'loop_direction': None,
   'extracting': False,
   'next_departure': {
     'trip_id': 'trip_id_1',
@@ -76,6 +77,10 @@
     'next_departures_destination_arrival_times': [
       '2026-09-03T12:36:00+00:00',
       '2026-09-03T13:36:00+00:00'
+    ],
+    'next_departures_origin_stop_id': [
+      'origin_stop_id',
+      'origin_stop_id'
     ]
   },
   'next_departure_realtime_attr': {

--- a/tests/case_route_combined/case_5_static_realtime_output_combined.txt
+++ b/tests/case_route_combined/case_5_static_realtime_output_combined.txt
@@ -8,6 +8,7 @@
   'file': 'zou_proximite',
   'route_type': '3',
   'route': 'route_id',
+  'loop_direction': None,
   'extracting': False,
   'next_departure': {
     'trip_id': 'trip_id_1',
@@ -76,6 +77,10 @@
     'next_departures_destination_arrival_times': [
       '2026-09-03T12:36:00+00:00',
       '2026-09-03T13:36:00+00:00'
+    ],
+    'next_departures_origin_stop_id': [
+      'origin_stop_id',
+      'origin_stop_id'
     ]
   },
   'next_departure_realtime_attr': {

--- a/tests/case_route_combined/case_6_static_realtime_output_combined.txt
+++ b/tests/case_route_combined/case_6_static_realtime_output_combined.txt
@@ -8,6 +8,7 @@
   'file': 'zou_proximite',
   'route_type': '3',
   'route': 'route_id',
+  'loop_direction': None,
   'extracting': False,
   'next_departure': {
     'trip_id': 'trip_id_1',
@@ -76,6 +77,10 @@
     'next_departures_destination_arrival_times': [
       '2026-09-03T12:36:00+00:00',
       '2026-09-03T13:36:00+00:00'
+    ],
+    'next_departures_origin_stop_id': [
+      'origin_stop_id',
+      'origin_stop_id'
     ]
   },
   'next_departure_realtime_attr': {

--- a/tests/case_route_combined/case_7_static_realtime_output_combined.txt
+++ b/tests/case_route_combined/case_7_static_realtime_output_combined.txt
@@ -8,6 +8,7 @@
   'file': 'zou_proximite',
   'route_type': '3',
   'route': 'route_id',
+  'loop_direction': None,
   'extracting': False,
   'next_departure': {
     'trip_id': 'trip_id_1',
@@ -76,6 +77,10 @@
     'next_departures_destination_arrival_times': [
       '2026-09-03T12:36:00+00:00',
 	  '2026-09-03T13:36:00+00:00'
+    ],
+    'next_departures_origin_stop_id': [
+      'origin_stop_id',
+      'origin_stop_id'
     ]
   },
   'next_departure_realtime_attr': {

--- a/tests_provider/instructions.txt
+++ b/tests_provider/instructions.txt
@@ -5,7 +5,7 @@ What it is:
 - manifest.json in each says where the bytes came from, what was kept and why; sncf also carries scenarios.json, the journeys its entities make testable
 - fixtures/build_fixture.py cuts any static zip down to named routes, a few trips per stop pattern
 - fixtures/capture_rt.py freezes a static + trip updates + alerts capture, SNCF by default, any feed with --static/--trip-updates/--alerts
-- test_journeys.py reads them: one test per fixture, route, direction and promise (stop list, a valid pair, the swapped pair), through the real query on a db fixture_db.py builds from the zip, no pygtfs import
+- test_journeys.py reads them: one test per fixture, route, direction and promise (stop list, destinations from an origin, a valid pair, the swapped pair), through the real query on a db fixture_db.py builds from the zip, no pygtfs import
 - the clock is pinned with freezegun to a day the trips run, in the agency's zone, so the data never has to be shifted to today
 - the cases known to fail on main are marked xfail with the reason, strict, so a fix has to lift its mark
 
@@ -20,6 +20,10 @@ How a case is built:
   file, the feed itself says what the line rides
 - stop_list asks get_stop_list for the route and direction and checks the list
   against every sequence: each stop once, in an order every trip agrees with
+- destinations asks get_destination_stop_list from three stops of each
+  sequence (the first, one in the middle, the one before last) and checks the
+  list against the trips through that stop: every stop they ride to after it,
+  once, in riding order, and nothing no trip through it reaches
 - pairs and swapped take three pairs per sequence (the two ends, first stop to
   middle, middle to last), pin the clock with freezegun at 00:05 in the agency's
   zone on the first day one of those trips runs, and hand get_next_departure

--- a/tests_provider/results.txt
+++ b/tests_provider/results.txt
@@ -1,15 +1,18 @@
-test_journeys.py case results -- 95 case(s)
+test_journeys.py case results -- 124 case(s)
+
+case: gvb-1-d0-destinations
+  result: PASSED
 
 case: gvb-1-d0-pairs
   result: PASSED
 
 case: gvb-1-d0-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 4138837 Amsterdam, Leidseplein at 1 and 4 and 16 and 19, 3979966 Amsterdam, Rhijnvis Feithstraat at 1 and 13, 3980187 Amsterdam, Rijksmuseum at 2 and 5 and 17 and 20, and 12 more
+  result: PASSED
 
 case: gvb-1-d0-swapped
+  result: PASSED
+
+case: gvb-1-d1-destinations
   result: PASSED
 
 case: gvb-1-d1-pairs
@@ -17,37 +20,38 @@ case: gvb-1-d1-pairs
 
 case: gvb-1-d1-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list offers a stop twice: 3979966 Amsterdam, Rhijnvis Feithstraat at 1 and 2, 3979725 Amsterdam, Surinameplein at 1 and 16 and 19, 3980938 Amsterdam, Jan Pieter Heijestraat at 2 and 3, and 24 more
-    the list offers one station twice in a row: 3979766 Amsterdam, Weesperplein then 3980631 Amsterdam, Weesperplein
+    the list offers one station twice in a row: 3979810 Amsterdam, Azartplein then 3980295 Amsterdam, Azartplein
 
 case: gvb-1-d1-swapped
+  result: PASSED
+
+case: gvb-13-d0-destinations
   result: PASSED
 
 case: gvb-13-d0-pairs
   result: PASSED
 
 case: gvb-13-d0-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 3979794 Amsterdam, Mercatorplein at 1 and 10, 3980464 Amsterdam, Marco Polostraat at 2 and 11, 3980544 Amsterdam, Admiraal de Ruijterweg at 3 and 12, and 10 more
-    the list offers one station twice in a row: 3980268 Amsterdam, Elandsgracht then 3980182 Amsterdam, Elandsgracht
+  result: PASSED
 
 case: gvb-13-d0-swapped
+  result: PASSED
+
+case: gvb-13-d1-destinations
   result: PASSED
 
 case: gvb-13-d1-pairs
   result: PASSED
 
 case: gvb-13-d1-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 3980794 Amsterdam, Admiraal Helfrichstraat at 1 and 14, 3980974 Amsterdam, Jan Voermanstraat at 2 and 15, 3980162 Amsterdam, Jan Tooropstraat at 3 and 16, and 6 more
+  result: PASSED
 
 case: gvb-13-d1-swapped
+  result: PASSED
+
+case: gvb-14-d0-destinations
   result: PASSED
 
 case: gvb-14-d0-pairs
@@ -55,12 +59,14 @@ case: gvb-14-d0-pairs
 
 case: gvb-14-d0-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list offers a stop twice: 3981274 Amsterdam, Centraal Station at 1 and 16, 3979805 Amsterdam, Mauritskade at 1 and 9, 3980549 Amsterdam, Mauritskade at 1 and 8, and 16 more
-    the list offers one station twice in a row: 3980489 Amsterdam, Dam then 3980251 Amsterdam, Dam, 3981274 Amsterdam, Centraal Station then 4045456 Amsterdam, Centraal Station
+    the list offers one station twice in a row: 3980992 Amsterdam, Flevopark then 3980163 Amsterdam, Flevopark, 3980251 Amsterdam, Dam then 3980489 Amsterdam, Dam
 
 case: gvb-14-d0-swapped
+  result: PASSED
+
+case: gvb-14-d1-destinations
   result: PASSED
 
 case: gvb-14-d1-pairs
@@ -68,54 +74,45 @@ case: gvb-14-d1-pairs
 
 case: gvb-14-d1-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups); trams 1, 7 and 17 also carry wrong direction_ids
   detail:
-    the stop list offers a stop twice: 3980549 Amsterdam, Mauritskade at 1 and 7 and 8, 3980234 Amsterdam, Javaplein at 1 and 4 and 12, 3981274 Amsterdam, Centraal Station at 1 and 9 and 15 and 16, and 14 more
-    the list offers one station twice in a row: 4045456 Amsterdam, Centraal Station then 3981274 Amsterdam, Centraal Station, 3980234 Amsterdam, Javaplein then 3981356 Amsterdam, Javaplein, 3979768 Amsterdam, Plantage Lepellaan then 3981148 Amsterdam, Plantage Lepellaan
-    the list contradicts the riding order 3980234 .. 3981274
-    the list contradicts the riding order 3981274 .. 3980992
+    the list offers one station twice in a row: 3980992 Amsterdam, Flevopark then 3980163 Amsterdam, Flevopark
 
 case: gvb-14-d1-swapped
+  result: PASSED
+
+case: gvb-17-d0-destinations
   result: PASSED
 
 case: gvb-17-d0-pairs
   result: PASSED
 
 case: gvb-17-d0-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 3980305 Amsterdam, Corantijnstraat at 1 and 11, 3981271 Amsterdam, Centraal Station at 1 and 8 and 14 and 24, 3980599 Amsterdam, Leidseplein at 1 and 7 and 17, and 11 more
-    the list offers one station twice in a row: 3981140 Amsterdam, Witte de Withstraat then 3980752 Amsterdam, Witte de Withstraat
-    the list contradicts the riding order 3981271 .. 4132580
+  result: PASSED
 
 case: gvb-17-d0-swapped
+  result: PASSED
+
+case: gvb-17-d1-destinations
   result: PASSED
 
 case: gvb-17-d1-pairs
   result: PASSED
 
 case: gvb-17-d1-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 3981271 Amsterdam, Centraal Station at 1 and 8 and 15, 3979725 Amsterdam, Surinameplein at 1 and 15, 3980599 Amsterdam, Leidseplein at 1 and 8, and 15 more
-    the list offers one station twice in a row: 3980573 Amsterdam, Koningsplein then 3980418 Amsterdam, Koningsplein
-    the list contradicts the riding order 3981271 .. 3980351
+  result: PASSED
 
 case: gvb-17-d1-swapped
+  result: PASSED
+
+case: gvb-7-d0-destinations
   result: PASSED
 
 case: gvb-7-d0-pairs
   result: PASSED
 
 case: gvb-7-d0-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 3980004 Amsterdam, Frederiksplein at 1 and 11, 3980102 Amsterdam, Sloterpark at 1 and 20 and 30, 3981181 Amsterdam, Frederiksplein at 1 and 19, and 22 more
-    the list offers one station twice in a row: 3980060 Amsterdam, Willem Schoutenstraat then 3980854 Amsterdam, Willem Schoutenstraat
-    the list contradicts the riding order 3980102 .. 3979878
+  result: PASSED
 
 case: gvb-7-d0-swapped
   result: XFAILED
@@ -123,22 +120,23 @@ case: gvb-7-d0-swapped
   detail:
     asked 3979878 -> 3980102 on 152328 d0 (stop 23 to stop 1 of a 23-stop ride, this direction does not make it): got 3979878 -> 3980102 on 152328 d1, trip 380799628
 
+case: gvb-7-d1-destinations
+  result: PASSED
+
 case: gvb-7-d1-pairs
   result: PASSED
 
 case: gvb-7-d1-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the stop list offers a stop twice: 3980102 Amsterdam, Sloterpark at 1 and 20 and 24, 3981181 Amsterdam, Frederiksplein at 1 and 19, 3980004 Amsterdam, Frederiksplein at 1 and 5, and 28 more
-    the list offers one station twice in a row: 3980752 Amsterdam, Witte de Withstraat then 3981140 Amsterdam, Witte de Withstraat
-    the list contradicts the riding order 3980102 .. 3980992
+  result: PASSED
 
 case: gvb-7-d1-swapped
   result: XFAILED
   reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
   detail:
     asked 3980102 -> 3979878 on 152328 d1 (stop 24 to stop 1 of a 24-stop ride, this direction does not make it): got 3980102 -> 3979878 on 152328 d0, trip 380799711
+
+case: palmbus-21-d0-destinations
+  result: PASSED
 
 case: palmbus-21-d0-pairs
   result: PASSED
@@ -149,16 +147,19 @@ case: palmbus-21-d0-stop_list
 case: palmbus-21-d0-swapped
   result: PASSED
 
+case: palmbus-22-d0-destinations
+  result: PASSED
+
 case: palmbus-22-d0-pairs
   result: PASSED
 
 case: palmbus-22-d0-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
-  detail:
-    the stop list offers a stop twice: THEC0A Théoule Plages at 1 and 13, ISL22R Le Princes des Iles at 2 and 14, THEG0A Théoule Gare at 3 and 15, and 24 more
+  result: PASSED
 
 case: palmbus-22-d0-swapped
+  result: PASSED
+
+case: palmbus-22-d1-destinations
   result: PASSED
 
 case: palmbus-22-d1-pairs
@@ -168,6 +169,9 @@ case: palmbus-22-d1-stop_list
   result: PASSED
 
 case: palmbus-22-d1-swapped
+  result: PASSED
+
+case: palmbus-A-d0-destinations
   result: PASSED
 
 case: palmbus-A-d0-pairs
@@ -182,6 +186,9 @@ case: palmbus-A-d0-swapped
   detail:
     asked GSNF0A -> CCO15A on A d0 (stop 35 to stop 1 of a 35-stop ride, this direction does not make it): got GSNF0A -> CCO15A on A d1, trip 1418363764878
 
+case: palmbus-A-d1-destinations
+  result: PASSED
+
 case: palmbus-A-d1-pairs
   result: PASSED
 
@@ -193,6 +200,9 @@ case: palmbus-A-d1-swapped
   reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
   detail:
     asked CCO15A -> GSNF0A on A d1 (stop 36 to stop 1 of a 36-stop ride, this direction does not make it): got CCO15A -> GSNF0A on A d0, trip 1418363764404
+
+case: palmbus-B-d0-destinations
+  result: PASSED
 
 case: palmbus-B-d0-pairs
   result: PASSED
@@ -206,14 +216,14 @@ case: palmbus-B-d0-swapped
   detail:
     asked MSCE0A -> GSNF0R on B d0 (stop 29 to stop 1 of a 29-stop ride, this direction does not make it): got MSCE0A -> GSNF0R on B d1, trip 1418363764159
 
+case: palmbus-B-d1-destinations
+  result: PASSED
+
 case: palmbus-B-d1-pairs
   result: PASSED
 
 case: palmbus-B-d1-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
-  detail:
-    the stop list offers a stop twice: TOUR0A Tournamy at 1 and 5, BLAN0C Blanchisserie at 1 and 7 and 11, OLI01A L'Olivet at 1 and 5 and 11 and 15, and 20 more
+  result: PASSED
 
 case: palmbus-B-d1-swapped
   result: XFAILED
@@ -266,6 +276,9 @@ case: sncf-journeys-P8(CDD3F95:)-d1-pairs
     asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 8 of a 8-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
     asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 5 of a 5-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
 
+case: tao-journeys-22-d0-destinations
+  result: PASSED
+
 case: tao-journeys-22-d0-pairs
   result: PASSED
 
@@ -273,6 +286,9 @@ case: tao-journeys-22-d0-stop_list
   result: PASSED
 
 case: tao-journeys-22-d0-swapped
+  result: PASSED
+
+case: tao-journeys-22-d1-destinations
   result: PASSED
 
 case: tao-journeys-22-d1-pairs
@@ -284,14 +300,14 @@ case: tao-journeys-22-d1-stop_list
 case: tao-journeys-22-d1-swapped
   result: PASSED
 
+case: tao-journeys-40-d0-destinations
+  result: PASSED
+
 case: tao-journeys-40-d0-pairs
   result: PASSED
 
 case: tao-journeys-40-d0-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
-  detail:
-    the stop list offers a stop twice: ORLEANS:StopArea:00007923 Chèques Postaux - M. Ricoud - Quai C at 0 and 10, ORLEANS:StopArea:00034303 Montesquieu at 1 and 11, ORLEANS:StopArea:01036003 Théâtre Philipe at 2 and 12, and 12 more
+  result: PASSED
 
 case: tao-journeys-40-d0-swapped
   result: XFAILED
@@ -300,20 +316,23 @@ case: tao-journeys-40-d0-swapped
     asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d0 (stop 15 to stop 1 of a 15-stop ride, this direction does not make it): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001
     asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401
 
+case: tao-journeys-40-d1-destinations
+  result: PASSED
+
 case: tao-journeys-40-d1-pairs
   result: PASSED
 
 case: tao-journeys-40-d1-stop_list
-  result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
-  detail:
-    the stop list offers a stop twice: ORLEANS:StopArea:01017071 Gare d'Orléans - Quai M bis at 0 and 1, ORLEANS:StopArea:00019303 Halmagrand at 1 and 2, ORLEANS:StopArea:00005401 Carré St-Vincent at 2 and 3, and 23 more
+  result: PASSED
 
 case: tao-journeys-40-d1-swapped
   result: XFAILED
   reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
   detail:
     asked ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d1 (stop 26 to stop 1 of a 26-stop ride, this direction does not make it): got ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0, trip ORLEANS:VehicleJourney:40_A_86_10_4002_1_070100
+
+case: tao-journeys-41-d0-destinations
+  result: PASSED
 
 case: tao-journeys-41-d0-pairs
   result: PASSED
@@ -322,6 +341,9 @@ case: tao-journeys-41-d0-stop_list
   result: PASSED
 
 case: tao-journeys-41-d0-swapped
+  result: PASSED
+
+case: tao-journeys-41-d1-destinations
   result: PASSED
 
 case: tao-journeys-41-d1-pairs
@@ -333,15 +355,17 @@ case: tao-journeys-41-d1-stop_list
 case: tao-journeys-41-d1-swapped
   result: PASSED
 
+case: tao-journeys-A-d0-destinations
+  result: PASSED
+
 case: tao-journeys-A-d0-pairs
   result: PASSED
 
 case: tao-journeys-A-d0-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)
   detail:
-    the stop list offers a stop twice: ORLEANS:StopArea:THOPAC1 Hôpital-Accueil at 0 and 1, ORLEANS:StopArea:TBOLIE1 Bolière at 1 and 2, ORLEANS:StopArea:TPOSTA1 Chèques Postaux - Michel Ricoud at 2 and 3, and 24 more
-    the list offers one station twice in a row: ORLEANS:StopArea:THOPIT2 Hôpital de La Source then ORLEANS:StopArea:THOPIT1 Hôpital de La Source, ORLEANS:StopArea:TZENIT1 Zénith then ORLEANS:StopArea:TZENIT1 Zénith, ORLEANS:StopArea:TVERNE2 Jules Verne then ORLEANS:StopArea:TVERNE1 Jules Verne, and 2 more
+    the list offers one station twice in a row: ORLEANS:StopArea:THOPIT1 Hôpital de La Source then ORLEANS:StopArea:THOPIT2 Hôpital de La Source, ORLEANS:StopArea:TVERNE1 Jules Verne then ORLEANS:StopArea:TVERNE2 Jules Verne
 
 case: tao-journeys-A-d0-swapped
   result: XFAILED
@@ -352,14 +376,17 @@ case: tao-journeys-A-d0-swapped
     asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900
     asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_468_10_A01_1_145630
 
+case: tao-journeys-A-d1-destinations
+  result: PASSED
+
 case: tao-journeys-A-d1-pairs
   result: PASSED
 
 case: tao-journeys-A-d1-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)
   detail:
-    the list offers one station twice in a row: ORLEANS:StopArea:TVERNE2 Jules Verne then ORLEANS:StopArea:TVERNE1 Jules Verne, ORLEANS:StopArea:THOPIT2 Hôpital de La Source then ORLEANS:StopArea:THOPIT1 Hôpital de La Source
+    the list offers one station twice in a row: ORLEANS:StopArea:TVERNE1 Jules Verne then ORLEANS:StopArea:TVERNE2 Jules Verne, ORLEANS:StopArea:THOPIT1 Hôpital de La Source then ORLEANS:StopArea:THOPIT2 Hôpital de La Source
 
 case: tao-journeys-A-d1-swapped
   result: XFAILED
@@ -370,15 +397,17 @@ case: tao-journeys-A-d1-swapped
     asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_467_10_A01_1_060100
     asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_466_10_A01_1_155930
 
+case: tao-journeys-B-d0-destinations
+  result: PASSED
+
 case: tao-journeys-B-d0-pairs
   result: PASSED
 
 case: tao-journeys-B-d0-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)
   detail:
-    the stop list offers a stop twice: ORLEANS:StopArea:TGAUBR2 Gaudier-Brzeska at 0 and 19, ORLEANS:StopArea:TPTBOR2 Pont Bordeau at 1 and 20, ORLEANS:StopArea:TVERVI2 Verville at 2 and 21, and 3 more
-    the list offers one station twice in a row: ORLEANS:StopArea:THAMEA1 Clos du Hameau then ORLEANS:StopArea:THAMEA2 Clos du Hameau
+    the list offers one station twice in a row: ORLEANS:StopArea:THAMEA2 Clos du Hameau then ORLEANS:StopArea:THAMEA1 Clos du Hameau
 
 case: tao-journeys-B-d0-swapped
   result: XFAILED
@@ -387,14 +416,17 @@ case: tao-journeys-B-d0-swapped
     asked ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_173_10_B01_1_055030
     asked ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_175_10_B09_1_201110
 
+case: tao-journeys-B-d1-destinations
+  result: PASSED
+
 case: tao-journeys-B-d1-pairs
   result: PASSED
 
 case: tao-journeys-B-d1-stop_list
   result: XFAILED
-  reason: the stop selector offers a stop twice or out of riding order (discussion #198)
+  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)
   detail:
-    the stop list offers a stop twice: ORLEANS:StopArea:TAMBER1 Ambert at 0 and 6, ORLEANS:StopArea:TGVILL1 Grand Villiers at 1 and 7, ORLEANS:StopArea:TMOZAR1 Mozart at 2 and 8, and 16 more
+    the list offers one station twice in a row: ORLEANS:StopArea:THAMEA2 Clos du Hameau then ORLEANS:StopArea:THAMEA1 Clos du Hameau
 
 case: tao-journeys-B-d1-swapped
   result: XFAILED
@@ -402,6 +434,9 @@ case: tao-journeys-B-d1-swapped
   detail:
     asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d1 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_167_10_B01_1_050300
     asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d1 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_168_10_B06_1_195730
+
+case: tao-journeys-N-d0-destinations
+  result: PASSED
 
 case: tao-journeys-N-d0-pairs
   result: PASSED
@@ -414,6 +449,9 @@ case: tao-journeys-N-d0-swapped
   reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
   detail:
     asked ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d0 (stop 30 to stop 1 of a 30-stop ride, this direction does not make it): got ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d1, trip ORLEANS:VehicleJourney:N_R_16_21_2184_4_013000
+
+case: tao-journeys-N-d1-destinations
+  result: PASSED
 
 case: tao-journeys-N-d1-pairs
   result: PASSED

--- a/tests_provider/results.txt
+++ b/tests_provider/results.txt
@@ -1,4 +1,64 @@
-test_journeys.py case results -- 124 case(s)
+provider case results -- 150 case(s)
+
+case: adelaide-GLNELG-d0-destinations
+  result: PASSED
+
+case: adelaide-GLNELG-d0-pairs
+  result: PASSED
+
+case: adelaide-GLNELG-d0-stop_list
+  result: PASSED
+
+case: adelaide-GLNELG-d0-swapped
+  result: PASSED
+
+case: adelaide-GLNELG-d1-destinations
+  result: PASSED
+
+case: adelaide-GLNELG-d1-pairs
+  result: PASSED
+
+case: adelaide-GLNELG-d1-stop_list
+  result: PASSED
+
+case: adelaide-GLNELG-d1-swapped
+  result: PASSED
+
+case: adelaide-N1-d0-destinations
+  result: PASSED
+
+case: adelaide-N1-d0-pairs
+  result: PASSED
+
+case: adelaide-N1-d0-stop_list
+  result: PASSED
+
+case: adelaide-N1-d0-swapped
+  result: PASSED
+
+case: adelaide-N1-d1-destinations
+  result: PASSED
+
+case: adelaide-N1-d1-pairs
+  result: PASSED
+
+case: adelaide-N1-d1-stop_list
+  result: PASSED
+
+case: adelaide-N1-d1-swapped
+  result: PASSED
+
+case: adelaide-local_stop-calendar
+  result: PASSED
+
+case: adelaide-local_stop-calendar_dates
+  result: PASSED
+
+case: adelaide-route-calendar
+  result: PASSED
+
+case: adelaide-route-calendar_dates
+  result: PASSED
 
 case: gvb-1-d0-destinations
   result: PASSED
@@ -19,10 +79,7 @@ case: gvb-1-d1-pairs
   result: PASSED
 
 case: gvb-1-d1-stop_list
-  result: XFAILED
-  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the list offers one station twice in a row: 3979810 Amsterdam, Azartplein then 3980295 Amsterdam, Azartplein
+  result: PASSED
 
 case: gvb-1-d1-swapped
   result: PASSED
@@ -58,10 +115,7 @@ case: gvb-14-d0-pairs
   result: PASSED
 
 case: gvb-14-d0-stop_list
-  result: XFAILED
-  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the list offers one station twice in a row: 3980992 Amsterdam, Flevopark then 3980163 Amsterdam, Flevopark, 3980251 Amsterdam, Dam then 3980489 Amsterdam, Dam
+  result: PASSED
 
 case: gvb-14-d0-swapped
   result: PASSED
@@ -73,10 +127,7 @@ case: gvb-14-d1-pairs
   result: PASSED
 
 case: gvb-14-d1-stop_list
-  result: XFAILED
-  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups); trams 1, 7 and 17 also carry wrong direction_ids
-  detail:
-    the list offers one station twice in a row: 3980992 Amsterdam, Flevopark then 3980163 Amsterdam, Flevopark
+  result: PASSED
 
 case: gvb-14-d1-swapped
   result: PASSED
@@ -115,10 +166,7 @@ case: gvb-7-d0-stop_list
   result: PASSED
 
 case: gvb-7-d0-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked 3979878 -> 3980102 on 152328 d0 (stop 23 to stop 1 of a 23-stop ride, this direction does not make it): got 3979878 -> 3980102 on 152328 d1, trip 380799628
+  result: PASSED
 
 case: gvb-7-d1-destinations
   result: PASSED
@@ -130,10 +178,19 @@ case: gvb-7-d1-stop_list
   result: PASSED
 
 case: gvb-7-d1-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked 3980102 -> 3979878 on 152328 d1 (stop 24 to stop 1 of a 24-stop ride, this direction does not make it): got 3980102 -> 3979878 on 152328 d0, trip 380799711
+  result: PASSED
+
+case: gvb-local_stop-calendar
+  result: PASSED
+
+case: gvb-local_stop-calendar_dates
+  result: PASSED
+
+case: gvb-route-calendar
+  result: PASSED
+
+case: gvb-route-calendar_dates
+  result: PASSED
 
 case: palmbus-21-d0-destinations
   result: PASSED
@@ -181,10 +238,7 @@ case: palmbus-A-d0-stop_list
   result: PASSED
 
 case: palmbus-A-d0-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked GSNF0A -> CCO15A on A d0 (stop 35 to stop 1 of a 35-stop ride, this direction does not make it): got GSNF0A -> CCO15A on A d1, trip 1418363764878
+  result: PASSED
 
 case: palmbus-A-d1-destinations
   result: PASSED
@@ -196,10 +250,7 @@ case: palmbus-A-d1-stop_list
   result: PASSED
 
 case: palmbus-A-d1-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked CCO15A -> GSNF0A on A d1 (stop 36 to stop 1 of a 36-stop ride, this direction does not make it): got CCO15A -> GSNF0A on A d0, trip 1418363764404
+  result: PASSED
 
 case: palmbus-B-d0-destinations
   result: PASSED
@@ -211,10 +262,7 @@ case: palmbus-B-d0-stop_list
   result: PASSED
 
 case: palmbus-B-d0-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked MSCE0A -> GSNF0R on B d0 (stop 29 to stop 1 of a 29-stop ride, this direction does not make it): got MSCE0A -> GSNF0R on B d1, trip 1418363764159
+  result: PASSED
 
 case: palmbus-B-d1-destinations
   result: PASSED
@@ -226,10 +274,7 @@ case: palmbus-B-d1-stop_list
   result: PASSED
 
 case: palmbus-B-d1-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked GSNF0R -> MSCE0A on B d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got GSNF0R -> MSCE0A on B d0, trip 1418363764271
+  result: PASSED
 
 case: sncf-journeys-K8+-d0-pairs
   result: XFAILED
@@ -276,6 +321,12 @@ case: sncf-journeys-P8(CDD3F95:)-d1-pairs
     asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 8 of a 8-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
     asked Orléans -> Paris Austerlitz on P8 (stop 1 to stop 5 of a 5-stop ride): got Orléans -> Paris Austerlitz on K8+ d1, trip OCESN860500F1187_F:TER:FR:Line::1BF2D66F-09EF-4CB8-A003-1417C1EA6532::87543009:87547000:3:608:20261119
 
+case: sncf-local_stop-calendar
+  result: PASSED
+
+case: sncf-local_stop-calendar_dates
+  result: PASSED
+
 case: tao-journeys-22-d0-destinations
   result: PASSED
 
@@ -310,11 +361,7 @@ case: tao-journeys-40-d0-stop_list
   result: PASSED
 
 case: tao-journeys-40-d0-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d0 (stop 15 to stop 1 of a 15-stop ride, this direction does not make it): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00007923 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_98_21_4003_1_063001
-    asked ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:01001712 -> ORLEANS:StopArea:00035910 on ORLEANS:Line:40 d1, trip ORLEANS:VehicleJourney:40_R_85_10_4002_1_061401
+  result: PASSED
 
 case: tao-journeys-40-d1-destinations
   result: PASSED
@@ -326,10 +373,7 @@ case: tao-journeys-40-d1-stop_list
   result: PASSED
 
 case: tao-journeys-40-d1-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d1 (stop 26 to stop 1 of a 26-stop ride, this direction does not make it): got ORLEANS:StopArea:00035910 -> ORLEANS:StopArea:01001712 on ORLEANS:Line:40 d0, trip ORLEANS:VehicleJourney:40_A_86_10_4002_1_070100
+  result: PASSED
 
 case: tao-journeys-41-d0-destinations
   result: PASSED
@@ -362,19 +406,10 @@ case: tao-journeys-A-d0-pairs
   result: PASSED
 
 case: tao-journeys-A-d0-stop_list
-  result: XFAILED
-  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)
-  detail:
-    the list offers one station twice in a row: ORLEANS:StopArea:THOPIT1 Hôpital de La Source then ORLEANS:StopArea:THOPIT2 Hôpital de La Source, ORLEANS:StopArea:TVERNE1 Jules Verne then ORLEANS:StopArea:TVERNE2 Jules Verne
+  result: PASSED
 
 case: tao-journeys-A-d0-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_470_21_A01_1_085930
-    asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT1 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_469_10_A01_1_050000
-    asked ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE1 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_472_21_A01_1_065900
-    asked ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d0 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:TVERNE2 -> ORLEANS:StopArea:THOPIT2 on ORLEANS:Line:A d1, trip ORLEANS:VehicleJourney:A_R_468_10_A01_1_145630
+  result: PASSED
 
 case: tao-journeys-A-d1-destinations
   result: PASSED
@@ -383,19 +418,10 @@ case: tao-journeys-A-d1-pairs
   result: PASSED
 
 case: tao-journeys-A-d1-stop_list
-  result: XFAILED
-  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)
-  detail:
-    the list offers one station twice in a row: ORLEANS:StopArea:TVERNE1 Jules Verne then ORLEANS:StopArea:TVERNE2 Jules Verne, ORLEANS:StopArea:THOPIT1 Hôpital de La Source then ORLEANS:StopArea:THOPIT2 Hôpital de La Source
+  result: PASSED
 
 case: tao-journeys-A-d1-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_477_21_A01_1_055950
-    asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE1 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_471_21_A01_1_080005
-    asked ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT1 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_467_10_A01_1_060100
-    asked ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d1 (stop 27 to stop 1 of a 27-stop ride, this direction does not make it): got ORLEANS:StopArea:THOPIT2 -> ORLEANS:StopArea:TVERNE2 on ORLEANS:Line:A d0, trip ORLEANS:VehicleJourney:A_A_466_10_A01_1_155930
+  result: PASSED
 
 case: tao-journeys-B-d0-destinations
   result: PASSED
@@ -404,17 +430,10 @@ case: tao-journeys-B-d0-pairs
   result: PASSED
 
 case: tao-journeys-B-d0-stop_list
-  result: XFAILED
-  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)
-  detail:
-    the list offers one station twice in a row: ORLEANS:StopArea:THAMEA2 Clos du Hameau then ORLEANS:StopArea:THAMEA1 Clos du Hameau
+  result: PASSED
 
 case: tao-journeys-B-d0-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:THAMEA1 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_173_10_B01_1_055030
-    asked ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d0 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:THAMEA2 -> ORLEANS:StopArea:TPOMPI2 on ORLEANS:Line:B d1, trip ORLEANS:VehicleJourney:B_R_175_10_B09_1_201110
+  result: PASSED
 
 case: tao-journeys-B-d1-destinations
   result: PASSED
@@ -423,17 +442,10 @@ case: tao-journeys-B-d1-pairs
   result: PASSED
 
 case: tao-journeys-B-d1-stop_list
-  result: XFAILED
-  reason: two platforms of one place, called one after the other, are offered as two entries (fix/stop-platform-groups)
-  detail:
-    the list offers one station twice in a row: ORLEANS:StopArea:THAMEA2 Clos du Hameau then ORLEANS:StopArea:THAMEA1 Clos du Hameau
+  result: PASSED
 
 case: tao-journeys-B-d1-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d1 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA1 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_167_10_B01_1_050300
-    asked ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d1 (stop 25 to stop 1 of a 25-stop ride, this direction does not make it): got ORLEANS:StopArea:TPOMPI2 -> ORLEANS:StopArea:THAMEA2 on ORLEANS:Line:B d0, trip ORLEANS:VehicleJourney:B_A_168_10_B06_1_195730
+  result: PASSED
 
 case: tao-journeys-N-d0-destinations
   result: PASSED
@@ -445,10 +457,7 @@ case: tao-journeys-N-d0-stop_list
   result: PASSED
 
 case: tao-journeys-N-d0-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d0 (stop 30 to stop 1 of a 30-stop ride, this direction does not make it): got ORLEANS:StopArea:01002003 -> ORLEANS:StopArea:01086001 on ORLEANS:Line:N d1, trip ORLEANS:VehicleJourney:N_R_16_21_2184_4_013000
+  result: PASSED
 
 case: tao-journeys-N-d1-destinations
   result: PASSED
@@ -460,7 +469,4 @@ case: tao-journeys-N-d1-stop_list
   result: PASSED
 
 case: tao-journeys-N-d1-swapped
-  result: XFAILED
-  reason: the swapped pair is answered although the asked direction does not ride it: the query filters neither route nor direction
-  detail:
-    asked ORLEANS:StopArea:01086001 -> ORLEANS:StopArea:01002003 on ORLEANS:Line:N d1 (stop 30 to stop 1 of a 30-stop ride, this direction does not make it): got ORLEANS:StopArea:01086001 -> ORLEANS:StopArea:01002003 on ORLEANS:Line:N d0, trip ORLEANS:VehicleJourney:N_A_17_21_2184_4_003001
+  result: PASSED

--- a/tests_provider/test_journeys.py
+++ b/tests_provider/test_journeys.py
@@ -7,6 +7,9 @@ fixture zip, with the clock pinned to a day the trips actually run:
     stop_list   each stop_id once, in an order every trip agrees with, and
                 one entry for two platforms of a place called one after the
                 other
+    destinations  from an origin, get_destination_stop_list offers every
+                stop a trip rides to after it, once, in riding order, and
+                nothing no trip through that origin reaches
     pairs       origin before destination on some trip: get_next_departure
                 answers it, on the right stops, in riding order, arriving no
                 earlier than it departs
@@ -16,7 +19,7 @@ fixture zip, with the clock pinned to a day the trips actually run:
 Trains (route_type 2) ride their own path in get_next_departure, matched by
 stop name with no direction: for them the pairs are checked by name, the
 answer must stay on the asked line, and a swapped pair is legitimate, it is
-the return journey, so only `pairs` is checked.
+the return journey, so only `pairs` is checked, by name.
 
 One test per fixture, route, direction and promise; its message lists every
 pair that broke the promise. The promises are about what the sensors say,
@@ -56,9 +59,11 @@ import fixture_db  # noqa: E402
 gtfs_helper = ha_stub.load("gtfs_helper")
 get_next_departure = gtfs_helper.get_next_departure
 get_stop_list = gtfs_helper.get_stop_list
+get_destination_stop_list = gtfs_helper.get_destination_stop_list
 
 FIXTURES = Path(__file__).parent / "fixtures"
-KINDS = ("stop_list", "pairs", "swapped")
+KINDS = ("stop_list", "destinations", "pairs", "swapped")
+TRAIN_KINDS = ("pairs",)
 
 
 class Fixture:
@@ -235,6 +240,12 @@ def served_between(patterns, origins, destinations):
     return False
 
 
+def sample_origins(pattern):
+    """The first stop, one in the middle, and the one before last."""
+    picks = sorted({0, len(pattern) // 2, max(0, len(pattern) - 2)})
+    return [i for i in picks if i < len(pattern) - 1]
+
+
 def sample_pairs(pattern):
     """First to last, first to middle, middle to last: the ends and a leg."""
     seen = []
@@ -266,23 +277,19 @@ class Check:
 # Cases known to fail on main today, each with what breaks the promise.
 # The marks are strict: the day a fix lands, its marks have to go with it,
 # which is how a fix PR and the test that turns green arrive together.
-SELECTOR = ("the stop selector offers a stop twice or out of riding order "
-            "(discussion #198)")
-SELECTOR_GVB = SELECTOR + "; trams 1, 7 and 17 also carry wrong direction_ids"
+PLATFORMS = ("two platforms of one place, called one after the other, are "
+             "offered as two entries (fix/stop-platform-groups)")
+PLATFORMS_GVB = PLATFORMS + "; trams 1, 7 and 17 also carry wrong direction_ids"
 SWAPPED = ("the swapped pair is answered although the asked direction does "
            "not ride it: the query filters neither route nor direction")
 TRAIN = ("a train journey is matched by stop name prefix on any line, not "
          "the asked one")
 KNOWN = {
-    **{f"gvb-{r}-d{d}-stop_list": SELECTOR_GVB
-       for r in ("1", "7", "13", "14", "17") for d in (0, 1)},
-    "palmbus-22-d0-stop_list": SELECTOR,
-    "palmbus-B-d1-stop_list": SELECTOR,
-    "adelaide-GLNELG-d0-stop_list": SELECTOR,
-    "adelaide-GLNELG-d1-stop_list": SELECTOR,
-    "adelaide-N1-d0-stop_list": SELECTOR,
-    **{f"tao-journeys-{r}-d{d}-stop_list": SELECTOR
-       for r in ("40", "A", "B") for d in (0, 1)},
+    "gvb-1-d1-stop_list": PLATFORMS_GVB,
+    "gvb-14-d0-stop_list": PLATFORMS_GVB,
+    "gvb-14-d1-stop_list": PLATFORMS_GVB,
+    **{f"tao-journeys-{r}-d{d}-stop_list": PLATFORMS
+       for r in ("A", "B") for d in (0, 1)},
     **{f"{line}-d{d}-swapped": SWAPPED
        for line in ("gvb-7", "palmbus-A", "palmbus-B", "tao-journeys-40",
                     "tao-journeys-A", "tao-journeys-B", "tao-journeys-N")
@@ -310,7 +317,7 @@ def _cases():
             ids = [ids] if isinstance(ids, str) else ids
             for route_id in ids:
                 train = fx.route_types.get(route_id) == 2
-                kinds = ("pairs",) if train else KINDS
+                kinds = TRAIN_KINDS if train else KINDS
                 shown = label if len(ids) == 1 else f"{label}({route_id[-8:]})"
                 for direction in directions_of(fx.schedule, route_id):
                     for kind in kinds:
@@ -336,7 +343,7 @@ def test_journeys(record_property, fixture, route_id, direction, kind):
     dt_util.set_default_time_zone(dt_util.get_time_zone(fx.agency_tz))
     check = Check()
     if fx.route_types.get(route_id) == 2:
-        check_train_route(check, fx, route_id, direction)
+        check_train_route(check, fx, route_id, direction, kind)
     else:
         check_route(check, fx, route_id, direction, kind)
     record_property("case", {"fixture": fixture, "route": route_id,
@@ -427,8 +434,53 @@ def check_route(check, fx, route_id, direction, kind):
                                 f"{pattern[0]} .. {pattern[-1]}")
         return
 
-    hass = fx.hass()
     route_type = str(fx.route_types.get(route_id))
+    if kind == "destinations":
+        # From an origin, the trips that call at it and the rest of their
+        # ride: the list must hold every such stop, once, in the order the
+        # ride makes, and no stop no trip through that origin reaches. The
+        # origin is matched on its own record, so the pattern's stops are
+        # expected under their own records too.
+        for pattern in grouped:
+            for o in sample_origins(pattern):
+                origin = pattern[o]
+                offered = [entry.split(": ", 1)[0] for entry in
+                           get_destination_stop_list(schedule, route_id,
+                                                     query_direction, origin)]
+                who = f"from {named(fx, origin)}"
+                twice = sorted({s for s in offered if offered.count(s) > 1})
+                text = f"a destination is offered twice {who}"
+                if twice:
+                    text += ": " + listed([named(fx, s) for s in twice])
+                check.note(not twice, text, origin=origin, twice=twice)
+                after = []
+                for stop in pattern[o + 1:]:
+                    if stop not in after:
+                        after.append(stop)
+                missing = [s for s in after if s not in offered]
+                text = f"a stop this ride reaches {who} is not offered"
+                if missing:
+                    text += (": " + listed([named(fx, s) for s in missing])
+                             + f" (on the ride {pattern[0]} .. {pattern[-1]})")
+                check.note(not missing, text, origin=origin, missing=missing)
+                reachable = set()
+                for other in grouped:
+                    if origin in other:
+                        reachable.update(other[other.index(origin) + 1:])
+                stray = [s for s in offered if s not in reachable]
+                text = f"a destination no trip reaches {who} is offered"
+                if stray:
+                    text += ": " + listed([named(fx, s) for s in stray])
+                check.note(not stray, text, origin=origin, stray=stray)
+                pos = {s: n for n, s in enumerate(offered)}
+                known = [pos[s] for s in after if s in pos]
+                descents = sum(1 for a, b in zip(known, known[1:]) if a >= b)
+                check.note(descents == 0, f"the destinations {who} contradict "
+                           f"the riding order {pattern[0]} .. {pattern[-1]}",
+                           origin=origin)
+        return
+
+    hass = fx.hass()
     with freeze_time(fx.instant_on("1970-01-01")) as clock:
         for pattern, trip_ids in sorted(grouped.items()):
             # the same stand-in reading as above, so a pair asks for the
@@ -565,7 +617,7 @@ def _data_for(schedule, route_id, route_type, entries, position,
     }
 
 
-def check_train_route(check, fx, route_id, direction):
+def check_train_route(check, fx, route_id, direction, kind):
     schedule = fx.schedule
     short_name = fx.route_short_names[route_id]
     hass = fx.hass()

--- a/tests_provider/test_journeys.py
+++ b/tests_provider/test_journeys.py
@@ -1,20 +1,25 @@
 """Every departure/arrival pair a fixture's routes offer must hold up.
 
-For each route named in a fixture's manifest and each direction it runs,
-three promises are checked against the real code, on a db built from the
-fixture zip, with the clock pinned to a day the trips actually run:
+For each route named in a fixture's manifest, the trips of each direction
+it runs are sampled, and the promises are checked against the real code, on
+a db built from the fixture zip, with the clock pinned to a day the trips
+actually run. The list and the queries are asked the way the flow asks them:
+one list per line, both ways round, a place per entry, and no direction but
+the rotation get_pair_direction keeps at a loop's terminus.
 
-    stop_list   each stop_id once, in an order every trip agrees with, and
-                one entry for two platforms of a place called one after the
-                other
+    stop_list   each place once (the records of a parent station, or of one
+                name close together), every stop a trip calls at stood for,
+                and every trip riding the list one way or the other
     destinations  from an origin, get_destination_stop_list offers every
-                stop a trip rides to after it, once, in riding order, and
+                place a trip rides to after it, once, in the order every
+                ride makes, nearest first where the rides leave it open, and
                 nothing no trip through that origin reaches
     pairs       origin before destination on some trip: get_next_departure
-                answers it, on the right stops, in riding order, arriving no
-                earlier than it departs
+                answers it, on the right places, in riding order, arriving no
+                earlier than it departs, on the shortest ride of its trip,
+                each departure leaving from a record of the asked place
     swapped     destination before origin: nothing, or a ride the line really
-                makes (a place served twice, once per platform, is one)
+                makes, either way round
 
 Trains (route_type 2) ride their own path in get_next_departure, matched by
 stop name with no direction: for them the pairs are checked by name, the
@@ -93,6 +98,7 @@ class Fixture:
         # row carries it), so the clock is pinned in that zone: 00:05 UTC is
         # 02:05 in Paris, past a night line's 00:30 departure
         self.agency_tz = agency_tz[0] if agency_tz else "UTC"
+        self._places = {}
 
     def hass(self):
         """What get_next_departure reads off hass, and nothing more."""
@@ -100,10 +106,11 @@ class Fixture:
             path=lambda *parts: str(self.path.joinpath(*parts)),
             time_zone=self.agency_tz))
 
-    def instant_on(self, date_iso: str) -> datetime.datetime:
-        """00:05 wall time of the agency's zone on that day."""
+    def instant_on(self, date_iso: str,
+                   at: datetime.time = datetime.time(0, 5)) -> datetime.datetime:
+        """A wall time of the agency's zone on that day, 00:05 by default."""
         return datetime.datetime.combine(
-            datetime.date.fromisoformat(date_iso), datetime.time(0, 5),
+            datetime.date.fromisoformat(date_iso), at,
             zoneinfo.ZoneInfo(self.agency_tz))
 
     def station_of(self, stop_id):
@@ -111,17 +118,29 @@ class Fixture:
         return self.stations.get(stop_id) or None
 
     def siblings_of(self, stop_id):
-        """Every record the feed groups with this one under a parent station.
+        """Every record of the place this one belongs to.
 
-        A stop written once per platform is one place to a rider, and since
-        the journey's ends are matched on whole stops, get_next_departure may
-        answer on any of their records: a pair is right when it lands on one
-        of these, not only on the record the pattern happened to carry.
+        A place is what a rider waits at: the records a feed groups under a
+        parent station, and without a parent, the records of one name close
+        together. The journey's ends are matched on whole places, so
+        get_next_departure may answer on any of their records: a pair is
+        right when it lands on one of these. The checkout's own rule is read
+        (_place_group), a parent-only reading when it has none.
         """
-        parent = self.station_of(stop_id)
-        if not parent:
-            return {stop_id}
-        return {stop_id} | {s for s, p in self.stations.items() if p == parent}
+        if stop_id in self._places:
+            return self._places[stop_id]
+        group = getattr(gtfs_helper, "_place_group", None)
+        if group:
+            with self.schedule.engine.connect() as conn:
+                found = {stop_id} | {row[0] for row in conn.execute(
+                    text("SELECT stop_id FROM stops WHERE stop_id IN " + group("s")),
+                    {"s": stop_id})}
+        else:
+            parent = self.station_of(stop_id)
+            found = {stop_id} | ({s for s, p in self.stations.items() if p == parent}
+                                 if parent else set())
+        self._places[stop_id] = found
+        return found
 
 
 def _repair_directions(schedule):
@@ -205,39 +224,79 @@ def service_date(schedule, trip_ids):
     return min(days) if days else None
 
 
-def circular_like(grouped_by_dir):
-    """Both directions ride mostly the same stops in the same order.
-
-    That is a circular line whose two 'directions' are rotations (GVB line
-    14): its trips wrap around the loop, and no linear list can agree with
-    every wrap point, so the order check has to allow the one wrap.
-    """
-    if len(grouped_by_dir) != 2:
-        return False
-    chains = []
-    for grouped in grouped_by_dir.values():
-        if not grouped:
-            return False
-        maxlen = max(len(p) for p in grouped)
-        chains.append(max((p for p in grouped if len(p) == maxlen),
-                          key=lambda p: len(grouped[p])))
-    first, second = chains
-    pos = {stop: n for n, stop in enumerate(second)}
-    shared = [pos[stop] for stop in first if stop in pos]
-    if len(shared) <= 0.5 * len(first) or len(shared) < 2:
-        return False
-    inc = sum(1 for a, b in zip(shared, shared[1:]) if b > a)
-    return inc / (len(shared) - 1) > 0.8
-
-
 def served_between(patterns, origins, destinations):
-    """Some trip of this direction really rides from one set to the other."""
+    """Some trip of the line really rides from one set to the other."""
     for pattern in patterns:
         before = [i for i, stop in enumerate(pattern) if stop in origins]
         after = [i for i, stop in enumerate(pattern) if stop in destinations]
         if before and after and min(before) < max(after):
             return True
     return False
+
+
+def pieces_of(places):
+    """A ride read as list positions, cut where it comes back to a position
+    it already passed (a racket, a loop), repeats in a row dropped."""
+    pieces, current = [], []
+    for p in places:
+        if current and p == current[-1]:
+            continue
+        if p in current:
+            pieces.append(current)
+            current = [current[-1], p]
+        else:
+            current.append(p)
+    if len(current) > 1:
+        pieces.append(current)
+    return pieces
+
+
+def rides_in_order(piece, size, ends=(), ways=(True, False)):
+    """One way along the list, forward or backward.
+
+    A loop has no straight order: its seam, a step across more than half the
+    list, is allowed once. Nor has a terminus the two ways share: TAO 40 ends
+    Montesquieu, Cheques Postaux quai D, then quai C, and GVB 14 starts in the
+    turning loop at Flevopark, so one step against the way is allowed when it
+    touches the trip's own first or last stop (ends). A step against the way
+    in the middle of a ride still fails.
+    """
+    for forward in ways:
+        wraps = shuffles = 0
+        for a, b in zip(piece, piece[1:]):
+            step = b - a
+            if abs(step) > size / 2:
+                wraps += 1
+            elif (step > 0) != forward:
+                if a in ends or b in ends:
+                    shuffles += 1
+                else:
+                    break
+        else:
+            if wraps <= 1 and shuffles <= 1:
+                return True
+    return False
+
+
+def line_patterns(schedule, route_id):
+    """{stop pattern: [trip_id]} for the whole line, both ways round."""
+    patterns = {}
+    for direction in directions_of(schedule, route_id):
+        for pattern, trip_ids in patterns_of(schedule, route_id, direction).items():
+            patterns.setdefault(pattern, []).extend(trip_ids)
+    return patterns
+
+
+def rode_past_an_end(schedule, result, origins, destinations):
+    """The stops the answer's trip calls at between its two ends that are one
+    of those ends again: a shorter ride was on the same trip."""
+    with schedule.engine.connect() as conn:
+        rows = conn.execute(text(
+            "SELECT stop_id FROM stop_times WHERE trip_id = :t "
+            "AND stop_sequence > :o AND stop_sequence < :d"),
+            {"t": result.get("trip_id"), "o": result["origin_stop_sequence"],
+             "d": result["destination_stop_time"]["Sequence"]}).fetchall()
+    return [r[0] for r in rows if r[0] in origins or r[0] in destinations]
 
 
 def sample_origins(pattern):
@@ -277,23 +336,9 @@ class Check:
 # Cases known to fail on main today, each with what breaks the promise.
 # The marks are strict: the day a fix lands, its marks have to go with it,
 # which is how a fix PR and the test that turns green arrive together.
-PLATFORMS = ("two platforms of one place, called one after the other, are "
-             "offered as two entries (fix/stop-platform-groups)")
-PLATFORMS_GVB = PLATFORMS + "; trams 1, 7 and 17 also carry wrong direction_ids"
-SWAPPED = ("the swapped pair is answered although the asked direction does "
-           "not ride it: the query filters neither route nor direction")
 TRAIN = ("a train journey is matched by stop name prefix on any line, not "
          "the asked one")
 KNOWN = {
-    "gvb-1-d1-stop_list": PLATFORMS_GVB,
-    "gvb-14-d0-stop_list": PLATFORMS_GVB,
-    "gvb-14-d1-stop_list": PLATFORMS_GVB,
-    **{f"tao-journeys-{r}-d{d}-stop_list": PLATFORMS
-       for r in ("A", "B") for d in (0, 1)},
-    **{f"{line}-d{d}-swapped": SWAPPED
-       for line in ("gvb-7", "palmbus-A", "palmbus-B", "tao-journeys-40",
-                    "tao-journeys-A", "tao-journeys-B", "tao-journeys-N")
-       for d in (0, 1)},
     "sncf-journeys-K8+-d0-pairs": TRAIN,
     "sncf-journeys-K8+-d1-pairs": TRAIN,
     "sncf-journeys-P8(A594575:)-d1-pairs": TRAIN,
@@ -353,34 +398,25 @@ def test_journeys(record_property, fixture, route_id, direction, kind):
 
 
 def check_route(check, fx, route_id, direction, kind):
-    schedule = fx.schedule
-    directions = directions_of(schedule, route_id)
-    by_dir = {d: patterns_of(schedule, route_id, d) for d in directions}
-    circular = circular_like(by_dir)
-    grouped = by_dir[direction]
-    query_direction = 0 if direction is None else direction
-    entries = get_stop_list(schedule, route_id, query_direction)
-    ids = [entry.split(": ", 1)[0] for entry in entries]
-    position = {stop_id: n for n, stop_id in enumerate(ids)}
+    """The flow's promises on one line, the trips of one direction sampled.
 
-    # A trip's stop may not be in the list under its own record when the
-    # list offers a station once: the entry offered for its station stands
-    # for it, and that is the entry a user would pick. A station a line
-    # calls at twice keeps several offered records (GVB 14 lists Dam three
-    # times, outbound and both return platforms), so the stand-in is read
-    # along the ride, taking the offered record nearest to where the trip
-    # already is rather than any of them.
-    def place_of(stop_id, previous):
-        if stop_id in position:
-            return position[stop_id]
-        offered = [position[sibling]
-                   for sibling in fx.siblings_of(stop_id)
-                   if sibling in position]
-        if not offered:
-            return None
-        if previous is None:
-            return min(offered)
-        return min(offered, key=lambda n: (n < previous, abs(n - previous)))
+    The rider is offered one list per line, a place per entry, and picks
+    where they are, then where they go; no direction is asked, the pair and
+    the order of the stops on a trip say which way it is, and a loop's
+    terminus keeps the rotation get_pair_direction settles. So the list, the
+    destinations and the departures are asked the way the flow asks them,
+    with no direction; `direction` only says which trips are sampled.
+    """
+    schedule = fx.schedule
+    everything = line_patterns(schedule, route_id)
+    grouped = patterns_of(schedule, route_id, direction)
+    entries = get_stop_list(schedule, route_id, None)
+    ids = [entry.split(": ", 1)[0] for entry in entries]
+    # the entry that stands for each record: the one of its place
+    entry_of = {}
+    for n, stop_id in enumerate(ids):
+        for member in fx.siblings_of(stop_id):
+            entry_of.setdefault(member, n)
 
     if kind == "stop_list":
         # The entries read "STOP: Name (12)", the number being the
@@ -401,35 +437,30 @@ def check_route(check, fx, route_id, direction, kind):
         check.note(not repeated, text,
                    repeated={stop_id: places
                              for stop_id, places in repeated.items()})
-        # Two platforms of one place, called one after the other, are one
-        # entry: TAO line A offered Jules Verne twice and each choice hid
-        # half the trams. Two records of a station the line calls at twice,
-        # far apart in the ride, are not that case and stay offered.
+        # A place is one entry, whatever its records: TAO line A offered
+        # Jules Verne twice and each choice hid half the trams, Zou 653
+        # offered each pole of Pont de la Brague, one per side of the road.
+        twice = [(a, b) for i, a in enumerate(ids) for b in ids[i + 1:]
+                 if b in fx.siblings_of(a)]
+        text = "the list offers one place twice"
+        if twice:
+            text += ": " + listed([f"{named(fx, a)} and {named(fx, b)}" for a, b in twice])
+        # folded keeps what the check recorded when it only looked at two
+        # platforms of one station listed one after the other
         folded = [(a, b) for a, b in zip(ids, ids[1:])
                   if fx.station_of(a) and fx.station_of(a) == fx.station_of(b)]
-        text = "the list offers one station twice in a row"
-        if folded:
-            text += ": " + listed([f"{named(fx, a)} then {named(fx, b)}"
-                                   for a, b in folded])
-        check.note(not folded, text, folded=[list(pair) for pair in folded])
+        check.note(not twice, text, twice=[list(pair) for pair in twice],
+                   folded=[list(pair) for pair in folded])
         for pattern in grouped:
-            places = []
-            for stop in pattern:
-                previous = next((p for p in reversed(places) if p is not None), None)
-                places.append(place_of(stop, previous))
-            unoffered = [stop for stop, place in zip(pattern, places)
-                         if place is None]
+            unoffered = [stop for stop in pattern if stop not in entry_of]
             text = "a trip serves a stop the list does not offer"
             if unoffered:
                 text += (": " + listed([named(fx, stop) for stop in unoffered])
                          + f" (on the ride {pattern[0]} .. {pattern[-1]})")
             check.note(not unoffered, text, unoffered=list(unoffered))
-            known = [place for place in places if place is not None]
-            descents = sum(1 for a, b in zip(known, known[1:]) if a >= b)
-            # a rotation of a circular line reads k..n then 0..k-1: one
-            # descent, ending below its start, is the loop's own seam
-            ordered = descents == 0 or (
-                circular and descents == 1 and known[-1] < known[0])
+            known = [entry_of[stop] for stop in pattern if stop in entry_of]
+            ends = (known[0], known[-1]) if known else ()
+            ordered = all(rides_in_order(piece, len(ids), ends) for piece in pieces_of(known))
             check.note(ordered, "the list contradicts the riding order "
                                 f"{pattern[0]} .. {pattern[-1]}")
         return
@@ -437,60 +468,128 @@ def check_route(check, fx, route_id, direction, kind):
     route_type = str(fx.route_types.get(route_id))
     if kind == "destinations":
         # From an origin, the trips that call at it and the rest of their
-        # ride: the list must hold every such stop, once, in the order the
-        # ride makes, and no stop no trip through that origin reaches. The
-        # origin is matched on its own record, so the pattern's stops are
-        # expected under their own records too.
+        # ride: the list must hold every place such a trip reaches, once, in
+        # the order the ride makes, and nothing no trip through that origin
+        # reaches, whichever way round the line it goes.
         for pattern in grouped:
             for o in sample_origins(pattern):
-                origin = pattern[o]
+                if pattern[o] not in entry_of:
+                    continue
+                origin = ids[entry_of[pattern[o]]]
                 offered = [entry.split(": ", 1)[0] for entry in
-                           get_destination_stop_list(schedule, route_id,
-                                                     query_direction, origin)]
+                           get_destination_stop_list(schedule, route_id, None, origin)]
+                at = {stop_id: n for n, stop_id in enumerate(offered)}
                 who = f"from {named(fx, origin)}"
                 twice = sorted({s for s in offered if offered.count(s) > 1})
                 text = f"a destination is offered twice {who}"
                 if twice:
                     text += ": " + listed([named(fx, s) for s in twice])
                 check.note(not twice, text, origin=origin, twice=twice)
-                after = []
-                for stop in pattern[o + 1:]:
-                    if stop not in after:
-                        after.append(stop)
-                missing = [s for s in after if s not in offered]
+                after = [stop for stop in pattern[o + 1:]
+                         if entry_of.get(stop) != entry_of[origin]]
+                missing = [s for s in dict.fromkeys(after)
+                           if s not in entry_of or ids[entry_of[s]] not in at]
                 text = f"a stop this ride reaches {who} is not offered"
                 if missing:
                     text += (": " + listed([named(fx, s) for s in missing])
                              + f" (on the ride {pattern[0]} .. {pattern[-1]})")
                 check.note(not missing, text, origin=origin, missing=missing)
                 reachable = set()
-                for other in grouped:
-                    if origin in other:
-                        reachable.update(other[other.index(origin) + 1:])
+                for other in everything:
+                    hits = [i for i, s in enumerate(other)
+                            if entry_of.get(s) == entry_of[origin]]
+                    if hits:
+                        reachable.update(ids[entry_of[s]] for s in other[hits[0] + 1:]
+                                         if s in entry_of)
                 stray = [s for s in offered if s not in reachable]
                 text = f"a destination no trip reaches {who} is offered"
                 if stray:
                     text += ": " + listed([named(fx, s) for s in stray])
                 check.note(not stray, text, origin=origin, stray=stray)
-                pos = {s: n for n, s in enumerate(offered)}
-                known = [pos[s] for s in after if s in pos]
-                descents = sum(1 for a, b in zip(known, known[1:]) if a >= b)
-                check.note(descents == 0, f"the destinations {who} contradict "
-                           f"the riding order {pattern[0]} .. {pattern[-1]}",
-                           origin=origin)
+                # Riding order across every trip of the line, nearest first
+                # where the rides leave it open. Read from all the line's
+                # trips: a place follows the places any of them calls at just
+                # before it on its way from the origin (counted again from a
+                # later call at the origin, a place met again on a ride
+                # starting a new stretch); among the places free to come
+                # next, the nearest one by the fewest stops, the far side of
+                # the list before the near one; when none is free (a loop's
+                # terminus, reached both ways round), the nearest remaining.
+                fewest, before = {}, {}
+                for other in everything:
+                    count, previous, stretch = None, None, set()
+                    for s in other:
+                        if s not in entry_of:
+                            continue
+                        e = ids[entry_of[s]]
+                        if entry_of[s] == entry_of[origin]:
+                            count, previous, stretch = 0, None, set()
+                            continue
+                        if count is None:
+                            continue
+                        count += 1
+                        fewest[e] = min(fewest.get(e, count), count)
+                        before.setdefault(e, set())
+                        if e in stretch:
+                            stretch = {e}
+                        elif previous is not None and previous != e:
+                            before[e].add(previous)
+                            stretch.add(e)
+                        else:
+                            stretch.add(e)
+                        previous = e
+                home = entry_of[origin]
+
+                def nearest(e):
+                    return (ids.index(e) < home, fewest.get(e, 0), ids.index(e))
+
+                listed_before, ordered, first_break = set(), True, None
+                for e in offered:
+                    left = [x for x in offered if x not in listed_before]
+                    free = [x for x in left if not (before.get(x, set()) - listed_before)]
+                    expected = min(free or left, key=nearest)
+                    if e != expected and ordered:
+                        ordered, first_break = False, [e, expected]
+                    listed_before.add(e)
+                check.note(ordered, f"the destinations {who} are not in riding order, "
+                           f"nearest first where the rides leave it open"
+                           + (f" ({named(fx, first_break[0])} before {named(fx, first_break[1])})"
+                              if first_break else ""),
+                           origin=origin,
+                           order=[[s, ids.index(s) < home, fewest.get(s, 0)] for s in offered])
+                # And along this ride, the order it makes: counted again from
+                # a later call at the origin, one reshuffle allowed where it
+                # touches the ride's own last stop (a terminus's quays). From
+                # a loop's terminus every stop is reached both ways round, so
+                # there nearest first is the order and this one is recorded
+                # as not applying.
+                terminus = any(entry_of.get(other[0]) == entry_of[origin]
+                               and entry_of.get(other[-1]) == entry_of[origin]
+                               for other in everything)
+                along = True
+                ride = []
+                for stop in pattern[o + 1:] + (None,):
+                    if stop is None or entry_of.get(stop) == entry_of[origin]:
+                        known = [at[ids[entry_of[s]]] for s in ride
+                                 if s in entry_of and ids[entry_of[s]] in at]
+                        ends = (known[-1],) if known else ()
+                        along = along and all(
+                            rides_in_order(piece, len(offered) * 4, ends, ways=(True,))
+                            for piece in pieces_of(known))
+                        ride = []
+                    else:
+                        ride.append(stop)
+                check.note(along or terminus,
+                           f"the destinations {who} contradict the riding order "
+                           f"{pattern[0]} .. {pattern[-1]}"
+                           + (" (a loop's terminus: nearest first applies)" if terminus else ""),
+                           origin=origin, loop_terminus=terminus, along=along)
         return
 
     hass = fx.hass()
     with freeze_time(fx.instant_on("1970-01-01")) as clock:
         for pattern, trip_ids in sorted(grouped.items()):
-            # the same stand-in reading as above, so a pair asks for the
-            # entry a user would have picked for that stop
-            stood_for = {}
-            previous = None
-            for stop in pattern:
-                stood_for[stop] = place_of(stop, previous)
-                previous = stood_for[stop] if stood_for[stop] is not None else previous
-            if any(place is None for place in stood_for.values()):
+            if any(stop not in entry_of for stop in pattern):
                 check.note(False, "a pattern stop has no entry")
                 continue
             day = service_date(schedule, trip_ids)
@@ -499,44 +598,85 @@ def check_route(check, fx, route_id, direction, kind):
                 continue
             clock.move_to(fx.instant_on(day))
             for o, d in sample_pairs(pattern):
+                origin, destination = ids[entry_of[pattern[o]]], ids[entry_of[pattern[d]]]
+                if origin == destination:
+                    # a racket or a loop from its terminus round to it: two
+                    # records of one place, which the list offers once, so no
+                    # entry can ask it; recorded, not asked
+                    asked = asked_of(pattern, o, d, route_id, None)
+                    check.note(True, f"asked {pattern[o]} -> {pattern[d]} on {route_id}: "
+                               f"one place ({named(fx, origin)}), not a journey the list offers",
+                               asked=asked, got=None, same_place=True)
+                    continue
+                kept = gtfs_helper.get_pair_direction(schedule, route_id, origin, destination)
                 data = _data_for(schedule, route_id, route_type, entries,
-                                 stood_for, pattern[o], pattern[d],
-                                 query_direction)
+                                 entry_of, pattern[o], pattern[d], kept)
+                origins, reached = fx.siblings_of(origin), fx.siblings_of(destination)
                 if kind == "pairs":
                     result = get_next_departure(hass, data)
                     ok = (isinstance(result, dict) and result
-                          and result.get("origin_stop_id")
-                          in fx.siblings_of(pattern[o])
-                          and result.get("destination_stop_id")
-                          in fx.siblings_of(pattern[d])
+                          and result.get("origin_stop_id") in origins
+                          and result.get("destination_stop_id") in reached
                           and result["origin_stop_sequence"]
                           < result["destination_stop_time"]["Sequence"]
                           and result["arrival_time"] >= result["departure_time"])
-                    asked = asked_of(pattern, o, d, route_id, query_direction)
+                    asked = asked_of(pattern, o, d, route_id, kept)
                     got = got_of(result)
                     check.note(ok, answered(asked, got), asked=asked, got=got)
+                    if result:
+                        # each departure names the record it leaves from, a
+                        # record of the asked place
+                        leaving = result.get("next_departures_origin_stop_id") or []
+                        elsewhere = [s for s in leaving if s not in origins]
+                        check.note(bool(leaving) and not elsewhere,
+                                   f"asked {origin} -> {destination} on {route_id}: "
+                                   f"{len(leaving)} departures leave from "
+                                   f"{sorted(set(leaving))}"
+                                   + (f", not the asked place: {sorted(set(elsewhere))}" if elsewhere else ""),
+                                   asked=asked, got=got, leaving=sorted(set(leaving)))
+                        # and it rides the direction the entry keeps, when it
+                        # keeps one (a loop's terminus); otherwise the pair
+                        # alone decides, and the direction ridden is recorded
+                        rode = str(result.get("trip_direction_id"))
+                        if kept is not None:
+                            check.note(rode == str(kept),
+                                       f"asked d{kept} on {route_id}: "
+                                       f"trip {got['trip']} rides d{rode}",
+                                       asked=asked, got=got)
+                        else:
+                            check.note(True,
+                                       f"asked no direction on {route_id}: "
+                                       f"trip {got['trip']} rides d{rode}",
+                                       asked=asked, got=got)
+                    if ok:
+                        # and it is the shortest ride on its trip: a trip
+                        # passing an end twice does not board the rider on
+                        # the pole across the road for the long way round
+                        past = rode_past_an_end(schedule, result, origins, reached)
+                        check.note(not past,
+                                   f"asked {origin} -> {destination} on {route_id}: "
+                                   f"trip {got['trip']} calls at an end again on the way"
+                                   + (f" ({listed(past)})" if past else ""),
+                                   asked=asked, got=got)
                 else:
                     swapped = dict(data, origin=data["destination"],
-                                   destination=data["origin"])
+                                   destination=data["origin"],
+                                   direction=str(gtfs_helper.get_pair_direction(
+                                       schedule, route_id, destination, origin)))
                     result = get_next_departure(hass, swapped)
-                    # A destination is matched on the whole stop, so the
-                    # reverse pair is answerable whenever this direction
-                    # really rides from the asked destination to one of the
-                    # records of the asked origin's stop, which happens on
-                    # the lines that serve a place twice, once per platform.
-                    # So the promise is not "nothing": it is that an answer,
-                    # when there is one, matches a ride the line actually
-                    # makes. Answering nothing stays acceptable, the pattern
-                    # that rides it may not run on the frozen day.
-                    served = served_between(grouped, fx.siblings_of(pattern[d]),
-                                            fx.siblings_of(pattern[o]))
+                    # Both ways round are offered, so the reverse pair is a
+                    # journey whenever some trip of the line rides it. The
+                    # promise is that an answer, when there is one, matches a
+                    # ride the line actually makes; answering nothing stays
+                    # acceptable, the pattern that rides it may not run on
+                    # the frozen day.
+                    served = served_between(everything, reached, origins)
                     honest = not result or (
                         served
                         and result["origin_stop_sequence"]
                         < result["destination_stop_time"]["Sequence"]
                         and result["arrival_time"] >= result["departure_time"])
-                    asked = asked_of(pattern, d, o, route_id, query_direction,
-                                     served=served)
+                    asked = asked_of(pattern, d, o, route_id, None, served=served)
                     got = got_of(result)
                     check.note(honest, answered(asked, got), asked=asked, got=got)
 
@@ -611,6 +751,7 @@ def _data_for(schedule, route_id, route_type, entries, position,
         "origin": entries[position[origin]],
         "destination": entries[position[destination]],
         "direction": str(direction),
+        "loop_direction": direction,
         "route": route_id,
         "offset": 0,
         "include_tomorrow": False,


### PR DESCRIPTION
Replaces #211: its three commits are here, rebased on #214. Merge this one only, #211 can be closed.

**Stop list.** One list for the whole line, each place once. Records under one parent_station are one place, or, without parents, records with the same name within about 150 m (TAO). The order comes from the trips' stop_sequence. direction_id only decides which end the list starts from: the way most direction 0 trips ride it.

**Where the bus goes.** After the departure stop, the flow asks only when buses from that stop go to different termini, and offers each terminus. On a loop the next stop is shown with it (TAO 22 from Zénith: Plissay or Jean Moulin). At the end of a line nothing is asked. It is built from the trips, so wrong direction labels (GVB 1) hide nothing.

**Destinations.** Only the places a bus really reaches that way, one branch at a time, busiest first (Zou 653 from Grasse).

**Departures.** Both ends match the whole place, on the entry's line only, and a trip passing a place twice counts its shortest ride (Palm Bus 21 at Gare SNCF). Each departure says which stop it leaves from in next_departures_origin_stop_id, and the station attributes follow it. On a loop terminus the rotation is stored as loop_direction, the only direction the query reads.

**Upgrade.** No migration. Older entries keep working, but now only show their own line.

**Tests.** Two checks of tests_provider read differently now: stop_list is one list for the whole line, each place once, and a swapped pair passes when a trip really rides it. So the SELECTOR and SWAPPED marks are lifted, the TRAIN marks stay. No case removed, destinations and towards cases added: 179 passed, 4 xfailed. tests/ records next_departures_origin_stop_id and loop_direction: 17 passed.
